### PR TITLE
fix: セッション画面でメッセージが重複して読み込まれるバグを修正

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -52,7 +52,7 @@ export const api = {
     request<LogEntry[]>(`/logs?limit=${limit}`),
 
   getStreamOutput: (id: string, limit = 200) =>
-    request<unknown[]>(`/sessions/${id}/stream?limit=${limit}`),
+    request<{ lines: unknown[]; total: number }>(`/sessions/${id}/stream?limit=${limit}`),
 
   getStreamOutputDelta: (id: string, after: number) =>
     request<{ lines: unknown[]; total: number }>(`/sessions/${id}/stream?after=${after}`),

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -821,9 +821,9 @@ export function SessionDetail() {
     api.getSession(sessionId).then((s) => {
       setSession(s);
       if (s.outputMode === "stream") {
-        api.getStreamOutput(sessionId).then((lines) => {
-          setStreamLines(lines);
-          streamCursorRef.current = lines.length;
+        api.getStreamOutput(sessionId).then((resp) => {
+          setStreamLines(resp.lines);
+          streamCursorRef.current = resp.total;
         }).catch(() => {});
       } else {
         api.getSessionOutput(sessionId).then((r) => setOutput(r.output));
@@ -846,9 +846,9 @@ export function SessionDetail() {
             }).catch(() => {});
           } else {
             // Fallback to full fetch if cursor not initialized
-            api.getStreamOutput(sessionId).then((lines) => {
-              setStreamLines(lines);
-              streamCursorRef.current = lines.length;
+            api.getStreamOutput(sessionId).then((resp) => {
+              setStreamLines(resp.lines);
+              streamCursorRef.current = resp.total;
             }).catch(() => {});
           }
         } else {
@@ -876,9 +876,9 @@ export function SessionDetail() {
             streamCursorRef.current = resp.total;
           }).catch(() => {});
         } else {
-          api.getStreamOutput(sessionId).then((lines) => {
-            setStreamLines(lines);
-            streamCursorRef.current = lines.length;
+          api.getStreamOutput(sessionId).then((resp) => {
+            setStreamLines(resp.lines);
+            streamCursorRef.current = resp.total;
           }).catch(() => {});
         }
       } else {
@@ -943,7 +943,10 @@ export function SessionDetail() {
                 await api.clearSession(session.id);
                 api.getSession(session.id).then(setSession);
                 if (session.outputMode === "stream") {
-                  api.getStreamOutput(session.id).then(setStreamLines).catch(() => {});
+                  api.getStreamOutput(session.id).then((resp) => {
+                    setStreamLines(resp.lines);
+                    streamCursorRef.current = resp.total;
+                  }).catch(() => {});
                 }
               }}
               className="p-1.5 text-orange-700 bg-orange-50 rounded hover:bg-orange-100"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -348,7 +348,7 @@ func (s *Server) getSessionStream(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	lines, err := s.sessions.GetStreamLines(id, limit)
+	lines, total, err := s.sessions.GetStreamLines(id, limit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -362,7 +362,10 @@ func (s *Server) getSessionStream(w http.ResponseWriter, r *http.Request) {
 		result = []json.RawMessage{}
 	}
 
-	writeJSON(w, http.StatusOK, result)
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"lines": result,
+		"total": total,
+	})
 }
 
 func (s *Server) getLogs(w http.ResponseWriter, r *http.Request) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -428,17 +428,27 @@ func (m *Manager) SendKeys(id string, text string) error {
 
 // GetStreamLines returns the last N lines from the stream process memory,
 // falling back to file if no active process (e.g. after server restart).
-func (m *Manager) GetStreamLines(id string, limit int) ([]string, error) {
+// Also returns the total line count so callers can use it as a cursor for delta fetches.
+func (m *Manager) GetStreamLines(id string, limit int) ([]string, int, error) {
 	m.streamMu.Lock()
 	sp, ok := m.streamProcesses[id]
 	m.streamMu.Unlock()
 
 	if ok {
-		return sp.GetLines(limit), nil
+		total := sp.TotalLines()
+		return sp.GetLines(limit), total, nil
 	}
 
-	// Fallback: read from file
-	return m.readStreamFile(id, limit)
+	// Fallback: read all lines from file, then truncate to limit
+	allLines, err := m.readStreamFile(id, 0)
+	if err != nil {
+		return nil, 0, err
+	}
+	total := len(allLines)
+	if limit > 0 && len(allLines) > limit {
+		allLines = allLines[len(allLines)-limit:]
+	}
+	return allLines, total, nil
 }
 
 func (m *Manager) readStreamFile(id string, limit int) ([]string, error) {


### PR DESCRIPTION
## Summary
- ストリーム出力の初回ロード時、`limit`付きで取得した行数をカーソルとして使用していたが、実際の総行数と一致しないためデルタフェッチで既読メッセージが再取得され重複していた
- バックエンドの`GetStreamLines`を変更し、返却行数だけでなく総行数(`total`)も返すようにした
- フロントエンドで`total`をカーソルとして使用することで、デルタフェッチが正しいオフセットから取得するよう修正

## Test plan
- [ ] セッション画面を開いたまま放置し、メッセージが重複しないことを確認
- [ ] 200行以上のストリーム出力があるセッションで初回ロード後にポーリングが正しく動作することを確認
- [ ] セッションクリア後にストリーム出力が正しくリセットされることを確認
- [ ] `go test ./internal/...` が通ることを確認

Closes #96

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>