### PR TITLE
fix: ターミナルモードのLog表示と関連コードを削除

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -51,9 +51,6 @@ export const api = {
   getLogs: (limit = 100) =>
     request<LogEntry[]>(`/logs?limit=${limit}`),
 
-  getSessionLogs: (id: string) =>
-    request<ClaudeLogEntry[]>(`/sessions/${id}/logs`),
-
   getStreamOutput: (id: string, limit = 200) =>
     request<unknown[]>(`/sessions/${id}/stream?limit=${limit}`),
 
@@ -77,20 +74,6 @@ export interface LogEntry {
   session?: string;
   sessionId?: string;
   [key: string]: unknown;
-}
-
-export interface ClaudeContentBlock {
-  type: "text" | "tool_use" | "tool_result";
-  text?: string;
-  name?: string;
-  input?: unknown;
-  content?: string;
-}
-
-export interface ClaudeLogEntry {
-  type: "user" | "assistant";
-  timestamp: string;
-  blocks: ClaudeContentBlock[];
 }
 
 export interface AppConfig {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -3,47 +3,12 @@ import { useParams, useNavigate } from "react-router-dom";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Session } from "../types/session";
-import { api, type ClaudeLogEntry, type ClaudeContentBlock } from "../api/client";
+import { api } from "../api/client";
 
 const roleStyles: Record<string, { bg: string; label: string; text: string }> = {
   user: { bg: "bg-blue-50", label: "User", text: "text-blue-700" },
   assistant: { bg: "bg-gray-50", label: "Assistant", text: "text-green-700" },
 };
-
-function ContentBlockView({ block }: { block: ClaudeContentBlock }) {
-  if (block.type === "text") {
-    return (
-      <div className="prose prose-xs max-w-none prose-pre:bg-gray-100 prose-pre:text-gray-800 prose-code:text-pink-600">
-        <Markdown remarkPlugins={[remarkGfm]}>{block.text ?? ""}</Markdown>
-      </div>
-    );
-  }
-  if (block.type === "tool_use") {
-    const inputStr = typeof block.input === "string"
-      ? block.input
-      : JSON.stringify(block.input, null, 2);
-    return (
-      <details className="bg-gray-100 rounded px-2 py-1">
-        <summary className="cursor-pointer text-yellow-700 font-mono text-xs">
-          Tool: {block.name}
-        </summary>
-        <pre className="text-gray-600 text-xs mt-1 overflow-x-auto whitespace-pre-wrap">{inputStr}</pre>
-      </details>
-    );
-  }
-  if (block.type === "tool_result") {
-    const content = block.content ?? "";
-    return (
-      <details className="bg-gray-100 rounded px-2 py-1">
-        <summary className="cursor-pointer text-cyan-700 font-mono text-xs">
-          Tool Result
-        </summary>
-        <pre className="text-gray-600 text-xs mt-1 overflow-x-auto whitespace-pre-wrap">{content.slice(0, 2000)}</pre>
-      </details>
-    );
-  }
-  return null;
-}
 
 // --- Stream mode types and helpers ---
 
@@ -298,22 +263,18 @@ export function SessionDetail() {
   const [session, setSession] = useState<Session | null>(null);
   const [output, setOutput] = useState("");
   const [message, setMessage] = useState("");
-  const [logs, setLogs] = useState<ClaudeLogEntry[]>([]);
   const [streamLines, setStreamLines] = useState<unknown[]>([]);
   const terminal = useAutoScroll(output);
-  const logsScroll = useAutoScroll(logs);
 
   useEffect(() => {
     if (!sessionId) return;
     api.getSession(sessionId).then(setSession);
     api.getSessionOutput(sessionId).then((r) => setOutput(r.output));
-    api.getSessionLogs(sessionId).then(setLogs).catch(() => {});
     api.getStreamOutput(sessionId).then(setStreamLines).catch(() => {});
 
     const interval = setInterval(() => {
       api.getSession(sessionId).then(setSession);
       api.getSessionOutput(sessionId).then((r) => setOutput(r.output));
-      api.getSessionLogs(sessionId).then(setLogs).catch(() => {});
       api.getStreamOutput(sessionId).then(setStreamLines).catch(() => {});
     }, 3000);
     return () => clearInterval(interval);
@@ -421,33 +382,6 @@ export function SessionDetail() {
             {output || "No output yet."}
           </div>
           {sendForm}
-          <div ref={logsScroll.ref} onScroll={logsScroll.onScroll} className="bg-gray-900 rounded-lg p-3 text-sm h-96 overflow-y-auto mb-4 space-y-3">
-            <h3 className="text-gray-400 text-xs font-semibold mb-2">Logs</h3>
-            {logs.length === 0 ? (
-              <p className="text-gray-500">No logs yet</p>
-            ) : (
-              logs.map((log, i) => {
-                const style = roleStyles[log.type] || roleStyles.assistant;
-                return (
-                  <div key={i} className={`rounded-lg p-3 ${style.bg}`}>
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className={`font-semibold text-xs ${style.text}`}>
-                        {style.label}
-                      </span>
-                      <span className="text-gray-500 text-xs">
-                        {new Date(log.timestamp).toLocaleTimeString()}
-                      </span>
-                    </div>
-                    <div className="text-gray-200 break-words text-xs space-y-2">
-                      {log.blocks.map((block, j) => (
-                        <ContentBlockView key={j} block={block} />
-                      ))}
-                    </div>
-                  </div>
-                );
-              })
-            )}
-          </div>
         </>
       )}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -18,9 +19,6 @@ import (
 	"github.com/myuon/agmux/internal/config"
 	"github.com/myuon/agmux/internal/db"
 	"github.com/myuon/agmux/internal/logging"
-	"path/filepath"
-	"strings"
-
 	"github.com/myuon/agmux/internal/session"
 )
 
@@ -69,7 +67,6 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/stop", s.stopSession)
 		r.Post("/sessions/{id}/send", s.sendToSession)
 		r.Get("/sessions/{id}/output", s.getSessionOutput)
-		r.Get("/sessions/{id}/logs", s.getSessionLogs)
 		r.Get("/sessions/{id}/stream", s.getSessionStream)
 		r.Post("/sessions/controller/restart", s.restartController)
 		r.Get("/logs", s.getLogs)
@@ -289,130 +286,6 @@ func (s *Server) getLogs(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, logs)
 }
 
-type claudeContentBlock struct {
-	Type    string `json:"type"`              // "text", "tool_use", "tool_result"
-	Text    string `json:"text,omitempty"`    // for type=text
-	Name    string `json:"name,omitempty"`    // for type=tool_use (tool name)
-	Input   any    `json:"input,omitempty"`   // for type=tool_use (tool input)
-	Content string `json:"content,omitempty"` // for type=tool_result
-}
-
-type claudeLogEntry struct {
-	Type      string               `json:"type"`
-	Timestamp string               `json:"timestamp"`
-	Blocks    []claudeContentBlock `json:"blocks"`
-}
-
-func (s *Server) getSessionLogs(w http.ResponseWriter, r *http.Request) {
-	sessionID := chi.URLParam(r, "id")
-
-	// Get session to find projectPath
-	sess, err := s.sessions.Get(sessionID)
-	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
-		return
-	}
-
-	// Build Claude Code JSONL path
-	jsonlPath := buildClaudeJSONLPath(sess.ProjectPath, sessionID)
-
-	file, err := os.Open(jsonlPath)
-	if err != nil {
-		writeJSON(w, http.StatusOK, []claudeLogEntry{})
-		return
-	}
-	defer file.Close()
-
-	var logs []claudeLogEntry
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		var entry struct {
-			Type      string `json:"type"`
-			Timestamp string `json:"timestamp"`
-			Message   struct {
-				Content json.RawMessage `json:"content"`
-			} `json:"message"`
-		}
-		if err := json.Unmarshal([]byte(line), &entry); err != nil {
-			continue
-		}
-		if entry.Type != "user" && entry.Type != "assistant" {
-			continue
-		}
-
-		blocks := extractContentBlocks(entry.Message.Content)
-		if len(blocks) == 0 {
-			continue
-		}
-
-		logs = append(logs, claudeLogEntry{
-			Type:      entry.Type,
-			Timestamp: entry.Timestamp,
-			Blocks:    blocks,
-		})
-	}
-
-	if logs == nil {
-		logs = []claudeLogEntry{}
-	}
-
-	writeJSON(w, http.StatusOK, logs)
-}
-
-// extractContentBlocks parses Claude message content into typed blocks.
-func extractContentBlocks(raw json.RawMessage) []claudeContentBlock {
-	if len(raw) == 0 {
-		return nil
-	}
-
-	// Try as string first (plain user message)
-	var str string
-	if err := json.Unmarshal(raw, &str); err == nil {
-		if str == "" {
-			return nil
-		}
-		return []claudeContentBlock{{Type: "text", Text: str}}
-	}
-
-	// Try as array of content blocks
-	var rawBlocks []struct {
-		Type      string          `json:"type"`
-		Text      string          `json:"text,omitempty"`
-		Name      string          `json:"name,omitempty"`
-		Input     json.RawMessage `json:"input,omitempty"`
-		Content   json.RawMessage `json:"content,omitempty"`
-		ToolUseID string          `json:"tool_use_id,omitempty"`
-	}
-	if err := json.Unmarshal(raw, &rawBlocks); err != nil {
-		return nil
-	}
-
-	var blocks []claudeContentBlock
-	for _, b := range rawBlocks {
-		switch b.Type {
-		case "text":
-			if b.Text != "" {
-				blocks = append(blocks, claudeContentBlock{Type: "text", Text: b.Text})
-			}
-		case "tool_use":
-			var input any
-			json.Unmarshal(b.Input, &input)
-			blocks = append(blocks, claudeContentBlock{Type: "tool_use", Name: b.Name, Input: input})
-		case "tool_result":
-			content := ""
-			// tool_result content can be string or structured
-			json.Unmarshal(b.Content, &content)
-			if content == "" {
-				content = string(b.Content)
-			}
-			blocks = append(blocks, claudeContentBlock{Type: "tool_result", Content: content})
-		}
-	}
-	return blocks
-}
-
 type configJSON struct {
 	Server  configServerJSON  `json:"server"`
 	Daemon  configDaemonJSON  `json:"daemon"`
@@ -523,13 +396,6 @@ func detectGithubURL(projectPath string) string {
 		return "https://github.com/" + path
 	}
 	return ""
-}
-
-func buildClaudeJSONLPath(projectPath, sessionID string) string {
-	homeDir, _ := os.UserHomeDir()
-	escapedPath := strings.ReplaceAll(projectPath, "/", "-")
-	escapedPath = strings.ReplaceAll(escapedPath, ".", "-")
-	return filepath.Join(homeDir, ".claude", "projects", escapedPath, sessionID+".jsonl")
 }
 
 func (s *Server) recordSessionAction(sessionID, actionType, detail string) {


### PR DESCRIPTION
## Summary
- フロントエンド: `ContentBlockView`コンポーネント、`getSessionLogs` API、`ClaudeLogEntry`/`ClaudeContentBlock`型を削除
- バックエンド: `/sessions/{id}/logs`エンドポイント、関連ハンドラ・型・ヘルパー関数(`buildClaudeJSONLPath`)を削除

closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)