### PR TITLE
refactor: Daemon Actions関連コードを削除

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -47,12 +47,6 @@ export const api = {
   getSessionOutput: (id: string) =>
     request<{ output: string }>(`/sessions/${id}/output`),
 
-  getActions: () =>
-    request<DaemonAction[]>("/actions"),
-
-  getSessionActions: (id: string) =>
-    request<DaemonAction[]>(`/sessions/${id}/actions`),
-
   getLogs: (limit = 100) =>
     request<LogEntry[]>(`/logs?limit=${limit}`),
 
@@ -102,10 +96,3 @@ export interface AppConfig {
   session: { claudeCommand: string };
 }
 
-export interface DaemonAction {
-  id: number;
-  sessionId: string;
-  actionType: string;
-  detail: string;
-  createdAt: string;
-}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2,14 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import Markdown from "react-markdown";
 import type { Session } from "../types/session";
-import { api, type DaemonAction, type ClaudeLogEntry, type ClaudeContentBlock } from "../api/client";
-
-const actionColors: Record<string, string> = {
-  approve: "text-green-600",
-  retry: "text-yellow-600",
-  escalate: "text-red-600",
-  none: "text-gray-400",
-};
+import { api, type ClaudeLogEntry, type ClaudeContentBlock } from "../api/client";
 
 const roleStyles: Record<string, { bg: string; label: string; text: string }> = {
   user: { bg: "bg-blue-900/30", label: "User", text: "text-blue-300" },
@@ -59,7 +52,6 @@ export function SessionDetail() {
   const [session, setSession] = useState<Session | null>(null);
   const [output, setOutput] = useState("");
   const [message, setMessage] = useState("");
-  const [actions, setActions] = useState<DaemonAction[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>("terminal");
   const [logs, setLogs] = useState<ClaudeLogEntry[]>([]);
   const terminalRef = useRef<HTMLDivElement>(null);
@@ -69,13 +61,11 @@ export function SessionDetail() {
     if (!sessionId) return;
     api.getSession(sessionId).then(setSession);
     api.getSessionOutput(sessionId).then((r) => setOutput(r.output));
-    api.getSessionActions(sessionId).then(setActions);
     api.getSessionLogs(sessionId).then(setLogs).catch(() => {});
 
     const interval = setInterval(() => {
       api.getSessionOutput(sessionId).then((r) => setOutput(r.output));
       api.getSession(sessionId).then(setSession);
-      api.getSessionActions(sessionId).then(setActions);
       api.getSessionLogs(sessionId).then(setLogs).catch(() => {});
     }, 3000);
     return () => clearInterval(interval);
@@ -208,29 +198,6 @@ export function SessionDetail() {
         </>
       )}
 
-      {actions.length > 0 && (
-        <div>
-          <h3 className="text-lg font-semibold mb-2">Daemon Actions</h3>
-          <div className="space-y-2">
-            {actions.map((a) => (
-              <div
-                key={a.id}
-                className="border border-gray-200 rounded px-3 py-2 text-sm flex items-start gap-2"
-              >
-                <span
-                  className={`font-medium ${actionColors[a.actionType] || "text-gray-500"}`}
-                >
-                  [{a.actionType}]
-                </span>
-                <span className="text-gray-700 flex-1">{a.detail}</span>
-                <span className="text-xs text-gray-400 whitespace-nowrap">
-                  {new Date(a.createdAt).toLocaleTimeString()}
-                </span>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -68,10 +68,8 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/stop", s.stopSession)
 		r.Post("/sessions/{id}/send", s.sendToSession)
 		r.Get("/sessions/{id}/output", s.getSessionOutput)
-		r.Get("/sessions/{id}/actions", s.getSessionActions)
 		r.Get("/sessions/{id}/logs", s.getSessionLogs)
 		r.Post("/sessions/controller/restart", s.restartController)
-		r.Get("/actions", s.getActions)
 		r.Get("/logs", s.getLogs)
 		r.Get("/config", s.getConfig)
 		r.Put("/config", s.updateConfig)
@@ -209,86 +207,6 @@ func (s *Server) getSessionOutput(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"output": output})
-}
-
-type daemonAction struct {
-	SessionID          string `json:"sessionId"`
-	ActionType         string `json:"actionType"`
-	Detail             string `json:"detail"`
-	Source             string `json:"source"`
-	CapturedOutputTail string `json:"capturedOutputTail,omitempty"`
-	PreviousStatus     string `json:"previousStatus,omitempty"`
-	NewStatus          string `json:"newStatus,omitempty"`
-	CreatedAt          string `json:"createdAt"`
-}
-
-// readActionsFromLog reads action entries from the log file, optionally filtered by sessionID.
-func (s *Server) readActionsFromLog(sessionID string, limit int) []daemonAction {
-	if s.logPath == "" {
-		return []daemonAction{}
-	}
-
-	file, err := os.Open(s.logPath)
-	if err != nil {
-		return []daemonAction{}
-	}
-	defer file.Close()
-
-	var actions []daemonAction
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		var entry map[string]interface{}
-		if err := json.Unmarshal([]byte(scanner.Text()), &entry); err != nil {
-			continue
-		}
-		cat, _ := entry["category"].(string)
-		if cat != "action" {
-			continue
-		}
-		sid, _ := entry["sessionId"].(string)
-		if sessionID != "" && sid != sessionID {
-			continue
-		}
-		a := daemonAction{
-			SessionID:          sid,
-			ActionType:         strVal(entry, "actionType"),
-			Detail:             strVal(entry, "detail"),
-			Source:             strVal(entry, "source"),
-			CapturedOutputTail: strVal(entry, "capturedOutputTail"),
-			PreviousStatus:     strVal(entry, "previousStatus"),
-			NewStatus:          strVal(entry, "newStatus"),
-			CreatedAt:          strVal(entry, "time"),
-		}
-		actions = append(actions, a)
-	}
-
-	// Return last N entries (newest last in file, we want newest first)
-	if len(actions) > limit {
-		actions = actions[len(actions)-limit:]
-	}
-	// Reverse to newest-first
-	for i, j := 0, len(actions)-1; i < j; i, j = i+1, j-1 {
-		actions[i], actions[j] = actions[j], actions[i]
-	}
-	if actions == nil {
-		actions = []daemonAction{}
-	}
-	return actions
-}
-
-func strVal(m map[string]interface{}, key string) string {
-	v, _ := m[key].(string)
-	return v
-}
-
-func (s *Server) getActions(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, s.readActionsFromLog("", 50))
-}
-
-func (s *Server) getSessionActions(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	writeJSON(w, http.StatusOK, s.readActionsFromLog(id, 50))
 }
 
 func (s *Server) getLogs(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- ログ統合(#19)により不要になったDaemon Actionsの概念を完全に除去
- バックエンド: `/api/actions`, `/api/sessions/{id}/actions` エンドポイント、`daemonAction`型、`readActionsFromLog()`を削除
- フロントエンド: `DaemonAction`型、API関数、SessionDetailのActions表示セクションを削除

Closes #21

## Test plan
- [x] `make build` 成功
- [x] `make test` 成功
- [ ] ダッシュボードでセッション詳細画面にDaemon Actionsセクションが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)