### PR TITLE
refactor: ページコンポーネントを pages/ ディレクトリに移動

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,11 +2,11 @@ import { useCallback, useEffect, useState } from "react";
 import { Routes, Route, useNavigate, useSearchParams } from "react-router-dom";
 import { api } from "./api/client";
 import type { Session } from "./types/session";
-import { SessionDetail } from "./components/SessionDetail";
+import { SessionPage } from "./pages/SessionPage";
 import { LogPanel } from "./components/LogPanel";
 import { SessionList } from "./components/SessionList";
-import { ConfigPage } from "./components/ConfigPage";
-import { MetricsPage } from "./components/MetricsPage";
+import { ConfigPage } from "./pages/ConfigPage";
+import { MetricsPage } from "./pages/MetricsPage";
 import { useWebSocket } from "./hooks/useWebSocket";
 import { getActiveSessionName } from "./activeSession";
 
@@ -242,7 +242,7 @@ function App() {
   return (
     <Routes>
       <Route path="/" element={<Dashboard />} />
-      <Route path="/sessions/:id" element={<SessionDetail />} />
+      <Route path="/sessions/:id" element={<SessionPage />} />
       <Route path="/config" element={<ConfigPage />} />
       <Route path="/metrics" element={<MetricsPage />} />
     </Routes>

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api } from "../api/client";
 import type { AppConfig } from "../api/client";
-import { Section, Field } from "./ui/Section";
+import { Section, Field } from "../components/ui/Section";
 
 export function ConfigPage() {
   const navigate = useNavigate();

--- a/frontend/src/pages/MetricsPage.tsx
+++ b/frontend/src/pages/MetricsPage.tsx
@@ -14,7 +14,7 @@ import {
 import { api } from "../api/client";
 import type { MetricsSummary, MetricRow, MetricEvent } from "../api/client";
 import { useNavigate } from "react-router-dom";
-import { SummaryCard } from "./ui/SummaryCard";
+import { SummaryCard } from "../components/ui/SummaryCard";
 
 type TimeRange = "1h" | "6h" | "24h" | "7d" | "all";
 

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -8,16 +8,16 @@ import {
   ListTodo, Target, RotateCcw, Circle, ImagePlus, SendHorizonal, AlertTriangle, Plus, Slash,
   Code, Eye,
 } from "lucide-react";
-import { Modal } from "./ui/Modal";
-import { CollapsibleText } from "./ui/CollapsibleText";
+import { Modal } from "../components/ui/Modal";
+import { CollapsibleText } from "../components/ui/CollapsibleText";
 import type { StreamEntry, StreamDisplayItem, AskUserQuestionItem } from "../models/stream";
 import { mergeStreamEntries } from "../models/stream";
 import { toolIcon, toolDescription, toolSubDetail, parseTodoInput } from "../models/tool";
-import { Toast } from "./ui/Toast";
+import { Toast } from "../components/ui/Toast";
 import { useAutoScroll } from "../hooks/useAutoScroll";
 import type { Session } from "../types/session";
 import { api, type DiffFile } from "../api/client";
-import { StatusDot } from "./StatusBadge";
+import { StatusDot } from "../components/StatusBadge";
 import { setActiveSessionName } from "../activeSession";
 import { useWebSocket } from "../hooks/useWebSocket";
 
@@ -579,7 +579,7 @@ function DiffDropdown({ files }: { files: DiffFile[] }) {
   );
 }
 
-export function SessionDetail() {
+export function SessionPage() {
   const { id: sessionId } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [session, setSession] = useState<Session | null>(null);


### PR DESCRIPTION
## Summary
- ページレベルのコンポーネント (`ConfigPage`, `MetricsPage`, `SessionDetail`) を `frontend/src/components/` から `frontend/src/pages/` に移動
- `SessionDetail` を `SessionPage` にリネームし、命名規則を統一
- `App.tsx` のインポートパスを更新

Closes #148

## Test plan
- [x] `make build` が成功することを確認
- [ ] 各ページ (`/`, `/sessions/:id`, `/config`, `/metrics`) が正常に表示されることを確認