### PR TITLE
feat: セッションコンテキスト表示・MCP注入・Reconnect機能

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install: build-frontend
 	go install ./cmd/agmux
 
 restart: install
-	-pkill -f 'agmux serve'
+	-lsof -ti :4321 | xargs kill
 	@sleep 1
 	@nohup agmux serve > /dev/null 2>&1 &
 	@echo "agmux restarted"

--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/myuon/agmux/internal/config"
 	"github.com/myuon/agmux/internal/db"
 	"github.com/myuon/agmux/internal/logging"
+	"github.com/myuon/agmux/internal/mcp"
 	"github.com/myuon/agmux/internal/monitor"
 	"github.com/myuon/agmux/internal/server"
 	"github.com/myuon/agmux/internal/session"
@@ -27,6 +28,7 @@ func main() {
 
 	rootCmd.AddCommand(sessionCmd())
 	rootCmd.AddCommand(serveCmd())
+	rootCmd.AddCommand(mcpCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -42,7 +44,7 @@ func initManager(cfg *config.Config) (*session.Manager, *sql.DB, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	return session.NewManager(database, tmux.NewClient(), cfg.Session.ClaudeCommand), database, nil
+	return session.NewManager(database, tmux.NewClient(), cfg.Session.ClaudeCommand, cfg.Server.Port), database, nil
 }
 
 func serveCmd() *cobra.Command {
@@ -267,6 +269,17 @@ func sessionSendCmd() *cobra.Command {
 			}
 			fmt.Println("Text sent.")
 			return nil
+		},
+	}
+}
+
+func mcpCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "mcp",
+		Short:  "Run as MCP server (stdio transport)",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return mcp.NewServer().Run()
 		},
 	}
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -54,6 +54,15 @@ export const api = {
   getStreamOutput: (id: string, limit = 200) =>
     request<unknown[]>(`/sessions/${id}/stream?limit=${limit}`),
 
+  updateSessionContext: (id: string, data: { currentTask: string; goal: string }) =>
+    request<{ status: string }>(`/sessions/${id}/context`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
+
+  reconnectSession: (id: string) =>
+    request<{ status: string }>(`/sessions/${id}/reconnect`, { method: "POST" }),
+
   restartController: () =>
     request<Session>("/sessions/controller/restart", { method: "POST" }),
 

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -342,6 +342,15 @@ export function SessionDetail() {
             )}
             <button
               onClick={async () => {
+                await api.reconnectSession(session.id);
+                api.getSession(session.id).then(setSession);
+              }}
+              className="px-3 py-1 text-xs bg-indigo-50 text-indigo-700 rounded hover:bg-indigo-100"
+            >
+              Reconnect
+            </button>
+            <button
+              onClick={async () => {
                 if (!confirm("Delete this session?")) return;
                 await api.deleteSession(session.id);
                 navigate("/");
@@ -395,6 +404,21 @@ export function SessionDetail() {
               #{pr.number} {pr.title}
             </a>
           ))}
+        </div>
+      )}
+
+      {(session.currentTask || session.goal) && (
+        <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-3 mb-4">
+          {session.currentTask && (
+            <p className="text-sm text-indigo-800">
+              <span className="font-semibold">Task:</span> {session.currentTask}
+            </p>
+          )}
+          {session.goal && (
+            <p className="text-sm text-indigo-600 mt-1">
+              <span className="font-semibold">Goal:</span> {session.goal}
+            </p>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -55,6 +55,9 @@ export function SessionList({ sessions, onStop, onRestartController }: Props) {
               {s.status}
             </span>
           </div>
+          {s.currentTask && (
+            <p className="text-xs text-indigo-600 truncate mb-0.5">{s.currentTask}</p>
+          )}
           <p className="text-xs text-gray-500 truncate mb-1">
             {s.projectPath}
           </p>

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -7,6 +7,8 @@ export interface Session {
   status: "working" | "idle" | "question_waiting" | "stopped";
   type: "worker" | "controller";
   outputMode: "terminal" | "stream";
+  currentTask?: string;
+  goal?: string;
   createdAt: string;
   updatedAt: string;
   githubUrl?: string;

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -98,6 +98,18 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: add current_task column if missing
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN current_task TEXT`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
+	// Migration: add goal column if missing
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN goal TEXT`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	// Migration: update old status values to new ones
 	_, err = db.Exec(`UPDATE sessions SET status = 'working' WHERE status IN ('running', 'waiting', 'error')`)
 	if err != nil {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,199 @@
+package mcp
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type Server struct {
+	sessionID string
+	apiURL    string
+}
+
+func NewServer() *Server {
+	return &Server{
+		sessionID: os.Getenv("AGMUX_SESSION_ID"),
+		apiURL:    os.Getenv("AGMUX_API_URL"),
+	}
+}
+
+// Run starts the MCP server on stdin/stdout (JSON-RPC 2.0).
+func (s *Server) Run() error {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		var req jsonRPCRequest
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			continue
+		}
+
+		// Notifications have no id — no response needed
+		if req.ID == nil {
+			continue
+		}
+
+		result, rpcErr := s.handleMethod(req.Method, req.Params)
+		resp := jsonRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+		}
+		if rpcErr != nil {
+			resp.Error = rpcErr
+		} else {
+			raw, _ := json.Marshal(result)
+			rawMsg := json.RawMessage(raw)
+			resp.Result = &rawMsg
+		}
+
+		out, _ := json.Marshal(resp)
+		fmt.Fprintf(os.Stdout, "%s\n", out)
+	}
+
+	return scanner.Err()
+}
+
+func (s *Server) handleMethod(method string, params json.RawMessage) (interface{}, *jsonRPCError) {
+	switch method {
+	case "initialize":
+		return map[string]interface{}{
+			"protocolVersion": "2024-11-05",
+			"capabilities": map[string]interface{}{
+				"tools": map[string]interface{}{},
+			},
+			"serverInfo": map[string]interface{}{
+				"name":    "agmux",
+				"version": "1.0.0",
+			},
+		}, nil
+
+	case "tools/list":
+		return map[string]interface{}{
+			"tools": []interface{}{
+				map[string]interface{}{
+					"name":        "set_session_context",
+					"description": "agmuxの管理画面に表示される、現在のセッションの「今取り組んでいるタスク」と「完了条件(Goal)」を設定します。新しいタスクに着手したときや、Goalが変わったときに呼んでください。",
+					"inputSchema": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"currentTask": map[string]interface{}{
+								"type":        "string",
+								"description": "今取り組んでいる作業の概要（例: 「ログイン画面のバリデーション実装」）",
+							},
+							"goal": map[string]interface{}{
+								"type":        "string",
+								"description": "この作業の完了条件（例: 「メールとパスワードのバリデーションが動作しテストが通る」）",
+							},
+						},
+						"required": []string{"currentTask", "goal"},
+					},
+				},
+			},
+		}, nil
+
+	case "tools/call":
+		var p struct {
+			Name      string          `json:"name"`
+			Arguments json.RawMessage `json:"arguments"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, &jsonRPCError{Code: -32602, Message: "invalid params"}
+		}
+		return s.callTool(p.Name, p.Arguments)
+
+	default:
+		return nil, &jsonRPCError{Code: -32601, Message: "method not found"}
+	}
+}
+
+func (s *Server) callTool(name string, args json.RawMessage) (interface{}, *jsonRPCError) {
+	if name != "set_session_context" {
+		return nil, &jsonRPCError{Code: -32602, Message: "unknown tool: " + name}
+	}
+
+	var input struct {
+		CurrentTask string `json:"currentTask"`
+		Goal        string `json:"goal"`
+	}
+	if err := json.Unmarshal(args, &input); err != nil {
+		return nil, &jsonRPCError{Code: -32602, Message: "invalid arguments"}
+	}
+
+	if err := s.updateContext(input.CurrentTask, input.Goal); err != nil {
+		return toolResult(fmt.Sprintf("Error: %v", err), true), nil
+	}
+
+	return toolResult("Context updated successfully.", false), nil
+}
+
+func (s *Server) updateContext(currentTask, goal string) error {
+	url := fmt.Sprintf("%s/api/sessions/%s/context", s.apiURL, s.sessionID)
+	body := fmt.Sprintf(`{"currentTask":%s,"goal":%s}`,
+		jsonString(currentTask), jsonString(goal))
+
+	req, err := http.NewRequest("PUT", url, strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func toolResult(text string, isError bool) interface{} {
+	return map[string]interface{}{
+		"content": []interface{}{
+			map[string]interface{}{
+				"type": "text",
+				"text": text,
+			},
+		},
+		"isError": isError,
+	}
+}
+
+// JSON-RPC types
+
+type jsonRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type jsonRPCResponse struct {
+	JSONRPC string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id"`
+	Result  *json.RawMessage `json:"result,omitempty"`
+	Error   *jsonRPCError    `json:"error,omitempty"`
+}
+
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -66,6 +66,8 @@ func (s *Server) setupRoutes() {
 		r.Delete("/sessions/{id}", s.deleteSession)
 		r.Post("/sessions/{id}/stop", s.stopSession)
 		r.Post("/sessions/{id}/send", s.sendToSession)
+		r.Put("/sessions/{id}/context", s.updateSessionContext)
+		r.Post("/sessions/{id}/reconnect", s.reconnectSession)
 		r.Get("/sessions/{id}/output", s.getSessionOutput)
 		r.Get("/sessions/{id}/stream", s.getSessionStream)
 		r.Post("/sessions/controller/restart", s.restartController)
@@ -112,6 +114,11 @@ type createSessionRequest struct {
 
 type sendRequest struct {
 	Text string `json:"text"`
+}
+
+type updateContextRequest struct {
+	CurrentTask string `json:"currentTask"`
+	Goal        string `json:"goal"`
 }
 
 func (s *Server) listSessions(w http.ResponseWriter, r *http.Request) {
@@ -216,6 +223,30 @@ func (s *Server) sendToSession(w http.ResponseWriter, r *http.Request) {
 	}
 	s.recordSessionAction(id, "session_send_keys", req.Text)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "sent"})
+}
+
+func (s *Server) updateSessionContext(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req updateContextRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := s.sessions.UpdateContext(id, req.CurrentTask, req.Goal); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) reconnectSession(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.sessions.Reconnect(id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.recordSessionAction(id, "session_reconnect", "")
+	writeJSON(w, http.StatusOK, map[string]string{"status": "reconnected"})
 }
 
 func (s *Server) getSessionOutput(w http.ResponseWriter, r *http.Request) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -19,11 +19,12 @@ type Manager struct {
 	db              *sql.DB
 	tmux            *tmux.Client
 	claudeCommand   string
+	apiPort         int
 	streamProcesses map[string]*StreamProcess
 	streamMu        sync.Mutex
 }
 
-func NewManager(db *sql.DB, tmuxClient *tmux.Client, claudeCommand string) *Manager {
+func NewManager(db *sql.DB, tmuxClient *tmux.Client, claudeCommand string, apiPort int) *Manager {
 	if claudeCommand == "" {
 		claudeCommand = "claude --dangerously-skip-permissions"
 	}
@@ -31,6 +32,7 @@ func NewManager(db *sql.DB, tmuxClient *tmux.Client, claudeCommand string) *Mana
 		db:              db,
 		tmux:            tmuxClient,
 		claudeCommand:   claudeCommand,
+		apiPort:         apiPort,
 		streamProcesses: make(map[string]*StreamProcess),
 	}
 }
@@ -43,6 +45,12 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 	id := uuid.New().String()
 	tmuxSession := tmux.SessionPrefix + name
 
+	// Generate MCP config for this session
+	mcpConfigPath, err := writeMCPConfig(id, m.apiPort)
+	if err != nil {
+		return nil, fmt.Errorf("write mcp config: %w", err)
+	}
+
 	// Start tmux session with a shell
 	if err := m.tmux.NewSession(name, projectPath, ""); err != nil {
 		return nil, fmt.Errorf("create tmux session: %w", err)
@@ -50,7 +58,7 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 
 	if outputMode == OutputModeStream {
 		// Stream mode: start Go subprocess instead of claude TUI
-		sp, err := StartStreamProcess(id, projectPath, false)
+		sp, err := StartStreamProcess(id, projectPath, mcpConfigPath, false)
 		if err != nil {
 			_ = m.tmux.KillSession(name)
 			return nil, fmt.Errorf("start stream process: %w", err)
@@ -68,7 +76,8 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 	} else {
 		// Terminal mode: launch claude TUI in tmux
 		time.Sleep(300 * time.Millisecond)
-		if err := m.tmux.SendKeysOnce(tmuxSession, m.claudeCommand+" --session-id "+id); err != nil {
+		claudeCmd := m.claudeCommand + " --session-id " + id + " --mcp-config " + mcpConfigPath
+		if err := m.tmux.SendKeysOnce(tmuxSession, claudeCmd); err != nil {
 			return nil, fmt.Errorf("launch claude: %w", err)
 		}
 
@@ -97,12 +106,11 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 		UpdatedAt:     now,
 	}
 
-	_, err := m.db.Exec(
+	if _, err := m.db.Exec(
 		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, s.TmuxSession, string(s.Status), string(s.Type), string(s.OutputMode), s.CreatedAt, s.UpdatedAt,
-	)
-	if err != nil {
+	); err != nil {
 		// Cleanup tmux session on DB error
 		_ = m.tmux.KillSession(name)
 		return nil, fmt.Errorf("insert session: %w", err)
@@ -113,7 +121,7 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 
 func (m *Manager) List() ([]Session, error) {
 	rows, err := m.db.Query(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, created_at, updated_at
 		 FROM sessions ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -127,8 +135,8 @@ func (m *Manager) List() ([]Session, error) {
 		var status string
 		var sessionType string
 		var outputMode string
-		var prompt sql.NullString
-		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		var prompt, currentTask, goal sql.NullString
+		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		s.Status = Status(status)
@@ -136,6 +144,12 @@ func (m *Manager) List() ([]Session, error) {
 		s.OutputMode = OutputMode(outputMode)
 		if prompt.Valid {
 			s.InitialPrompt = prompt.String
+		}
+		if currentTask.Valid {
+			s.CurrentTask = currentTask.String
+		}
+		if goal.Valid {
+			s.Goal = goal.String
 		}
 
 		// Correct status based on tmux reality
@@ -156,11 +170,11 @@ func (m *Manager) Get(id string) (*Session, error) {
 	var status string
 	var sessionType string
 	var outputMode string
-	var prompt sql.NullString
+	var prompt, currentTask, goal sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id,
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
@@ -172,6 +186,12 @@ func (m *Manager) Get(id string) (*Session, error) {
 	s.OutputMode = OutputMode(outputMode)
 	if prompt.Valid {
 		s.InitialPrompt = prompt.String
+	}
+	if currentTask.Valid {
+		s.CurrentTask = currentTask.String
+	}
+	if goal.Valid {
+		s.Goal = goal.String
 	}
 	return &s, nil
 }
@@ -239,8 +259,9 @@ func (m *Manager) SendKeys(id string, text string) error {
 		m.streamMu.Unlock()
 		if !ok {
 			// Auto-recover: restart stream process after server restart
+			mcpPath, _ := writeMCPConfig(s.ID, m.apiPort)
 			var err error
-			sp, err = StartStreamProcess(s.ID, s.ProjectPath, true)
+			sp, err = StartStreamProcess(s.ID, s.ProjectPath, mcpPath, true)
 			if err != nil {
 				return fmt.Errorf("restart stream process: %w", err)
 			}
@@ -342,11 +363,11 @@ func (m *Manager) GetController() (*Session, error) {
 	var status string
 	var sessionType string
 	var outputMode string
-	var prompt sql.NullString
+	var prompt, currentTask, goal sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, created_at, updated_at
 		 FROM sessions WHERE type = ? LIMIT 1`, string(TypeController),
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -358,6 +379,12 @@ func (m *Manager) GetController() (*Session, error) {
 	s.OutputMode = OutputMode(outputMode)
 	if prompt.Valid {
 		s.InitialPrompt = prompt.String
+	}
+	if currentTask.Valid {
+		s.CurrentTask = currentTask.String
+	}
+	if goal.Valid {
+		s.Goal = goal.String
 	}
 	return &s, nil
 }
@@ -383,12 +410,18 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 	name := "controller"
 	tmuxSession := tmux.SessionPrefix + name
 
+	mcpConfigPath, err := writeMCPConfig(id, m.apiPort)
+	if err != nil {
+		return nil, fmt.Errorf("write mcp config: %w", err)
+	}
+
 	if err := m.tmux.NewSession(name, projectPath, ""); err != nil {
 		return nil, fmt.Errorf("create controller tmux session: %w", err)
 	}
 
 	time.Sleep(300 * time.Millisecond)
-	if err := m.tmux.SendKeysOnce(tmuxSession, m.claudeCommand+" --session-id "+id); err != nil {
+	claudeCmd := m.claudeCommand + " --session-id " + id + " --mcp-config " + mcpConfigPath
+	if err := m.tmux.SendKeysOnce(tmuxSession, claudeCmd); err != nil {
 		return nil, fmt.Errorf("launch claude for controller: %w", err)
 	}
 
@@ -420,5 +453,58 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 
 func (m *Manager) UpdateStatus(id string, status Status) error {
 	_, err := m.db.Exec("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", string(status), time.Now(), id)
+	return err
+}
+
+func (m *Manager) UpdateContext(id string, currentTask, goal string) error {
+	_, err := m.db.Exec("UPDATE sessions SET current_task = ?, goal = ?, updated_at = ? WHERE id = ?", currentTask, goal, time.Now(), id)
+	return err
+}
+
+// Reconnect restarts the Claude process for an existing session,
+// preserving the Claude session ID (--resume) and injecting a fresh MCP config.
+func (m *Manager) Reconnect(id string) error {
+	s, err := m.Get(id)
+	if err != nil {
+		return err
+	}
+
+	// Stop existing stream process if any
+	m.stopStreamProcess(id)
+
+	// Kill existing tmux session
+	name := s.TmuxSession[len(tmux.SessionPrefix):]
+	if m.tmux.HasSession(name) {
+		_ = m.tmux.KillSession(name)
+	}
+
+	// Generate fresh MCP config
+	mcpConfigPath, err := writeMCPConfig(id, m.apiPort)
+	if err != nil {
+		return fmt.Errorf("write mcp config: %w", err)
+	}
+
+	// Recreate tmux session
+	if err := m.tmux.NewSession(name, s.ProjectPath, ""); err != nil {
+		return fmt.Errorf("create tmux session: %w", err)
+	}
+
+	if s.OutputMode == OutputModeStream {
+		sp, err := StartStreamProcess(id, s.ProjectPath, mcpConfigPath, true)
+		if err != nil {
+			return fmt.Errorf("start stream process: %w", err)
+		}
+		m.streamMu.Lock()
+		m.streamProcesses[id] = sp
+		m.streamMu.Unlock()
+	} else {
+		time.Sleep(300 * time.Millisecond)
+		claudeCmd := m.claudeCommand + " --resume --session-id " + id + " --mcp-config " + mcpConfigPath
+		if err := m.tmux.SendKeysOnce(s.TmuxSession, claudeCmd); err != nil {
+			return fmt.Errorf("launch claude: %w", err)
+		}
+	}
+
+	_, err = m.db.Exec("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", string(StatusWorking), time.Now(), id)
 	return err
 }

--- a/internal/session/mcp_config.go
+++ b/internal/session/mcp_config.go
@@ -1,0 +1,68 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/myuon/agmux/internal/db"
+)
+
+type mcpConfig struct {
+	McpServers map[string]mcpServerEntry `json:"mcpServers"`
+}
+
+type mcpServerEntry struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// writeMCPConfig generates a temporary MCP config JSON file for a session.
+// Returns the path to the config file.
+func writeMCPConfig(sessionID string, apiPort int) (string, error) {
+	dir, err := db.AgmuxDir()
+	if err != nil {
+		return "", err
+	}
+	mcpDir := filepath.Join(dir, "mcp-configs")
+	if err := os.MkdirAll(mcpDir, 0o755); err != nil {
+		return "", fmt.Errorf("create mcp-configs dir: %w", err)
+	}
+
+	agmuxPath, err := exec.LookPath("agmux")
+	if err != nil {
+		// Fallback to "agmux" if not found in PATH
+		agmuxPath = "agmux"
+	}
+
+	cfg := mcpConfig{
+		McpServers: map[string]mcpServerEntry{
+			"agmux": {
+				Command: agmuxPath,
+				Args:    []string{"mcp"},
+				Env: map[string]string{
+					"AGMUX_SESSION_ID": sessionID,
+					"AGMUX_API_URL":    fmt.Sprintf("http://localhost:%d", apiPort),
+				},
+			},
+		},
+	}
+
+	path := filepath.Join(mcpDir, sessionID+".json")
+	f, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("create mcp config file: %w", err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(cfg); err != nil {
+		return "", fmt.Errorf("encode mcp config: %w", err)
+	}
+
+	return path, nil
+}

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -34,6 +34,8 @@ type Session struct {
 	Status        Status      `json:"status"`
 	Type          SessionType `json:"type"`
 	OutputMode    OutputMode  `json:"outputMode"`
+	CurrentTask   string      `json:"currentTask,omitempty"`
+	Goal          string      `json:"goal,omitempty"`
 	CreatedAt     time.Time   `json:"createdAt"`
 	UpdatedAt     time.Time   `json:"updatedAt"`
 }

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -30,7 +30,7 @@ type StreamProcess struct {
 // StartStreamProcess starts a claude CLI subprocess in stream-json mode.
 // If resume is true, it uses --resume to continue an existing conversation;
 // otherwise it uses --session-id to start a new one.
-func StartStreamProcess(sessionID, projectPath string, resume bool) (*StreamProcess, error) {
+func StartStreamProcess(sessionID, projectPath, mcpConfigPath string, resume bool) (*StreamProcess, error) {
 	streamsDir, err := db.StreamsDir()
 	if err != nil {
 		return nil, fmt.Errorf("get streams dir: %w", err)
@@ -53,6 +53,9 @@ func StartStreamProcess(sessionID, projectPath string, resume bool) (*StreamProc
 		"--input-format", "stream-json",
 		sessionFlag, sessionID,
 		"--dangerously-skip-permissions",
+	}
+	if mcpConfigPath != "" {
+		args = append(args, "--mcp-config", mcpConfigPath)
 	}
 	cmd := exec.Command("claude", args...)
 	cmd.Dir = projectPath

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "skills": {
+    "agent-browser": {
+      "source": "vercel-labs/agent-browser",
+      "sourceType": "github",
+      "computedHash": "57bfa07d34f966bccf791d49c9b6ce507fbba08f7dbf9e2ad15809e2dd29041e"
+    },
     "commit": {
       "source": "myuon/agent-skills",
       "sourceType": "github",


### PR DESCRIPTION
## Summary
- セッションに `currentTask` / `goal` メタデータを追加し、一覧・詳細画面に表示
- MCP serverサブコマンド (`agmux mcp`) を追加し、セッション起動時に `--mcp-config` で自動注入
- 既存セッション向けに Reconnect ボタンを追加（MCP設定を再注入して `--resume` で再起動）
- Makefile の `restart` ターゲットで `pkill` → `lsof` ベースに修正

## Test plan
- [ ] 新規セッション作成時にMCPツール (`set_session_context`) が利用可能か確認
- [ ] `set_session_context` 呼び出し後、管理画面にTask/Goalが表示されるか確認
- [ ] 既存セッションでReconnectボタン押下後、MCPツールが利用可能になるか確認
- [ ] `make restart` が正常に動作するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)