### PR TITLE
feat: 子ツールパネルを最新5件に制限し残りを折りたたむ

### DIFF
--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -665,11 +665,13 @@ function ToolCallView({ item, onAnswer, sessionId, escalationId, escalationTimed
   }
 
   const [open, setOpen] = useState(false);
+  const [childrenExpanded, setChildrenExpanded] = useState(false);
   const Icon = toolIcon(item.name);
   const desc = toolDescription(item.name, item.input);
   const subDetail = toolSubDetail(item.name, item.input);
   const done = item.result !== undefined;
   const hasChildren = item.children && item.children.length > 0;
+  const CHILD_DISPLAY_LIMIT = 5;
 
   return (
     <>
@@ -719,19 +721,44 @@ function ToolCallView({ item, onAnswer, sessionId, escalationId, escalationTimed
           )}
         </div>
       </Modal>
-      {hasChildren && (
-        <div className="ml-4 border-l-2 border-indigo-200 pl-3 space-y-1.5">
-          {item.children!.map((child, i) => (
-            <div key={i}>
-              {child.kind === "tool_call" ? (
-                <ToolCallView item={child} />
-              ) : child.kind === "text" ? (
-                <CollapsibleText text={child.text} />
-              ) : null}
-            </div>
-          ))}
-        </div>
-      )}
+      {hasChildren && (() => {
+        const allChildren = item.children!;
+        const totalCount = allChildren.length;
+        const hasHidden = totalCount > CHILD_DISPLAY_LIMIT && !childrenExpanded;
+        const hiddenCount = totalCount - CHILD_DISPLAY_LIMIT;
+        const visibleChildren = hasHidden
+          ? allChildren.slice(totalCount - CHILD_DISPLAY_LIMIT)
+          : allChildren;
+        return (
+          <div className="ml-4 border-l-2 border-indigo-200 pl-3 space-y-1.5">
+            {hasHidden && (
+              <button
+                onClick={() => setChildrenExpanded(true)}
+                className="text-xs text-blue-500 hover:text-blue-700 py-0.5"
+              >
+                他 {hiddenCount} 件を表示
+              </button>
+            )}
+            {childrenExpanded && totalCount > CHILD_DISPLAY_LIMIT && (
+              <button
+                onClick={() => setChildrenExpanded(false)}
+                className="text-xs text-blue-500 hover:text-blue-700 py-0.5"
+              >
+                折りたたむ
+              </button>
+            )}
+            {visibleChildren.map((child, i) => (
+              <div key={hasHidden ? i + hiddenCount : i}>
+                {child.kind === "tool_call" ? (
+                  <ToolCallView item={child} />
+                ) : child.kind === "text" ? (
+                  <CollapsibleText text={child.text} />
+                ) : null}
+              </div>
+            ))}
+          </div>
+        );
+      })()}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- ツール親子表示で子ツールパネルを最新5件のみ表示するように制限
- 5件を超える古い子ツールは省略し、「他N件を表示」ボタンで全件展開可能
- 展開後は「折りたたむ」ボタンで再度折りたたみ可能

closes #143