### PR TITLE
feat: セッション閲覧中はそのセッションの通知を抑制する

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { LogPanel } from "./components/LogPanel";
 import { SessionList } from "./components/SessionList";
 import { ConfigPage } from "./components/ConfigPage";
 import { useWebSocket } from "./hooks/useWebSocket";
+import { getActiveSessionName } from "./activeSession";
 
 // Register service worker for mobile notifications
 if ("serviceWorker" in navigator) {
@@ -48,6 +49,8 @@ function useGlobalNotifications() {
       const saved = localStorage.getItem("agmux-notify-statuses");
       const statusFilters = saved ? JSON.parse(saved) as Record<string, boolean> : defaultStatuses;
       if (!(statusFilters[data.status] ?? defaultStatuses[data.status] ?? true)) return;
+      // Suppress notification if the user is currently viewing this session
+      if (data.sessionName === getActiveSessionName()) return;
       sendNotification("agmux", `${data.sessionName}: ${data.summary}`);
     }
   }, []);

--- a/frontend/src/activeSession.ts
+++ b/frontend/src/activeSession.ts
@@ -1,0 +1,11 @@
+// Global ref to track the currently viewed session name.
+// Used to suppress notifications for the session the user is actively viewing.
+let activeSessionName: string | null = null;
+
+export function setActiveSessionName(name: string | null) {
+  activeSessionName = name;
+}
+
+export function getActiveSessionName(): string | null {
+  return activeSessionName;
+}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -10,6 +10,7 @@ import {
 import type { Session } from "../types/session";
 import { api, type DiffFile } from "../api/client";
 import { StatusDot } from "./StatusBadge";
+import { setActiveSessionName } from "../activeSession";
 
 const roleStyles: Record<string, { bg: string; label: string; text: string }> = {
   user: { bg: "bg-blue-50", label: "User", text: "text-blue-700" },
@@ -846,6 +847,13 @@ export function SessionDetail() {
   const terminal = useAutoScroll(output);
   const streamCursorRef = useRef<number | null>(null);
 
+  // Track active session name for notification suppression
+  useEffect(() => {
+    return () => {
+      setActiveSessionName(null);
+    };
+  }, []);
+
   useEffect(() => {
     if (!sessionId) return;
     // Reset cursor on session change
@@ -853,6 +861,7 @@ export function SessionDetail() {
 
     api.getSession(sessionId).then((s) => {
       setSession(s);
+      setActiveSessionName(s.name);
       if (s.outputMode === "stream") {
         api.getStreamOutput(sessionId).then((resp) => {
           setStreamLines(resp.lines);


### PR DESCRIPTION
## Summary
- セッション詳細ページを開いている間、そのセッションに関するブラウザ通知を抑制する
- グローバルなモジュール変数で現在閲覧中のセッション名を追跡し、`useGlobalNotifications` の通知ハンドラで一致するセッションの通知をスキップ
- フロントエンドのみの変更、サーバー側の変更なし

## Test plan
- [ ] セッション詳細ページを開いた状態で、そのセッションのステータスが変わっても通知が来ないことを確認
- [ ] 別のセッションの通知は引き続き表示されることを確認
- [ ] セッション詳細ページから離れた後は、再び通知が届くことを確認
- [ ] `make test` が通ることを確認済み
- [ ] TypeScript型チェック (`tsc --noEmit`) が通ることを確認済み

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>