### PR TITLE
refactor(ui): セッション削除を詳細画面に移動しカードをクリック可能に

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,15 +58,6 @@ function Dashboard() {
     }
   };
 
-  const handleDelete = async (id: string) => {
-    try {
-      await api.deleteSession(id);
-      loadSessions();
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to delete session");
-    }
-  };
-
   const handleRestartController = async () => {
     try {
       await api.restartController();
@@ -160,8 +151,6 @@ function Dashboard() {
           <SessionList
             sessions={sessions}
             onStop={handleStop}
-            onDelete={handleDelete}
-            onSelect={(id) => navigate(`/sessions/${id}`)}
             onRestartController={handleRestartController}
           />
         </div>

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -128,6 +128,18 @@ export function SessionDetail() {
       <div className="flex items-center gap-3 mb-4">
         <h2 className="text-2xl font-bold">{session.name}</h2>
         <span className="text-sm text-gray-500">{session.status}</span>
+        {session.type !== "controller" && (
+          <button
+            onClick={async () => {
+              if (!confirm("Delete this session?")) return;
+              await api.deleteSession(session.id);
+              navigate("/");
+            }}
+            className="ml-auto px-3 py-1 text-xs bg-red-50 text-red-600 rounded hover:bg-red-100"
+          >
+            Delete
+          </button>
+        )}
       </div>
       <p className="text-sm text-gray-500 mb-4">
         Project: {session.projectPath}

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import type { Session } from "../types/session";
 
 const statusDots: Record<Session["status"], string> = {
@@ -21,12 +22,12 @@ function timeAgo(dateStr: string): string {
 interface Props {
   sessions: Session[];
   onStop: (id: string) => void;
-  onDelete: (id: string) => void;
-  onSelect: (id: string) => void;
   onRestartController: () => void;
 }
 
-export function SessionList({ sessions, onStop, onDelete, onSelect, onRestartController }: Props) {
+export function SessionList({ sessions, onStop, onRestartController }: Props) {
+  const navigate = useNavigate();
+
   if (sessions.length === 0) {
     return (
       <div className="text-center text-gray-400 py-8">
@@ -40,7 +41,8 @@ export function SessionList({ sessions, onStop, onDelete, onSelect, onRestartCon
       {sessions.map((s) => (
         <div
           key={s.id}
-          className="border border-gray-200 rounded-lg p-3 hover:shadow-sm transition-shadow bg-white"
+          onClick={() => navigate(`/sessions/${s.id}`)}
+          className="border border-gray-200 rounded-lg p-3 hover:shadow-sm transition-shadow bg-white cursor-pointer"
         >
           <div className="flex items-center gap-2 mb-1">
             <span className={`w-2 h-2 rounded-full shrink-0 ${statusDots[s.status]}`} />
@@ -64,7 +66,7 @@ export function SessionList({ sessions, onStop, onDelete, onSelect, onRestartCon
             <div className="flex gap-1.5">
               {(s.status === "running" || s.status === "waiting") && (
                 <button
-                  onClick={() => onStop(s.id)}
+                  onClick={(e) => { e.stopPropagation(); onStop(s.id); }}
                   className="px-2 py-0.5 text-xs bg-red-50 text-red-600 rounded hover:bg-red-100"
                 >
                   Stop
@@ -72,26 +74,12 @@ export function SessionList({ sessions, onStop, onDelete, onSelect, onRestartCon
               )}
               {s.type === "controller" && (s.status === "stopped" || s.status === "done" || s.status === "error") && (
                 <button
-                  onClick={() => onRestartController()}
+                  onClick={(e) => { e.stopPropagation(); onRestartController(); }}
                   className="px-2 py-0.5 text-xs bg-purple-50 text-purple-600 rounded hover:bg-purple-100"
                 >
                   Restart
                 </button>
               )}
-              {s.type !== "controller" && (
-                <button
-                  onClick={() => onDelete(s.id)}
-                  className="px-2 py-0.5 text-xs bg-gray-50 text-gray-500 rounded hover:bg-gray-100"
-                >
-                  Delete
-                </button>
-              )}
-              <button
-                onClick={() => onSelect(s.id)}
-                className="px-2 py-0.5 text-xs bg-gray-50 text-gray-700 rounded hover:bg-gray-100"
-              >
-                View
-              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- SessionListからDelete・Viewボタンを削除し、カード全体をクリックでセッション詳細に遷移するように変更
- SessionDetailにDeleteボタンを追加（確認ダイアログ付き、controller以外のみ表示）
- App.tsxから不要になった`handleDelete`・`onSelect` propsを削除

Closes #39

## Test plan
- [ ] セッションカードをクリックして詳細画面に遷移できることを確認
- [ ] Stop/Restartボタンがカード内で正常に動作することを確認（カード遷移をブロック）
- [ ] セッション詳細画面のDeleteボタンで削除→ダッシュボードに戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)