### PR TITLE
feat(daemon): デーモンログの詳細化

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -57,12 +58,32 @@ func (d *Daemon) Start(ctx context.Context) {
 	}
 }
 
+// outputTail returns the last n lines of the output string.
+func outputTail(output string, n int) string {
+	lines := strings.Split(output, "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}
+
 func (d *Daemon) patrol() {
 	sessions, err := d.sessions.List()
 	if err != nil {
 		d.logger.Error("list sessions failed", "error", err)
 		return
 	}
+
+	var targetCount, skipCount int
+	for _, s := range sessions {
+		if s.Status == session.StatusRunning || s.Status == session.StatusWaiting || s.Status == session.StatusError {
+			targetCount++
+		} else {
+			skipCount++
+			d.logger.Debug("skipping session", "session", s.Name, "status", string(s.Status))
+		}
+	}
+	d.logger.Info("patrol started", "targetSessions", targetCount, "skippedSessions", skipCount)
 
 	for _, s := range sessions {
 		if s.Status != session.StatusRunning && s.Status != session.StatusWaiting && s.Status != session.StatusError {
@@ -77,6 +98,10 @@ func (d *Daemon) patrol() {
 			continue
 		}
 
+		capturedLines := len(strings.Split(output, "\n"))
+		log.Info("captured pane output", "lines", capturedLines)
+		log.Debug("captured output tail", "tail", outputTail(output, 20))
+
 		// Skip if output hasn't changed
 		d.mu.Lock()
 		if d.lastOutputs[s.ID] == output {
@@ -88,8 +113,14 @@ func (d *Daemon) patrol() {
 		d.mu.Unlock()
 
 		// Ask LLM to analyze
-		log.Info("analyzing session")
+		previousStatus := string(s.Status)
+		log.Info("analyzing session",
+			"projectPath", s.ProjectPath,
+			"previousStatus", previousStatus,
+			"capturedLines", capturedLines,
+		)
 		prompt := llm.BuildAnalysisPrompt(s.Name, s.ProjectPath, string(s.Status), output)
+		log.Debug("analysis prompt", "prompt", prompt)
 		result, err := d.llm.Analyze(prompt)
 		if err != nil {
 			log.Error("analyze failed", "error", err)
@@ -100,22 +131,24 @@ func (d *Daemon) patrol() {
 			"status", result.Status,
 			"action", result.Action,
 			"reason", result.Reason,
+			"sendText", result.SendText,
 		)
 
 		// Update session status
 		newStatus := session.Status(result.Status)
 		if newStatus != s.Status {
+			log.Info("status changed", "previousStatus", previousStatus, "newStatus", string(newStatus))
 			if err := d.sessions.UpdateStatus(s.ID, newStatus); err != nil {
 				log.Error("update status failed", "error", err)
 			}
 		}
 
 		// Execute action
-		d.executeAction(&s, result)
+		d.executeAction(&s, result, outputTail(output, 20), previousStatus, string(newStatus))
 	}
 }
 
-func (d *Daemon) executeAction(s *session.Session, result *llm.AnalysisResult) {
+func (d *Daemon) executeAction(s *session.Session, result *llm.AnalysisResult, capturedOutputTail, previousStatus, newStatus string) {
 	log := d.logger.With("session", s.Name, "sessionId", s.ID, "action", result.Action)
 
 	switch result.Action {
@@ -137,18 +170,18 @@ func (d *Daemon) executeAction(s *session.Session, result *llm.AnalysisResult) {
 	}
 
 	// Record action
-	d.recordAction(s.ID, result)
+	d.recordAction(s.ID, result, capturedOutputTail, previousStatus, newStatus)
 }
 
-func (d *Daemon) recordAction(sessionID string, result *llm.AnalysisResult) {
+func (d *Daemon) recordAction(sessionID string, result *llm.AnalysisResult, capturedOutputTail, previousStatus, newStatus string) {
 	detail := result.Reason
 	if result.SendText != "" {
 		detail += " | sent: " + result.SendText
 	}
 
 	_, err := d.db.Exec(
-		"INSERT INTO daemon_actions (session_id, action_type, detail) VALUES (?, ?, ?)",
-		sessionID, result.Action, detail,
+		"INSERT INTO daemon_actions (session_id, action_type, detail, captured_output_tail, previous_status, new_status) VALUES (?, ?, ?, ?, ?, ?)",
+		sessionID, result.Action, detail, capturedOutputTail, previousStatus, newStatus,
 	)
 	if err != nil {
 		d.logger.Error("record action failed", "error", err)
@@ -157,10 +190,13 @@ func (d *Daemon) recordAction(sessionID string, result *llm.AnalysisResult) {
 
 	if d.broadcast != nil {
 		d.broadcast("action_log", map[string]interface{}{
-			"sessionId":  sessionID,
-			"actionType": result.Action,
-			"detail":     detail,
-			"timestamp":  time.Now(),
+			"sessionId":          sessionID,
+			"actionType":         result.Action,
+			"detail":             detail,
+			"capturedOutputTail": capturedOutputTail,
+			"previousStatus":     previousStatus,
+			"newStatus":          newStatus,
+			"timestamp":          time.Now(),
 		})
 	}
 }

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -86,6 +86,22 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: add detailed logging columns to daemon_actions
+	_, err = db.Exec(`ALTER TABLE daemon_actions ADD COLUMN captured_output_tail TEXT`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
+	_, err = db.Exec(`ALTER TABLE daemon_actions ADD COLUMN previous_status TEXT`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
+	_, err = db.Exec(`ALTER TABLE daemon_actions ADD COLUMN new_status TEXT`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -199,16 +199,19 @@ func (s *Server) getSessionOutput(w http.ResponseWriter, r *http.Request) {
 }
 
 type daemonAction struct {
-	ID         int    `json:"id"`
-	SessionID  string `json:"sessionId"`
-	ActionType string `json:"actionType"`
-	Detail     string `json:"detail"`
-	CreatedAt  string `json:"createdAt"`
+	ID                 int    `json:"id"`
+	SessionID          string `json:"sessionId"`
+	ActionType         string `json:"actionType"`
+	Detail             string `json:"detail"`
+	CapturedOutputTail string `json:"capturedOutputTail,omitempty"`
+	PreviousStatus     string `json:"previousStatus,omitempty"`
+	NewStatus          string `json:"newStatus,omitempty"`
+	CreatedAt          string `json:"createdAt"`
 }
 
 func (s *Server) getActions(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.db.Query(
-		"SELECT id, session_id, action_type, detail, created_at FROM daemon_actions ORDER BY created_at DESC LIMIT 50",
+		"SELECT id, session_id, action_type, detail, captured_output_tail, previous_status, new_status, created_at FROM daemon_actions ORDER BY created_at DESC LIMIT 50",
 	)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -219,13 +222,22 @@ func (s *Server) getActions(w http.ResponseWriter, r *http.Request) {
 	actions := []daemonAction{}
 	for rows.Next() {
 		var a daemonAction
-		var detail sql.NullString
-		if err := rows.Scan(&a.ID, &a.SessionID, &a.ActionType, &detail, &a.CreatedAt); err != nil {
+		var detail, capturedOutputTail, previousStatus, newStatus sql.NullString
+		if err := rows.Scan(&a.ID, &a.SessionID, &a.ActionType, &detail, &capturedOutputTail, &previousStatus, &newStatus, &a.CreatedAt); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 		if detail.Valid {
 			a.Detail = detail.String
+		}
+		if capturedOutputTail.Valid {
+			a.CapturedOutputTail = capturedOutputTail.String
+		}
+		if previousStatus.Valid {
+			a.PreviousStatus = previousStatus.String
+		}
+		if newStatus.Valid {
+			a.NewStatus = newStatus.String
 		}
 		actions = append(actions, a)
 	}
@@ -235,7 +247,7 @@ func (s *Server) getActions(w http.ResponseWriter, r *http.Request) {
 func (s *Server) getSessionActions(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	rows, err := s.db.Query(
-		"SELECT id, session_id, action_type, detail, created_at FROM daemon_actions WHERE session_id = ? ORDER BY created_at DESC LIMIT 50",
+		"SELECT id, session_id, action_type, detail, captured_output_tail, previous_status, new_status, created_at FROM daemon_actions WHERE session_id = ? ORDER BY created_at DESC LIMIT 50",
 		id,
 	)
 	if err != nil {
@@ -247,13 +259,22 @@ func (s *Server) getSessionActions(w http.ResponseWriter, r *http.Request) {
 	actions := []daemonAction{}
 	for rows.Next() {
 		var a daemonAction
-		var detail sql.NullString
-		if err := rows.Scan(&a.ID, &a.SessionID, &a.ActionType, &detail, &a.CreatedAt); err != nil {
+		var detail, capturedOutputTail, previousStatus, newStatus sql.NullString
+		if err := rows.Scan(&a.ID, &a.SessionID, &a.ActionType, &detail, &capturedOutputTail, &previousStatus, &newStatus, &a.CreatedAt); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 		if detail.Valid {
 			a.Detail = detail.String
+		}
+		if capturedOutputTail.Valid {
+			a.CapturedOutputTail = capturedOutputTail.String
+		}
+		if previousStatus.Valid {
+			a.PreviousStatus = previousStatus.String
+		}
+		if newStatus.Valid {
+			a.NewStatus = newStatus.String
 		}
 		actions = append(actions, a)
 	}


### PR DESCRIPTION
## Summary
- `daemon_actions`テーブルに`captured_output_tail`, `previous_status`, `new_status`カラムを追加（マイグレーション）
- `patrol()`のログに巡回対象/スキップセッション数、キャプチャ行数、ステータス変化（旧→新）、`sendText`を追加
- APIレスポンス（`getActions`, `getSessionActions`）に新フィールドを含める

## Test plan
- [x] `make test` パス確認
- [x] `make build` パス確認
- [ ] 実際にデーモン稼働時にログ出力が詳細化されていることを確認
- [ ] `/api/actions`レスポンスに新フィールドが含まれることを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)