### PR TITLE
feat: セッションクリア機能を実装

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -63,6 +63,9 @@ export const api = {
   reconnectSession: (id: string) =>
     request<{ status: string }>(`/sessions/${id}/reconnect`, { method: "POST" }),
 
+  clearSession: (id: string) =>
+    request<{ status: string }>(`/sessions/${id}/clear`, { method: "POST" }),
+
   restartController: () =>
     request<Session>("/sessions/controller/restart", { method: "POST" }),
 

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -5,7 +5,7 @@ import remarkGfm from "remark-gfm";
 import {
   Square, RefreshCw, Trash2, ArrowLeft, GitBranch, GitPullRequest, FileDiff, X, FolderOpen,
   Terminal, FileText, FilePen, PenLine, Search, Sparkles, Globe, Wrench, CheckCircle2,
-  ListTodo, Target,
+  ListTodo, Target, RotateCcw,
 } from "lucide-react";
 import type { Session } from "../types/session";
 import { api, type DiffFile } from "../api/client";
@@ -734,6 +734,20 @@ export function SessionDetail() {
                 <Square className="w-3.5 h-3.5" />
               </button>
             )}
+            <button
+              onClick={async () => {
+                if (!confirm("Clear session context? This will start a fresh conversation.")) return;
+                await api.clearSession(session.id);
+                api.getSession(session.id).then(setSession);
+                if (session.outputMode === "stream") {
+                  api.getStreamOutput(session.id).then(setStreamLines).catch(() => {});
+                }
+              }}
+              className="p-1.5 text-orange-700 bg-orange-50 rounded hover:bg-orange-100"
+              title="Clear"
+            >
+              <RotateCcw className="w-3.5 h-3.5" />
+            </button>
             <button
               onClick={async () => {
                 await api.reconnectSession(session.id);

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -70,6 +70,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/goals", s.createGoal)
 		r.Post("/sessions/{id}/goals/complete", s.completeGoal)
 		r.Post("/sessions/{id}/reconnect", s.reconnectSession)
+		r.Post("/sessions/{id}/clear", s.clearSession)
 		r.Get("/sessions/{id}/output", s.getSessionOutput)
 		r.Get("/sessions/{id}/stream", s.getSessionStream)
 		r.Get("/sessions/{id}/diff", s.getSessionDiff)
@@ -287,6 +288,16 @@ func (s *Server) reconnectSession(w http.ResponseWriter, r *http.Request) {
 	}
 	s.recordSessionAction(id, "session_reconnect", "")
 	writeJSON(w, http.StatusOK, map[string]string{"status": "reconnected"})
+}
+
+func (s *Server) clearSession(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.sessions.Clear(id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.recordSessionAction(id, "session_clear", "")
+	writeJSON(w, http.StatusOK, map[string]string{"status": "cleared"})
 }
 
 func (s *Server) getSessionOutput(w http.ResponseWriter, r *http.Request) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -254,6 +254,65 @@ func (m *Manager) stopStreamProcess(id string) {
 	}
 }
 
+// Clear resets the session context by stopping the current process,
+// clearing the stream history, and restarting without --resume.
+func (m *Manager) Clear(id string) error {
+	s, err := m.Get(id)
+	if err != nil {
+		return err
+	}
+
+	// Stop existing stream process if any
+	m.stopStreamProcess(id)
+
+	// Kill existing tmux session
+	name := s.TmuxSession[len(tmux.SessionPrefix):]
+	if m.tmux.HasSession(name) {
+		_ = m.tmux.KillSession(name)
+	}
+
+	// Clear the JSONL stream file (truncate)
+	if s.OutputMode == OutputModeStream {
+		streamsDir, err := db.StreamsDir()
+		if err == nil {
+			streamPath := filepath.Join(streamsDir, id+".jsonl")
+			_ = os.Truncate(streamPath, 0)
+		}
+	}
+
+	// Generate fresh MCP config
+	mcpConfigPath, err := writeMCPConfig(id, m.apiPort)
+	if err != nil {
+		return fmt.Errorf("write mcp config: %w", err)
+	}
+
+	// Recreate tmux session
+	if err := m.tmux.NewSession(name, s.ProjectPath, ""); err != nil {
+		return fmt.Errorf("create tmux session: %w", err)
+	}
+
+	if s.OutputMode == OutputModeStream {
+		// Start fresh (no resume)
+		sp, err := StartStreamProcess(id, s.ProjectPath, mcpConfigPath, false)
+		if err != nil {
+			return fmt.Errorf("start stream process: %w", err)
+		}
+		m.streamMu.Lock()
+		m.streamProcesses[id] = sp
+		m.streamMu.Unlock()
+	} else {
+		time.Sleep(300 * time.Millisecond)
+		claudeCmd := m.claudeCommand + " --session-id " + id + " --mcp-config " + mcpConfigPath + " --append-system-prompt " + shellQuote(agmuxSystemPrompt)
+		if err := m.tmux.SendKeysOnce(s.TmuxSession, claudeCmd); err != nil {
+			return fmt.Errorf("launch claude: %w", err)
+		}
+	}
+
+	// Reset task/goal and set status to working
+	_, err = m.db.Exec("UPDATE sessions SET status = ?, current_task = NULL, goal = NULL, goals = NULL, updated_at = ? WHERE id = ?", string(StatusWorking), time.Now(), id)
+	return err
+}
+
 func (m *Manager) SendKeys(id string, text string) error {
 	s, err := m.Get(id)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `Manager.Clear()` メソッド追加: プロセス停止 → JSONLファイルクリア → `--resume`なしで再起動
- `POST /api/sessions/{id}/clear` エンドポイント追加
- フロントエンドのセッション詳細画面にクリアボタン（RotateCcw アイコン）追加
- クリア時に `current_task` / `goal` / `goals` もリセット

## Test plan

- [ ] Stream modeセッションでクリアボタンを押し、新しいコンテキストで会話が始まることを確認
- [ ] クリア後にストリーム出力がリセットされることを確認
- [ ] Task/Goalがリセットされることを確認

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)