### PR TITLE
fix: ステータスチェッカーの冗長なログを削除

### DIFF
--- a/internal/monitor/checker.go
+++ b/internal/monitor/checker.go
@@ -148,31 +148,8 @@ func (sc *StatusChecker) check() {
 					s.Status = session.StatusWorking
 				}
 			}
-		} else {
-			sc.logger.Info(fmt.Sprintf("[%s] %s (%s): %s (%s)",
-				s.OutputMode, s.Name, shortID,
-				s.Status, result.Reason),
-				slog.String("category", "status_checker"),
-				slog.String("sessionId", s.ID),
-			)
 		}
 	}
-
-	// Log summary
-	counts := map[session.Status]int{}
-	for _, s := range sessions {
-		counts[s.Status]++
-	}
-	sc.logger.Info(fmt.Sprintf("checked %d sessions: %d working, %d idle, %d paused, %d question, %d alignment, %d stopped",
-		len(sessions),
-		counts[session.StatusWorking],
-		counts[session.StatusIdle],
-		counts[session.StatusPaused],
-		counts[session.StatusQuestionWaiting],
-		counts[session.StatusAlignmentNeeded],
-		counts[session.StatusStopped]),
-		slog.String("category", "status_checker"),
-	)
 
 	if changed && sc.onUpdate != nil {
 		sc.onUpdate(sessions)


### PR DESCRIPTION
## Summary

- 変化がないセッションの個別ログ（`idle (no change)` 等）を削除
- 30秒ごとのサマリーログ（`checked 4 sessions: ...`）を削除
- ステータスが変わった時のみログを出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)