### PR TITLE
feat: セッション起動時にsystem promptでコンテキスト更新を指示

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -76,7 +76,7 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 	} else {
 		// Terminal mode: launch claude TUI in tmux
 		time.Sleep(300 * time.Millisecond)
-		claudeCmd := m.claudeCommand + " --session-id " + id + " --mcp-config " + mcpConfigPath
+		claudeCmd := m.claudeCommand + " --session-id " + id + " --mcp-config " + mcpConfigPath + " --append-system-prompt " + shellQuote(agmuxSystemPrompt)
 		if err := m.tmux.SendKeysOnce(tmuxSession, claudeCmd); err != nil {
 			return nil, fmt.Errorf("launch claude: %w", err)
 		}
@@ -423,7 +423,7 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 	}
 
 	time.Sleep(300 * time.Millisecond)
-	claudeCmd := m.claudeCommand + " --session-id " + id + " --mcp-config " + mcpConfigPath
+	claudeCmd := m.claudeCommand + " --session-id " + id + " --mcp-config " + mcpConfigPath + " --append-system-prompt " + shellQuote(agmuxSystemPrompt)
 	if err := m.tmux.SendKeysOnce(tmuxSession, claudeCmd); err != nil {
 		return nil, fmt.Errorf("launch claude for controller: %w", err)
 	}
@@ -502,7 +502,7 @@ func (m *Manager) Reconnect(id string) error {
 		m.streamMu.Unlock()
 	} else {
 		time.Sleep(300 * time.Millisecond)
-		claudeCmd := m.claudeCommand + " --resume --session-id " + id + " --mcp-config " + mcpConfigPath
+		claudeCmd := m.claudeCommand + " --resume --session-id " + id + " --mcp-config " + mcpConfigPath + " --append-system-prompt " + shellQuote(agmuxSystemPrompt)
 		if err := m.tmux.SendKeysOnce(s.TmuxSession, claudeCmd); err != nil {
 			return fmt.Errorf("launch claude: %w", err)
 		}

--- a/internal/session/mcp_config.go
+++ b/internal/session/mcp_config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/myuon/agmux/internal/db"
 )
@@ -18,6 +19,15 @@ type mcpServerEntry struct {
 	Command string            `json:"command"`
 	Args    []string          `json:"args"`
 	Env     map[string]string `json:"env,omitempty"`
+}
+
+const agmuxSystemPrompt = `あなたはagmuxで管理されているセッションです。以下のルールを守ってください:
+- 新しいタスクに着手するとき、set_session_context ツールで currentTask と goal を設定してください
+- タスクの内容や目標が変わったら、その都度 set_session_context を呼び出して更新してください
+- タスクが完了したら、set_session_context で完了状態を反映してください`
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
 // writeMCPConfig generates a temporary MCP config JSON file for a session.

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -57,6 +57,7 @@ func StartStreamProcess(sessionID, projectPath, mcpConfigPath string, resume boo
 	if mcpConfigPath != "" {
 		args = append(args, "--mcp-config", mcpConfigPath)
 	}
+	args = append(args, "--append-system-prompt", agmuxSystemPrompt)
 	cmd := exec.Command("claude", args...)
 	cmd.Dir = projectPath
 	// Filter out CLAUDECODE env var to avoid nested session detection


### PR DESCRIPTION
## Summary
- `--append-system-prompt` で `set_session_context` の利用ルールをClaude起動時に注入
- terminal mode / stream mode / reconnect の全経路で適用
- Claudeがタスク着手・変更・完了時に自発的にコンテキストを更新するよう促す

## Test plan
- [ ] 新規セッション作成後、Claudeが自発的に `set_session_context` を呼ぶことを確認
- [ ] reconnect後も同様に指示が注入されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)