### PR TITLE
feat: セッション詳細画面にStopボタンを追加

### DIFF
--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -367,16 +367,29 @@ export function SessionDetail() {
         <h2 className="text-2xl font-bold">{session.name}</h2>
         <span className="text-sm text-gray-500">{session.status}</span>
         {session.type !== "controller" && (
-          <button
-            onClick={async () => {
-              if (!confirm("Delete this session?")) return;
-              await api.deleteSession(session.id);
-              navigate("/");
-            }}
-            className="ml-auto px-3 py-1 text-xs bg-red-50 text-red-600 rounded hover:bg-red-100"
-          >
-            Delete
-          </button>
+          <div className="ml-auto flex gap-2">
+            {session.status !== "stopped" && (
+              <button
+                onClick={async () => {
+                  await api.stopSession(session.id);
+                  api.getSession(session.id).then(setSession);
+                }}
+                className="px-3 py-1 text-xs bg-yellow-50 text-yellow-700 rounded hover:bg-yellow-100"
+              >
+                Stop
+              </button>
+            )}
+            <button
+              onClick={async () => {
+                if (!confirm("Delete this session?")) return;
+                await api.deleteSession(session.id);
+                navigate("/");
+              }}
+              className="px-3 py-1 text-xs bg-red-50 text-red-600 rounded hover:bg-red-100"
+            >
+              Delete
+            </button>
+          </div>
         )}
       </div>
       <p className="text-sm text-gray-500 mb-4">


### PR DESCRIPTION
## Summary
- セッション詳細画面にStopボタンを追加
- stoppedでないセッションにのみ表示
- 既存のstop API (`POST /sessions/{id}/stop`) を利用

Closes #50

## Test plan
- [ ] 実行中のセッション詳細画面でStopボタンが表示されることを確認
- [ ] Stopボタン押下でセッションが停止し、ボタンが非表示になることを確認
- [ ] stoppedセッションではStopボタンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)