### PR TITLE
fix: タスク開始のシステムイベント表示を削除

### DIFF
--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -96,12 +96,7 @@ function parseSystemEvent(entry: StreamEntry): StreamDisplayItem | null {
   }
 
   if (subtype === "task_started") {
-    const desc = (raw.description as string) || "バックグラウンドタスク";
-    return {
-      kind: "system_event",
-      eventType: "task_started",
-      label: `タスク開始: ${desc}`,
-    };
+    return null;
   }
 
   if (subtype === "init") {


### PR DESCRIPTION
## Summary
- `task_started` のシステムイベント表示を削除（`null` を返して非表示に）
- `task_completed` の表示はそのまま残す
- Agent ツールパネルに description が表示されるため冗長になったことが理由

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)