### PR TITLE
fix: graceful shutdownでinflight HTTPリクエストの完了を待つ

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -5,7 +5,10 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 	"text/tabwriter"
+	"time"
 
 	agmux "github.com/myuon/agmux"
 	"github.com/myuon/agmux/internal/config"
@@ -129,7 +132,27 @@ func serveCmd() *cobra.Command {
 			addr := fmt.Sprintf(":%d", port)
 			logger.Info(fmt.Sprintf("Starting agmux on http://localhost:%d", port))
 			logger.Info(fmt.Sprintf("Config: check interval=%s", cfg.Daemon.Interval))
-			return srv.ListenAndServe(addr)
+
+			httpSrv := srv.NewHTTPServer(addr)
+
+			// Graceful shutdown on SIGTERM/SIGINT
+			shutdownCh := make(chan os.Signal, 1)
+			signal.Notify(shutdownCh, syscall.SIGTERM, syscall.SIGINT)
+
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- httpSrv.ListenAndServe()
+			}()
+
+			select {
+			case err := <-errCh:
+				return err
+			case sig := <-shutdownCh:
+				logger.Info(fmt.Sprintf("Received %s, shutting down gracefully...", sig))
+				shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer shutdownCancel()
+				return httpSrv.Shutdown(shutdownCtx)
+			}
 		},
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"io/fs"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
@@ -101,9 +100,11 @@ func (s *Server) Handler() http.Handler {
 	return s.router
 }
 
-func (s *Server) ListenAndServe(addr string) error {
-	log.Printf("Server listening on %s", addr)
-	return http.ListenAndServe(addr, s.router)
+func (s *Server) NewHTTPServer(addr string) *http.Server {
+	return &http.Server{
+		Addr:    addr,
+		Handler: s.router,
+	}
 }
 
 // API handlers


### PR DESCRIPTION
## Summary
- `make restart` 時にMCPツール呼び出し（`set_session_context` 等）がレスポンス前に切断される問題を修正
- SIGTERM/SIGINTをキャッチし、`http.Server.Shutdown()` で5秒タイムアウト付きgraceful shutdownを実装
- `server.ListenAndServe()` → `server.NewHTTPServer()` に変更し、呼び出し側でライフサイクルを制御

Closes #70

## Test plan
- [ ] `make restart` でサーバー再起動し、MCPツール呼び出し中にkillされてもレスポンスが返ることを確認
- [ ] 通常の起動・停止が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)