### PR TITLE
feat: CLAUDE.md表示で.claudeディレクトリ内ファイルと@参照も読み込む

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -76,7 +76,7 @@ export const api = {
     request<{ files: DiffFile[] }>(`/sessions/${id}/diff`),
 
   getClaudeMD: (id: string) =>
-    request<{ content: string }>(`/sessions/${id}/claude-md`),
+    request<{ files: { path: string; content: string }[] }>(`/sessions/${id}/claude-md`),
 
   getPendingEscalation: (sessionId: string) =>
     request<{ escalation: { id: string; sessionId: string; message: string; timedOut?: boolean; timeoutSeconds?: number } | null }>(`/sessions/${sessionId}/escalate`),

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -40,7 +40,7 @@ export function SessionPage() {
   const [slashFilter, setSlashFilter] = useState("");
   const [slashSelectedIndex, setSlashSelectedIndex] = useState(0);
   const [claudeMDOpen, setClaudeMDOpen] = useState(false);
-  const [claudeMDContent, setClaudeMDContent] = useState<string | null>(null);
+  const [claudeMDFiles, setClaudeMDFiles] = useState<{ path: string; content: string }[] | null>(null);
   const [claudeMDLoading, setClaudeMDLoading] = useState(false);
   const [claudeMDViewMode, setClaudeMDViewMode] = useState<"preview" | "source">("preview");
   const [claudeMDSelectedLine, setClaudeMDSelectedLine] = useState<number | null>(null);
@@ -492,12 +492,12 @@ export function SessionPage() {
         <button
           onClick={() => {
             setClaudeMDOpen(true);
-            if (claudeMDContent === null && !claudeMDLoading) {
+            if (claudeMDFiles === null && !claudeMDLoading) {
               setClaudeMDLoading(true);
               api.getClaudeMD(session.id).then((res) => {
-                setClaudeMDContent(res.content);
+                setClaudeMDFiles(res.files);
               }).catch(() => {
-                setClaudeMDContent("CLAUDE.md not found");
+                setClaudeMDFiles([{ path: "CLAUDE.md", content: "CLAUDE.md not found" }]);
               }).finally(() => {
                 setClaudeMDLoading(false);
               });
@@ -628,36 +628,47 @@ export function SessionPage() {
       >
         {claudeMDLoading ? (
           <div className="text-gray-400 text-sm">Loading...</div>
-        ) : claudeMDContent ? (
-          claudeMDViewMode === "preview" ? (
-            <div className="prose prose-sm max-w-none">
-              <Markdown remarkPlugins={[remarkGfm]}>{claudeMDContent}</Markdown>
-            </div>
-          ) : (
-            <pre className="text-xs leading-relaxed font-mono whitespace-pre-wrap">
-              {claudeMDContent.split("\n").map((line, i) => {
-                const lineNum = i + 1;
-                const isSelected = claudeMDSelectedLine === lineNum;
-                return (
-                  <div
-                    key={i}
-                    className={`flex cursor-pointer ${isSelected ? "bg-yellow-100" : "hover:bg-gray-50"}`}
-                    onClick={() => {
-                      setClaudeMDSelectedLine(isSelected ? null : lineNum);
-                      navigator.clipboard.writeText(`CLAUDE.md:L${lineNum}`);
-                    }}
-                  >
-                    <span
-                      className={`select-none w-10 text-right pr-3 shrink-0 ${isSelected ? "text-yellow-600" : "text-gray-300"}`}
-                    >
-                      {lineNum}
-                    </span>
-                    <span className="flex-1">{line}</span>
+        ) : claudeMDFiles && claudeMDFiles.length > 0 ? (
+          <div className="space-y-6">
+            {claudeMDFiles.map((file, fileIdx) => (
+              <div key={fileIdx}>
+                {claudeMDFiles.length > 1 && (
+                  <div className="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-1 rounded-t border border-b-0 border-gray-200">
+                    {file.path}
                   </div>
-                );
-              })}
-            </pre>
-          )
+                )}
+                {claudeMDViewMode === "preview" ? (
+                  <div className={`prose prose-sm max-w-none ${claudeMDFiles.length > 1 ? "border border-gray-200 rounded-b p-3" : ""}`}>
+                    <Markdown remarkPlugins={[remarkGfm]}>{file.content}</Markdown>
+                  </div>
+                ) : (
+                  <pre className={`text-xs leading-relaxed font-mono whitespace-pre-wrap ${claudeMDFiles.length > 1 ? "border border-gray-200 rounded-b" : ""}`}>
+                    {file.content.split("\n").map((line, i) => {
+                      const lineNum = i + 1;
+                      const isSelected = claudeMDSelectedLine === lineNum;
+                      return (
+                        <div
+                          key={i}
+                          className={`flex cursor-pointer ${isSelected ? "bg-yellow-100" : "hover:bg-gray-50"}`}
+                          onClick={() => {
+                            setClaudeMDSelectedLine(isSelected ? null : lineNum);
+                            navigator.clipboard.writeText(`${file.path}:L${lineNum}`);
+                          }}
+                        >
+                          <span
+                            className={`select-none w-10 text-right pr-3 shrink-0 ${isSelected ? "text-yellow-600" : "text-gray-300"}`}
+                          >
+                            {lineNum}
+                          </span>
+                          <span className="flex-1">{line}</span>
+                        </div>
+                      );
+                    })}
+                  </pre>
+                )}
+              </div>
+            ))}
+          </div>
         ) : (
           <div className="text-gray-400 text-sm">No content</div>
         )}

--- a/internal/server/claudemd_test.go
+++ b/internal/server/claudemd_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseAtReferences(t *testing.T) {
+	// Create a temp directory with a referenced file
+	tmpDir := t.TempDir()
+	refFile := filepath.Join(tmpDir, "RTK.md")
+	if err := os.WriteFile(refFile, []byte("# RTK content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{
+			name:    "single @reference",
+			content: "@RTK.md",
+			want:    1,
+		},
+		{
+			name:    "no references",
+			content: "# Just a heading\nSome text",
+			want:    0,
+		},
+		{
+			name:    "reference to nonexistent file",
+			content: "@nonexistent.md",
+			want:    0,
+		},
+		{
+			name:    "reference with surrounding text",
+			content: "# Title\n@RTK.md\nSome other text",
+			want:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs := parseAtReferences(tt.content, tmpDir)
+			if len(refs) != tt.want {
+				t.Errorf("parseAtReferences() returned %d refs, want %d", len(refs), tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -817,6 +817,30 @@ func (s *Server) getSessionDiff(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]interface{}{"files": files})
 }
 
+// parseAtReferences extracts file paths from @filename references in CLAUDE.md content.
+// It looks for lines starting with @ followed by a filename (e.g., "@RTK.md").
+func parseAtReferences(content string, baseDir string) []string {
+	var refs []string
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "@") && len(line) > 1 {
+			ref := strings.TrimPrefix(line, "@")
+			// Remove any trailing whitespace or comments
+			ref = strings.Fields(ref)[0]
+			refPath := filepath.Join(baseDir, ref)
+			if _, err := os.Stat(refPath); err == nil {
+				refs = append(refs, refPath)
+			}
+		}
+	}
+	return refs
+}
+
+type claudeMDFile struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
 func (s *Server) getClaudeMD(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sess, err := s.sessions.Get(id)
@@ -825,18 +849,52 @@ func (s *Server) getClaudeMD(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	claudeMDPath := filepath.Join(sess.ProjectPath, "CLAUDE.md")
-	content, err := os.ReadFile(claudeMDPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			writeError(w, http.StatusNotFound, "CLAUDE.md not found")
-			return
+	var files []claudeMDFile
+
+	// Candidate paths for CLAUDE.md files
+	candidates := []string{
+		filepath.Join(sess.ProjectPath, "CLAUDE.md"),
+		filepath.Join(sess.ProjectPath, ".claude", "CLAUDE.md"),
+	}
+
+	seen := map[string]bool{}
+
+	for _, candidate := range candidates {
+		if seen[candidate] {
+			continue
 		}
-		writeError(w, http.StatusInternalServerError, err.Error())
+		content, err := os.ReadFile(candidate)
+		if err != nil {
+			continue
+		}
+		seen[candidate] = true
+
+		// Compute relative path from project root for display
+		relPath, _ := filepath.Rel(sess.ProjectPath, candidate)
+		files = append(files, claudeMDFile{Path: relPath, Content: string(content)})
+
+		// Parse @references and include referenced files
+		refs := parseAtReferences(string(content), filepath.Dir(candidate))
+		for _, ref := range refs {
+			if seen[ref] {
+				continue
+			}
+			seen[ref] = true
+			refContent, err := os.ReadFile(ref)
+			if err != nil {
+				continue
+			}
+			refRelPath, _ := filepath.Rel(sess.ProjectPath, ref)
+			files = append(files, claudeMDFile{Path: refRelPath, Content: string(refContent)})
+		}
+	}
+
+	if len(files) == 0 {
+		writeError(w, http.StatusNotFound, "CLAUDE.md not found")
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"content": string(content)})
+	writeJSON(w, http.StatusOK, map[string]interface{}{"files": files})
 }
 
 func getWorkingTreeDiff(projectPath string) ([]diffFileEntry, error) {


### PR DESCRIPTION
## Summary

Closes #166

- バックエンド (`internal/server/server.go`): `getClaudeMD` を拡張し、プロジェクトルートの `CLAUDE.md` に加えて `.claude/CLAUDE.md` も読み込み対象に追加。さらに `@ファイル名` 記法で参照されているファイルも再帰的に読み込む
- フロントエンド: APIレスポンス形式を `{content: string}` から `{files: [{path, content}]}` に変更し、複数ファイルをファイルパス付きヘッダーで表示
- `parseAtReferences` 関数のユニットテストを追加

## Test plan

- [x] `go test ./internal/...` パス確認
- [x] `make build` ビルド確認
- [ ] プロジェクトルートに `CLAUDE.md` のみある場合、従来通り表示される
- [ ] `.claude/CLAUDE.md` がある場合、両方のファイルが表示される
- [ ] `@ファイル名` 参照があれば、参照先ファイルも表示される