### PR TITLE
feat: サーバーログを~/.agmux/server.logに記録する

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"os"
 	"os/signal"
@@ -76,8 +77,18 @@ func serveCmd() *cobra.Command {
 				return err
 			}
 
-			// Logger
-			logFile, logger, err := logging.Setup()
+			// Server log (HTTP requests, events, errors → ~/.agmux/server.log + stdout)
+			serverLogFile, serverLogWriter, err := logging.SetupServerLog()
+			if err != nil {
+				return fmt.Errorf("setup server log: %w", err)
+			}
+			defer serverLogFile.Close()
+
+			// Redirect standard log (used by chi middleware.Logger) to server log
+			log.SetOutput(serverLogWriter)
+
+			// Logger (slog → stderr + agmux.log + server.log)
+			logFile, logger, err := logging.Setup(serverLogFile)
 			if err != nil {
 				return fmt.Errorf("setup logging: %w", err)
 			}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -9,8 +9,9 @@ import (
 )
 
 // Setup initializes slog with JSON output to both stderr and a log file.
+// Additional writers can be provided to tee log output to extra destinations.
 // Returns the log file (caller should defer Close) and the logger.
-func Setup() (*os.File, *slog.Logger, error) {
+func Setup(extraWriters ...io.Writer) (*os.File, *slog.Logger, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, nil, err
@@ -27,7 +28,9 @@ func Setup() (*os.File, *slog.Logger, error) {
 		return nil, nil, err
 	}
 
-	writer := io.MultiWriter(os.Stderr, file)
+	writers := []io.Writer{os.Stderr, file}
+	writers = append(writers, extraWriters...)
+	writer := io.MultiWriter(writers...)
 	logger := slog.New(slog.NewJSONHandler(writer, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
@@ -42,6 +45,38 @@ func LogPath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, ".agmux", "agmux.log"), nil
+}
+
+// ServerLogPath returns the server log file path (~/.agmux/server.log).
+func ServerLogPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".agmux", "server.log"), nil
+}
+
+// SetupServerLog opens ~/.agmux/server.log for append and returns the file
+// and an io.Writer that tees to both os.Stdout and the file.
+// The caller should defer file.Close().
+func SetupServerLog() (*os.File, io.Writer, error) {
+	logPath, err := ServerLogPath()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dir := filepath.Dir(logPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, nil, err
+	}
+
+	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	writer := io.MultiWriter(os.Stdout, file)
+	return file, writer, nil
 }
 
 // LogAction logs an action entry with category:"action" to distinguish from general logs.


### PR DESCRIPTION
## Summary
- `agmux serve` 実行時にサーバーログを `~/.agmux/server.log` に記録するようにした
- chi の HTTP リクエストログ（`middleware.Logger`）を標準 `log` パッケージ経由で server.log + stdout に出力
- slog ベースのイベントログ・エラーログも server.log に追加出力（既存の stderr + agmux.log への出力は維持）
- セッションログ `agmux.log` とは別ファイルとして管理

## Test plan
- [x] `go test ./...` パス確認
- [x] `go build ./...` コンパイル確認
- [ ] `agmux serve` 起動後、`~/.agmux/server.log` にHTTPリクエストログとslogイベントが記録されることを確認

Closes #114

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>