### PR TITLE
feat: slash commandの一覧をポップアップから選択可能にする

### DIFF
--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -5,7 +5,7 @@ import remarkGfm from "remark-gfm";
 import {
   Square, RefreshCw, Trash2, ArrowLeft, GitBranch, GitPullRequest, FileDiff, X, FolderOpen,
   Terminal, FileText, FilePen, PenLine, Search, Sparkles, Globe, Wrench, CheckCircle2,
-  ListTodo, Target, RotateCcw, Circle, Bot, ImagePlus, SendHorizonal, AlertTriangle,
+  ListTodo, Target, RotateCcw, Circle, Bot, ImagePlus, SendHorizonal, AlertTriangle, Plus, Slash,
 } from "lucide-react";
 import type { Session } from "../types/session";
 import { api, type DiffFile } from "../api/client";
@@ -994,6 +994,7 @@ export function SessionDetail() {
   const [pendingEscalationId, setPendingEscalationId] = useState<string | null>(null);
   const [slashCommands, setSlashCommands] = useState<string[]>([]);
   const [showSlashMenu, setShowSlashMenu] = useState(false);
+  const [showActionMenu, setShowActionMenu] = useState(false);
   const [slashFilter, setSlashFilter] = useState("");
   const [slashSelectedIndex, setSlashSelectedIndex] = useState(0);
   const terminal = useAutoScroll(output);
@@ -1169,7 +1170,75 @@ export function SessionDetail() {
           ))}
         </div>
       )}
-      <div className="flex gap-2">
+      <div className="flex gap-2 items-center">
+        {/* Left action menu */}
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setShowActionMenu((v) => !v)}
+            className="w-9 h-9 flex items-center justify-center text-gray-500 bg-gray-50 rounded-full hover:bg-gray-100"
+            title="Actions"
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+          {showActionMenu && (
+            <div className="absolute bottom-full left-0 mb-1 bg-white border border-gray-200 rounded-lg shadow-lg z-50 min-w-[160px]">
+              <button
+                type="button"
+                className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  fileInputRef.current?.click();
+                  setShowActionMenu(false);
+                }}
+              >
+                <ImagePlus className="w-4 h-4" /> Add image
+              </button>
+              {slashCommands.length > 0 && (
+                <button
+                  type="button"
+                  className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    setMessage("/");
+                    setSlashFilter("");
+                    setSlashSelectedIndex(0);
+                    setShowSlashMenu(true);
+                    setShowActionMenu(false);
+                  }}
+                >
+                  <Slash className="w-4 h-4" /> Slash commands
+                </button>
+              )}
+              {session.status !== "stopped" && session.type !== "controller" && (
+                <button
+                  type="button"
+                  className="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2"
+                  onMouseDown={async (e) => {
+                    e.preventDefault();
+                    setShowActionMenu(false);
+                    await api.stopSession(session.id);
+                    api.getSession(session.id).then(setSession);
+                  }}
+                >
+                  <Square className="w-4 h-4" /> Stop session
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/gif,image/webp"
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            if (e.target.files) addImageFiles(e.target.files);
+            e.target.value = "";
+          }}
+        />
+        {/* Message input with slash command popup */}
         <div className="relative flex-1">
           {showSlashMenu && (() => {
             const filtered = slashCommands.filter((cmd) =>
@@ -1203,10 +1272,8 @@ export function SessionDetail() {
             onChange={(e) => {
               const val = e.target.value;
               setMessage(val);
-              // Show slash menu when input starts with /
               if (val.startsWith("/") && slashCommands.length > 0) {
                 const filter = val.slice(1).split(" ")[0];
-                // Only show menu if user hasn't finished typing a command (no space yet)
                 if (!val.includes(" ") || val === "/") {
                   setSlashFilter(filter);
                   setSlashSelectedIndex(0);
@@ -1238,7 +1305,7 @@ export function SessionDetail() {
                 setShowSlashMenu(false);
               }
             }}
-            onBlur={() => setShowSlashMenu(false)}
+            onBlur={() => { setShowSlashMenu(false); setShowActionMenu(false); }}
             onPaste={(e) => {
               const items = e.clipboardData?.items;
               if (!items) return;
@@ -1258,41 +1325,10 @@ export function SessionDetail() {
             className="w-full border border-gray-300 rounded px-3 py-2 text-sm"
           />
         </div>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/jpeg,image/png,image/gif,image/webp"
-          multiple
-          className="hidden"
-          onChange={(e) => {
-            if (e.target.files) addImageFiles(e.target.files);
-            e.target.value = "";
-          }}
-        />
-        <button
-          type="button"
-          onClick={() => fileInputRef.current?.click()}
-          className="w-9 h-9 flex items-center justify-center text-gray-500 bg-gray-50 rounded hover:bg-gray-100"
-          title="Add image"
-        >
-          <ImagePlus className="w-4 h-4" />
-        </button>
-        {session.status !== "stopped" && session.type !== "controller" && (
-          <button
-            type="button"
-            onClick={async () => {
-              await api.stopSession(session.id);
-              api.getSession(session.id).then(setSession);
-            }}
-            className="w-9 h-9 flex items-center justify-center text-red-600 bg-red-50 rounded hover:bg-red-100"
-            title="Stop"
-          >
-            <Square className="w-4 h-4" />
-          </button>
-        )}
+        {/* Send button */}
         <button
           type="submit"
-          className="w-9 h-9 flex items-center justify-center bg-blue-600 text-white rounded hover:bg-blue-700"
+          className="w-9 h-9 flex items-center justify-center bg-blue-600 text-white rounded-full hover:bg-blue-700"
         >
           <SendHorizonal className="w-4 h-4" />
         </button>


### PR DESCRIPTION
## Summary
- system initレスポンスの `slash_commands` フィールドからコマンド一覧を抽出
- 入力欄で `/` をタイプするとフィルタリング付きポップアップでコマンド一覧を表示
- 矢印キー・Enter・Tabで選択、Escで閉じる操作に対応

## Test plan
- [ ] セッション詳細画面の入力欄で `/` を入力し、slash commandの一覧がポップアップ表示されることを確認
- [ ] 文字を続けて入力するとフィルタリングされることを確認
- [ ] 矢印キーで選択を移動し、EnterまたはTabで確定できることを確認
- [ ] Escでポップアップが閉じることを確認
- [ ] 選択後、入力欄に `/<command> ` が挿入されることを確認

Closes #40