### PR TITLE
feat: セッション詳細画面にClaude Codeの会話ログを表示

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-frontend dev clean test install
+.PHONY: build build-frontend dev clean test install restart
 
 build: build-frontend
 	go build -o agmux ./cmd/agmux
@@ -19,3 +19,9 @@ test:
 
 install: build-frontend
 	go install ./cmd/agmux
+
+restart: install
+	-pkill -f 'agmux serve'
+	@sleep 1
+	@nohup agmux serve > /dev/null 2>&1 &
+	@echo "agmux restarted"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -56,6 +56,9 @@ export const api = {
   getLogs: (limit = 100) =>
     request<LogEntry[]>(`/logs?limit=${limit}`),
 
+  getSessionLogs: (id: string) =>
+    request<ClaudeLogEntry[]>(`/sessions/${id}/logs`),
+
   restartController: () =>
     request<Session>("/sessions/controller/restart", { method: "POST" }),
 };
@@ -68,6 +71,12 @@ export interface LogEntry {
   session?: string;
   sessionId?: string;
   [key: string]: unknown;
+}
+
+export interface ClaudeLogEntry {
+  type: "user" | "assistant";
+  timestamp: string;
+  content: string;
 }
 
 export interface DaemonAction {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import type { Session } from "../types/session";
-import { api, type DaemonAction } from "../api/client";
+import { api, type DaemonAction, type ClaudeLogEntry } from "../api/client";
 
 const actionColors: Record<string, string> = {
   approve: "text-green-600",
@@ -10,6 +10,13 @@ const actionColors: Record<string, string> = {
   none: "text-gray-400",
 };
 
+const roleStyles: Record<string, { bg: string; label: string; text: string }> = {
+  user: { bg: "bg-blue-900/30", label: "User", text: "text-blue-300" },
+  assistant: { bg: "bg-gray-800/50", label: "Assistant", text: "text-green-300" },
+};
+
+type ViewMode = "terminal" | "logs";
+
 export function SessionDetail() {
   const { id: sessionId } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -17,17 +24,21 @@ export function SessionDetail() {
   const [output, setOutput] = useState("");
   const [message, setMessage] = useState("");
   const [actions, setActions] = useState<DaemonAction[]>([]);
+  const [viewMode, setViewMode] = useState<ViewMode>("terminal");
+  const [logs, setLogs] = useState<ClaudeLogEntry[]>([]);
 
   useEffect(() => {
     if (!sessionId) return;
     api.getSession(sessionId).then(setSession);
     api.getSessionOutput(sessionId).then((r) => setOutput(r.output));
     api.getSessionActions(sessionId).then(setActions);
+    api.getSessionLogs(sessionId).then(setLogs).catch(() => {});
 
     const interval = setInterval(() => {
       api.getSessionOutput(sessionId).then((r) => setOutput(r.output));
       api.getSession(sessionId).then(setSession);
       api.getSessionActions(sessionId).then(setActions);
+      api.getSessionLogs(sessionId).then(setLogs).catch(() => {});
     }, 3000);
     return () => clearInterval(interval);
   }, [sessionId]);
@@ -62,25 +73,80 @@ export function SessionDetail() {
         Project: {session.projectPath}
       </p>
 
-      <div className="bg-gray-900 text-green-400 rounded-lg p-4 mb-4 font-mono text-xs h-96 overflow-y-auto whitespace-pre-wrap">
-        {output || "No output yet."}
+      <div className="flex border-b border-gray-300 mb-4">
+        <button
+          onClick={() => setViewMode("terminal")}
+          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
+            viewMode === "terminal"
+              ? "border-blue-600 text-blue-600"
+              : "border-transparent text-gray-500 hover:text-gray-700"
+          }`}
+        >
+          Terminal
+        </button>
+        <button
+          onClick={() => setViewMode("logs")}
+          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
+            viewMode === "logs"
+              ? "border-blue-600 text-blue-600"
+              : "border-transparent text-gray-500 hover:text-gray-700"
+          }`}
+        >
+          Logs
+          {logs.length > 0 && (
+            <span className="ml-1 text-xs text-gray-400">({logs.length})</span>
+          )}
+        </button>
       </div>
 
-      <form onSubmit={handleSend} className="flex gap-2 mb-6">
-        <input
-          type="text"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          placeholder="Send a message..."
-          className="flex-1 border border-gray-300 rounded px-3 py-2 text-sm"
-        />
-        <button
-          type="submit"
-          className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
-        >
-          Send
-        </button>
-      </form>
+      {viewMode === "terminal" ? (
+        <>
+          <div className="bg-gray-900 text-green-400 rounded-lg p-4 mb-4 font-mono text-xs h-96 overflow-y-auto whitespace-pre-wrap">
+            {output || "No output yet."}
+          </div>
+
+          <form onSubmit={handleSend} className="flex gap-2 mb-6">
+            <input
+              type="text"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Send a message..."
+              className="flex-1 border border-gray-300 rounded px-3 py-2 text-sm"
+            />
+            <button
+              type="submit"
+              className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              Send
+            </button>
+          </form>
+        </>
+      ) : (
+        <div className="bg-gray-900 rounded-lg p-3 text-sm h-96 overflow-y-auto mb-4 space-y-3">
+          {logs.length === 0 ? (
+            <p className="text-gray-500">No logs yet</p>
+          ) : (
+            logs.map((log, i) => {
+              const style = roleStyles[log.type] || roleStyles.assistant;
+              return (
+                <div key={i} className={`rounded-lg p-3 ${style.bg}`}>
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className={`font-semibold text-xs ${style.text}`}>
+                      {style.label}
+                    </span>
+                    <span className="text-gray-500 text-xs">
+                      {new Date(log.timestamp).toLocaleTimeString()}
+                    </span>
+                  </div>
+                  <div className="text-gray-200 whitespace-pre-wrap break-words text-xs">
+                    {log.content}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
 
       {actions.length > 0 && (
         <div>

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,7 +8,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -63,6 +65,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/send", s.sendToSession)
 		r.Get("/sessions/{id}/output", s.getSessionOutput)
 		r.Get("/sessions/{id}/actions", s.getSessionActions)
+		r.Get("/sessions/{id}/logs", s.getSessionLogs)
 		r.Post("/sessions/controller/restart", s.restartController)
 		r.Get("/actions", s.getActions)
 		r.Get("/logs", s.getLogs)
@@ -323,6 +326,108 @@ func (s *Server) getLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, logs)
+}
+
+type claudeLogEntry struct {
+	Type      string `json:"type"`
+	Timestamp string `json:"timestamp"`
+	Content   string `json:"content"`
+}
+
+func (s *Server) getSessionLogs(w http.ResponseWriter, r *http.Request) {
+	sessionID := chi.URLParam(r, "id")
+
+	// Get session to find projectPath
+	sess, err := s.sessions.Get(sessionID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	// Build Claude Code JSONL path: ~/.claude/projects/[escaped-path]/[sessionId].jsonl
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "cannot determine home directory")
+		return
+	}
+
+	escapedPath := strings.ReplaceAll(sess.ProjectPath, "/", "-")
+	jsonlPath := filepath.Join(homeDir, ".claude", "projects", escapedPath, sessionID+".jsonl")
+
+	file, err := os.Open(jsonlPath)
+	if err != nil {
+		writeJSON(w, http.StatusOK, []claudeLogEntry{})
+		return
+	}
+	defer file.Close()
+
+	var logs []claudeLogEntry
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		var entry struct {
+			Type      string `json:"type"`
+			Timestamp string `json:"timestamp"`
+			Message   struct {
+				Content json.RawMessage `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.Type != "user" && entry.Type != "assistant" {
+			continue
+		}
+
+		content := extractTextContent(entry.Message.Content)
+		if content == "" {
+			continue
+		}
+
+		logs = append(logs, claudeLogEntry{
+			Type:      entry.Type,
+			Timestamp: entry.Timestamp,
+			Content:   content,
+		})
+	}
+
+	if logs == nil {
+		logs = []claudeLogEntry{}
+	}
+
+	writeJSON(w, http.StatusOK, logs)
+}
+
+// extractTextContent extracts text from Claude message content.
+// Content can be a string or an array of content blocks.
+func extractTextContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	// Try as string first
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+
+	// Try as array of content blocks
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		var texts []string
+		for _, b := range blocks {
+			if b.Type == "text" && b.Text != "" {
+				texts = append(texts, b.Text)
+			}
+		}
+		return strings.Join(texts, "\n")
+	}
+
+	return ""
 }
 
 func (s *Server) restartController(w http.ResponseWriter, r *http.Request) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -35,7 +35,7 @@ func (m *Manager) Create(name, projectPath, prompt string) (*Session, error) {
 
 	// Wait for shell to be ready, then send claude command
 	time.Sleep(300 * time.Millisecond)
-	if err := m.tmux.SendKeysOnce(tmuxSession, m.claudeCommand); err != nil {
+	if err := m.tmux.SendKeysOnce(tmuxSession, m.claudeCommand+" --session-id "+id); err != nil {
 		return nil, fmt.Errorf("launch claude: %w", err)
 	}
 
@@ -271,7 +271,7 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 	}
 
 	time.Sleep(300 * time.Millisecond)
-	if err := m.tmux.SendKeysOnce(tmuxSession, m.claudeCommand); err != nil {
+	if err := m.tmux.SendKeysOnce(tmuxSession, m.claudeCommand+" --session-id "+id); err != nil {
 		return nil, fmt.Errorf("launch claude for controller: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- `claude --session-id` フラグでagmuxセッションIDをClaude Codeに渡し、JSONLファイル名を一致させる
- `GET /api/sessions/{id}/logs` で `~/.claude/projects/` 配下のJSONLからuser/assistant会話ログを返却
- Logsタブにチャット形式（user=青、assistant=緑）で会話ログを表示

Closes #7

## Test plan
- [ ] `make test` / `make build` が通ること
- [ ] 新規セッション作成後、Logsタブで会話ログが表示されること
- [ ] user/assistantが色分けされて表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)