### PR TITLE
feat: ゴールのネスト（スタック）対応 (#71)

### DIFF
--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -419,6 +419,17 @@ export function SessionDetail() {
 
       {(session.currentTask || session.goal) && (
         <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-3 mb-4">
+          {session.goals && session.goals.length > 1 && (
+            <div className="text-xs text-indigo-400 mb-2">
+              {session.goals.slice(0, -1).map((g, i) => (
+                <span key={i}>
+                  {i > 0 && " > "}
+                  {g.goal}
+                </span>
+              ))}
+              {" > "}
+            </div>
+          )}
           {session.currentTask && (
             <p className="text-sm text-indigo-800">
               <span className="font-semibold">Task:</span> {session.currentTask}

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -9,6 +9,7 @@ export interface Session {
   outputMode: "terminal" | "stream";
   currentTask?: string;
   goal?: string;
+  goals?: { currentTask: string; goal: string }[];
   createdAt: string;
   updatedAt: string;
   githubUrl?: string;

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -110,6 +110,12 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: add goals (JSON array) column if missing
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN goals TEXT NOT NULL DEFAULT '[]'`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	// Migration: update old status values to new ones
 	_, err = db.Exec(`UPDATE sessions SET status = 'working' WHERE status IN ('running', 'waiting', 'error')`)
 	if err != nil {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -81,8 +81,8 @@ func (s *Server) handleMethod(method string, params json.RawMessage) (interface{
 		return map[string]interface{}{
 			"tools": []interface{}{
 				map[string]interface{}{
-					"name":        "set_session_context",
-					"description": "agmuxの管理画面に表示される、現在のセッションの「今取り組んでいるタスク」と「完了条件(Goal)」を設定します。新しいタスクに着手したときや、Goalが変わったときに呼んでください。",
+					"name":        "create_goal",
+					"description": "agmuxの管理画面に表示されるゴールを設定します。新しいタスクに着手するときに呼んでください。subgoal=trueにすると現在のゴールを保持したままサブゴールを積めます。",
 					"inputSchema": map[string]interface{}{
 						"type": "object",
 						"properties": map[string]interface{}{
@@ -94,8 +94,21 @@ func (s *Server) handleMethod(method string, params json.RawMessage) (interface{
 								"type":        "string",
 								"description": "この作業の完了条件（例: 「メールとパスワードのバリデーションが動作しテストが通る」）",
 							},
+							"subgoal": map[string]interface{}{
+								"type":        "boolean",
+								"description": "trueにすると現在のゴールを保持しサブゴールとしてスタックに積む。falseまたは省略で現在のゴールを上書き。",
+								"default":     false,
+							},
 						},
 						"required": []string{"currentTask", "goal"},
+					},
+				},
+				map[string]interface{}{
+					"name":        "complete_goal",
+					"description": "現在のゴールを達成済みとしてポップします。親ゴールがあればそれがアクティブになります。",
+					"inputSchema": map[string]interface{}{
+						"type":       "object",
+						"properties": map[string]interface{}{},
 					},
 				},
 			},
@@ -117,23 +130,107 @@ func (s *Server) handleMethod(method string, params json.RawMessage) (interface{
 }
 
 func (s *Server) callTool(name string, args json.RawMessage) (interface{}, *jsonRPCError) {
-	if name != "set_session_context" {
+	switch name {
+	case "create_goal":
+		return s.handleCreateGoal(args)
+	case "complete_goal":
+		return s.handleCompleteGoal()
+	case "set_session_context":
+		// Backward compatibility
+		return s.handleCreateGoal(args)
+	default:
 		return nil, &jsonRPCError{Code: -32602, Message: "unknown tool: " + name}
 	}
+}
 
+func (s *Server) handleCreateGoal(args json.RawMessage) (interface{}, *jsonRPCError) {
 	var input struct {
 		CurrentTask string `json:"currentTask"`
 		Goal        string `json:"goal"`
+		Subgoal     bool   `json:"subgoal"`
 	}
 	if err := json.Unmarshal(args, &input); err != nil {
 		return nil, &jsonRPCError{Code: -32602, Message: "invalid arguments"}
 	}
 
-	if err := s.updateContext(input.CurrentTask, input.Goal); err != nil {
+	if err := s.apiCreateGoal(input.CurrentTask, input.Goal, input.Subgoal); err != nil {
 		return toolResult(fmt.Sprintf("Error: %v", err), true), nil
 	}
 
-	return toolResult("Context updated successfully.", false), nil
+	msg := "Goal created successfully."
+	if input.Subgoal {
+		msg = "Subgoal created successfully."
+	}
+	return toolResult(msg, false), nil
+}
+
+func (s *Server) handleCompleteGoal() (interface{}, *jsonRPCError) {
+	parent, err := s.apiCompleteGoal()
+	if err != nil {
+		return toolResult(fmt.Sprintf("Error: %v", err), true), nil
+	}
+
+	if parent != "" {
+		return toolResult(fmt.Sprintf("Goal completed. Returning to parent goal: %s", parent), false), nil
+	}
+	return toolResult("Goal completed. No more goals in the stack.", false), nil
+}
+
+func (s *Server) apiCreateGoal(currentTask, goal string, subgoal bool) error {
+	url := fmt.Sprintf("%s/api/sessions/%s/goals", s.apiURL, s.sessionID)
+	body := fmt.Sprintf(`{"currentTask":%s,"goal":%s,"subgoal":%t}`,
+		jsonString(currentTask), jsonString(goal), subgoal)
+
+	req, err := http.NewRequest("POST", url, strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func (s *Server) apiCompleteGoal() (string, error) {
+	url := fmt.Sprintf("%s/api/sessions/%s/goals/complete", s.apiURL, s.sessionID)
+
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		ParentGoal *struct {
+			Goal string `json:"goal"`
+		} `json:"parentGoal"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", nil
+	}
+	if result.ParentGoal != nil {
+		return result.ParentGoal.Goal, nil
+	}
+	return "", nil
 }
 
 func (s *Server) updateContext(currentTask, goal string) error {
@@ -180,10 +277,10 @@ func toolResult(text string, isError bool) interface{} {
 // JSON-RPC types
 
 type jsonRPCRequest struct {
-	JSONRPC string          `json:"jsonrpc"`
+	JSONRPC string           `json:"jsonrpc"`
 	ID      *json.RawMessage `json:"id,omitempty"`
-	Method  string          `json:"method"`
-	Params  json.RawMessage `json:"params,omitempty"`
+	Method  string           `json:"method"`
+	Params  json.RawMessage  `json:"params,omitempty"`
 }
 
 type jsonRPCResponse struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -68,6 +68,8 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/stop", s.stopSession)
 		r.Post("/sessions/{id}/send", s.sendToSession)
 		r.Put("/sessions/{id}/context", s.updateSessionContext)
+		r.Post("/sessions/{id}/goals", s.createGoal)
+		r.Post("/sessions/{id}/goals/complete", s.completeGoal)
 		r.Post("/sessions/{id}/reconnect", s.reconnectSession)
 		r.Get("/sessions/{id}/output", s.getSessionOutput)
 		r.Get("/sessions/{id}/stream", s.getSessionStream)
@@ -239,6 +241,40 @@ func (s *Server) updateSessionContext(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+type createGoalRequest struct {
+	CurrentTask string `json:"currentTask"`
+	Goal        string `json:"goal"`
+	Subgoal     bool   `json:"subgoal"`
+}
+
+func (s *Server) createGoal(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req createGoalRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := s.sessions.CreateGoal(id, req.CurrentTask, req.Goal, req.Subgoal); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) completeGoal(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	parent, err := s.sessions.CompleteGoal(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	result := map[string]interface{}{"status": "ok"}
+	if parent != nil {
+		result["parentGoal"] = parent
+	}
+	writeJSON(w, http.StatusOK, result)
 }
 
 func (s *Server) reconnectSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -121,7 +121,7 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 
 func (m *Manager) List() ([]Session, error) {
 	rows, err := m.db.Query(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, goals, created_at, updated_at
 		 FROM sessions ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -135,8 +135,8 @@ func (m *Manager) List() ([]Session, error) {
 		var status string
 		var sessionType string
 		var outputMode string
-		var prompt, currentTask, goal sql.NullString
-		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		var prompt, currentTask, goal, goalsJSON sql.NullString
+		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		s.Status = Status(status)
@@ -150,6 +150,9 @@ func (m *Manager) List() ([]Session, error) {
 		}
 		if goal.Valid {
 			s.Goal = goal.String
+		}
+		if goalsJSON.Valid {
+			s.Goals = ParseGoalStack(goalsJSON.String)
 		}
 
 		// Correct status based on tmux reality
@@ -170,11 +173,11 @@ func (m *Manager) Get(id string) (*Session, error) {
 	var status string
 	var sessionType string
 	var outputMode string
-	var prompt, currentTask, goal sql.NullString
+	var prompt, currentTask, goal, goalsJSON sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, goals, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id,
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
@@ -192,6 +195,9 @@ func (m *Manager) Get(id string) (*Session, error) {
 	}
 	if goal.Valid {
 		s.Goal = goal.String
+	}
+	if goalsJSON.Valid {
+		s.Goals = ParseGoalStack(goalsJSON.String)
 	}
 	return &s, nil
 }
@@ -366,11 +372,11 @@ func (m *Manager) GetController() (*Session, error) {
 	var status string
 	var sessionType string
 	var outputMode string
-	var prompt, currentTask, goal sql.NullString
+	var prompt, currentTask, goal, goalsJSON sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, goals, created_at, updated_at
 		 FROM sessions WHERE type = ? LIMIT 1`, string(TypeController),
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -388,6 +394,9 @@ func (m *Manager) GetController() (*Session, error) {
 	}
 	if goal.Valid {
 		s.Goal = goal.String
+	}
+	if goalsJSON.Valid {
+		s.Goals = ParseGoalStack(goalsJSON.String)
 	}
 	return &s, nil
 }
@@ -462,6 +471,54 @@ func (m *Manager) UpdateStatus(id string, status Status) error {
 func (m *Manager) UpdateContext(id string, currentTask, goal string) error {
 	_, err := m.db.Exec("UPDATE sessions SET current_task = ?, goal = ?, updated_at = ? WHERE id = ?", currentTask, goal, time.Now(), id)
 	return err
+}
+
+func (m *Manager) CreateGoal(id string, currentTask, goal string, subgoal bool) error {
+	s, err := m.Get(id)
+	if err != nil {
+		return err
+	}
+
+	var newGoals GoalStack
+	if subgoal {
+		newGoals = s.Goals.Push(GoalEntry{CurrentTask: currentTask, Goal: goal})
+	} else {
+		newGoals = GoalStack{GoalEntry{CurrentTask: currentTask, Goal: goal}}
+	}
+
+	_, err = m.db.Exec(
+		"UPDATE sessions SET current_task = ?, goal = ?, goals = ?, updated_at = ? WHERE id = ?",
+		currentTask, goal, newGoals.ToJSON(), time.Now(), id,
+	)
+	return err
+}
+
+func (m *Manager) CompleteGoal(id string) (*GoalEntry, error) {
+	s, err := m.Get(id)
+	if err != nil {
+		return nil, err
+	}
+
+	newGoals := s.Goals.Pop()
+
+	var currentTask, goal string
+	if top := newGoals.Top(); top != nil {
+		currentTask = top.CurrentTask
+		goal = top.Goal
+	}
+
+	_, err = m.db.Exec(
+		"UPDATE sessions SET current_task = ?, goal = ?, goals = ?, updated_at = ? WHERE id = ?",
+		currentTask, goal, newGoals.ToJSON(), time.Now(), id,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if top := newGoals.Top(); top != nil {
+		return top, nil
+	}
+	return nil, nil
 }
 
 // Reconnect restarts the Claude process for an existing session,

--- a/internal/session/mcp_config.go
+++ b/internal/session/mcp_config.go
@@ -22,9 +22,11 @@ type mcpServerEntry struct {
 }
 
 const agmuxSystemPrompt = `あなたはagmuxで管理されているセッションです。以下のルールを守ってください:
-- 新しいタスクに着手するとき、set_session_context ツールで currentTask と goal を設定してください
-- タスクの内容や目標が変わったら、その都度 set_session_context を呼び出して更新してください
-- タスクが完了したら、set_session_context で完了状態を反映してください`
+- 新しいタスクに着手するとき、create_goal ツールで currentTask と goal を設定してください
+- タスクの内容や目標が変わったら、その都度 create_goal を呼び出して更新してください
+- タスクが完了したら、complete_goal で完了状態を反映してください
+- サブタスクが発生した場合は create_goal の subgoal=true で親ゴールを保持したままサブゴールを設定してください
+- サブタスクが完了したら complete_goal でポップし、親ゴールに戻ってください`
 
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -1,6 +1,9 @@
 package session
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type Status string
 
@@ -38,6 +41,51 @@ type Session struct {
 	OutputMode    OutputMode  `json:"outputMode"`
 	CurrentTask   string      `json:"currentTask,omitempty"`
 	Goal          string      `json:"goal,omitempty"`
+	Goals         GoalStack   `json:"goals,omitempty"`
 	CreatedAt     time.Time   `json:"createdAt"`
 	UpdatedAt     time.Time   `json:"updatedAt"`
+}
+
+type GoalEntry struct {
+	CurrentTask string `json:"currentTask"`
+	Goal        string `json:"goal"`
+}
+
+type GoalStack []GoalEntry
+
+func (gs GoalStack) Top() *GoalEntry {
+	if len(gs) == 0 {
+		return nil
+	}
+	return &gs[len(gs)-1]
+}
+
+func (gs GoalStack) Push(entry GoalEntry) GoalStack {
+	return append(gs, entry)
+}
+
+func (gs GoalStack) Pop() GoalStack {
+	if len(gs) == 0 {
+		return gs
+	}
+	return gs[:len(gs)-1]
+}
+
+func (gs GoalStack) ToJSON() string {
+	if len(gs) == 0 {
+		return "[]"
+	}
+	b, _ := json.Marshal(gs)
+	return string(b)
+}
+
+func ParseGoalStack(s string) GoalStack {
+	if s == "" || s == "[]" {
+		return nil
+	}
+	var gs GoalStack
+	if err := json.Unmarshal([]byte(s), &gs); err != nil {
+		return nil
+	}
+	return gs
 }


### PR DESCRIPTION
## Summary
- ゴールをスタック構造で管理し、サブゴールのネストに対応
- MCPツールを `create_goal` / `complete_goal` に変更（`set_session_context` は後方互換で維持）
- `create_goal` に `subgoal` パラメータ追加（true=サブゴールとしてプッシュ、false=上書き）
- `complete_goal` でゴールをポップし親ゴールに復帰
- UIでネストされたゴールをパンくずリスト表示
- LLMステータス判定のフォールバック削除、CLAUDECODE環境変数除外修正も含む

## Test plan
- [ ] `create_goal` で新規ゴール設定（上書き）が動作する
- [ ] `create_goal` with `subgoal=true` でサブゴールがスタックに積まれる
- [ ] `complete_goal` でスタックがポップされ親ゴールに戻る
- [ ] UIでネストされたゴールがパンくずリスト表示される
- [ ] 後方互換: `set_session_context` が引き続き動作する

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)