### PR TITLE
fix: stream modeセッションの/output 500エラーを修正

### DIFF
--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -268,14 +268,24 @@ export function SessionDetail() {
 
   useEffect(() => {
     if (!sessionId) return;
-    api.getSession(sessionId).then(setSession);
-    api.getSessionOutput(sessionId).then((r) => setOutput(r.output));
-    api.getStreamOutput(sessionId).then(setStreamLines).catch(() => {});
+    api.getSession(sessionId).then((s) => {
+      setSession(s);
+      if (s.outputMode === "stream") {
+        api.getStreamOutput(sessionId).then(setStreamLines).catch(() => {});
+      } else {
+        api.getSessionOutput(sessionId).then((r) => setOutput(r.output));
+      }
+    });
 
     const interval = setInterval(() => {
-      api.getSession(sessionId).then(setSession);
-      api.getSessionOutput(sessionId).then((r) => setOutput(r.output));
-      api.getStreamOutput(sessionId).then(setStreamLines).catch(() => {});
+      api.getSession(sessionId).then((s) => {
+        setSession(s);
+        if (s.outputMode === "stream") {
+          api.getStreamOutput(sessionId).then(setStreamLines).catch(() => {});
+        } else {
+          api.getSessionOutput(sessionId).then((r) => setOutput(r.output));
+        }
+      });
     }, 3000);
     return () => clearInterval(interval);
   }, [sessionId]);

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -320,6 +320,9 @@ func (m *Manager) CaptureOutput(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if s.OutputMode == OutputModeStream {
+		return "", nil
+	}
 	return m.tmux.CapturePane(s.TmuxSession, 200)
 }
 


### PR DESCRIPTION
## Summary
- stream modeセッションで `GET /api/sessions/{id}/output` が500エラーを返す問題を修正
- バックエンド: `CaptureOutput` でstream modeの場合はtmux capture-paneを呼ばず空文字を返す
- フロントエンド: `outputMode` に応じて `/output` か `/stream` の一方だけをポーリング

Closes #60

## Test plan
- [ ] stream modeセッションの詳細画面で500エラーが出ないことを確認
- [ ] terminal modeセッションの出力表示が引き続き正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)