### PR TITLE
fix: セッション一覧からStopボタンを削除

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -107,15 +107,6 @@ function Dashboard() {
 
   useWebSocket(handleWsMessage);
 
-  const handleStop = async (id: string) => {
-    try {
-      await api.stopSession(id);
-      loadSessions();
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to stop session");
-    }
-  };
-
   const handleRestartController = async () => {
     try {
       await api.restartController();
@@ -226,7 +217,6 @@ function Dashboard() {
           </h2>
           <SessionList
             sessions={sessions}
-            onStop={handleStop}
             onRestartController={handleRestartController}
           />
         </div>

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -36,11 +36,10 @@ function groupSessionsByProject(sessions: Session[]): Map<string, Session[]> {
 
 interface Props {
   sessions: Session[];
-  onStop: (id: string) => void;
   onRestartController: () => void;
 }
 
-export function SessionList({ sessions, onStop, onRestartController }: Props) {
+export function SessionList({ sessions, onRestartController }: Props) {
   const navigate = useNavigate();
   const groupedSessions = useMemo(() => {
     const groups = groupSessionsByProject(sessions);
@@ -108,14 +107,6 @@ export function SessionList({ sessions, onStop, onRestartController }: Props) {
                     {timeAgo(s.createdAt)}
                   </span>
                   <div className="flex gap-1.5">
-                    {(s.status === "working" || s.status === "idle" || s.status === "question_waiting") && (
-                      <button
-                        onClick={(e) => { e.stopPropagation(); onStop(s.id); }}
-                        className="px-2 py-0.5 text-xs bg-red-50 text-red-600 rounded hover:bg-red-100"
-                      >
-                        Stop
-                      </button>
-                    )}
                     {s.type === "controller" && s.status === "stopped" && (
                       <button
                         onClick={(e) => { e.stopPropagation(); onRestartController(); }}


### PR DESCRIPTION
## Summary
- セッション一覧（トップページ）からStopボタンを削除
- SessionListコンポーネントからonStop propを削除
- App.tsxから不要になったhandleStop関数を削除
- セッション詳細画面のStopボタンはそのまま残す

Closes #176