### PR TITLE
fix: stream modeセッションがList()のtmuxチェックでstoppedになるバグを修正

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -155,11 +155,13 @@ func (m *Manager) List() ([]Session, error) {
 			s.Goals = ParseGoalStack(goalsJSON.String)
 		}
 
-		// Correct status based on tmux reality
-		if s.Status == StatusWorking || s.Status == StatusQuestionWaiting || s.Status == StatusIdle {
-			if !m.tmux.HasSessionByFullName(s.TmuxSession) {
-				s.Status = StatusStopped
-				m.db.Exec("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", string(StatusStopped), time.Now(), s.ID)
+		// Correct status based on tmux reality (only for non-stream modes)
+		if s.OutputMode != OutputModeStream {
+			if s.Status == StatusWorking || s.Status == StatusQuestionWaiting || s.Status == StatusIdle {
+				if !m.tmux.HasSessionByFullName(s.TmuxSession) {
+					s.Status = StatusStopped
+					m.db.Exec("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", string(StatusStopped), time.Now(), s.ID)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

- `manager.go` の `List()` 内にあるtmux存在チェック補正が、stream modeセッションにも適用されていた
- フロントの3秒ポーリングで `getSession` が呼ばれるたびに `List()` → tmux不在 → `stopped` に上書きされていた
- stream modeではtmuxを使わないため、この補正をスキップするように修正

## 原因

#81 の修正はchecker.goのみだったが、真犯人は `manager.go:158-163` の `List()` 内の tmux 補正ロジックだった。APIリクエストのたびに実行されるため、送信でworkingに戻しても即座にstoppedに上書きされていた。

## Test plan

- [x] `make test` パス
- [x] `make restart` 後にstream modeセッションがstoppedにならないことを確認
- [x] DBを手動でworkingに変更後、5秒経ってもworkingのままであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)