### PR TITLE
feat: セッション詳細にGitHubリポジトリリンクを表示

### DIFF
--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -394,6 +394,20 @@ export function SessionDetail() {
       </div>
       <p className="text-sm text-gray-500 mb-4">
         Project: {session.projectPath}
+        {session.githubUrl && (
+          <>
+            {" "}
+            <a
+              href={session.githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-gray-600 hover:text-gray-900"
+              title="Open on GitHub"
+            >
+              <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+            </a>
+          </>
+        )}
       </p>
 
       {isStream ? (

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -9,4 +9,5 @@ export interface Session {
   outputMode: "terminal" | "stream";
   createdAt: string;
   updatedAt: string;
+  githubUrl?: string;
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"time"
 
@@ -147,6 +148,11 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, sess)
 }
 
+type sessionResponse struct {
+	*session.Session
+	GithubURL string `json:"githubUrl,omitempty"`
+}
+
 func (s *Server) getSession(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sess, err := s.sessions.Get(id)
@@ -154,7 +160,8 @@ func (s *Server) getSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, sess)
+	resp := sessionResponse{Session: sess, GithubURL: detectGithubURL(sess.ProjectPath)}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
@@ -486,6 +493,36 @@ func writeJSON(w http.ResponseWriter, status int, data interface{}) {
 
 func writeError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func detectGithubURL(projectPath string) string {
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = projectPath
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	remote := strings.TrimSpace(string(out))
+
+	// SSH format: git@github.com:user/repo.git
+	if strings.HasPrefix(remote, "git@github.com:") {
+		path := strings.TrimPrefix(remote, "git@github.com:")
+		path = strings.TrimSuffix(path, ".git")
+		return "https://github.com/" + path
+	}
+	// HTTPS format: https://github.com/user/repo.git
+	if strings.Contains(remote, "github.com") && strings.HasPrefix(remote, "https://") {
+		return strings.TrimSuffix(remote, ".git")
+	}
+	// SSH format: ssh://git@github.com/user/repo.git
+	if strings.HasPrefix(remote, "ssh://") && strings.Contains(remote, "github.com") {
+		path := remote
+		path = strings.TrimPrefix(path, "ssh://git@github.com/")
+		path = strings.TrimPrefix(path, "ssh://github.com/")
+		path = strings.TrimSuffix(path, ".git")
+		return "https://github.com/" + path
+	}
+	return ""
 }
 
 func buildClaudeJSONLPath(projectPath, sessionID string) string {


### PR DESCRIPTION
## Summary
- `git remote get-url origin` でGitHubリポジトリURLを検出
- SSH/HTTPS/SSH(ssh://)の各フォーマットに対応
- セッション詳細のプロジェクトパスの横にGitHubアイコン(SVG)を表示
- アイコンクリックで新タブでGitHubリポジトリを開く

Closes #34

## Test plan
- [ ] GitHubリポジトリのプロジェクトでセッションを開いた時にアイコンが表示される
- [ ] アイコンクリックで正しいGitHub URLが開く
- [ ] GitHub以外のリポジトリではアイコンが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)