### PR TITLE
fix: stream modeセッションがtmux不在で誤ってstoppedになるバグを修正

### DIFF
--- a/internal/monitor/checker.go
+++ b/internal/monitor/checker.go
@@ -80,8 +80,8 @@ func (sc *StatusChecker) check() {
 
 		shortID := s.ID[:8]
 
-		// Check if tmux session still exists
-		if !sc.tmux.HasSessionByFullName(s.TmuxSession) {
+		// Check if tmux session still exists (only for non-stream modes)
+		if s.OutputMode != session.OutputModeStream && !sc.tmux.HasSessionByFullName(s.TmuxSession) {
 			if s.Status != session.StatusStopped {
 				sc.logger.Info(fmt.Sprintf("%s (%s): tmux session gone, %s → stopped",
 					s.Name, shortID, s.Status),


### PR DESCRIPTION
## Summary

- stream modeセッションのステータスチェックで、tmuxセッション不在時に誤って`stopped`に変更されるバグを修正
- stream modeはtmuxではなく直接プロセスで動作するため、tmux存在チェックをスキップ

## 原因

`make restart` やサーバー再起動でtmuxセッションが消えると、モニターのステータスチェッカーがstream modeセッションも含めてtmux不在→`stopped`に変更していた。一度`stopped`になるとチェッカーはスキップするため、復帰しなかった。

## Test plan

- [x] `make test` パス
- [x] `make restart` 後にstream modeセッションがstoppedにならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)