### PR TITLE
feat: Provider インターフェース導入とCLI依存の抽象化

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -56,7 +56,9 @@ func initManager(cfg *config.Config, logger *slog.Logger) (*session.Manager, *sq
 	if err != nil {
 		return nil, nil, err
 	}
-	return session.NewManager(database, tmux.NewClient(), cfg.Session.ClaudeCommand, cfg.Server.Port, logger, cfg.Session.SystemPrompt), database, nil
+	mgr := session.NewManager(database, tmux.NewClient(), cfg.Session.ClaudeCommand, cfg.Server.Port, logger, cfg.Session.SystemPrompt)
+	mgr.SetCodexCommand(cfg.Session.CodexCommand)
+	return mgr, database, nil
 }
 
 func serveCmd() *cobra.Command {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ type DaemonConfig struct {
 
 type SessionConfig struct {
 	ClaudeCommand string `toml:"claude_command"`
+	CodexCommand  string `toml:"codex_command"`
 	SystemPrompt  string `toml:"system_prompt"`
 }
 
@@ -46,6 +47,7 @@ func Default() *Config {
 		},
 		Session: SessionConfig{
 			ClaudeCommand: "claude --dangerously-skip-permissions",
+			CodexCommand:  "codex",
 		},
 	}
 }

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -116,6 +116,12 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: add provider column if missing
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN provider TEXT NOT NULL DEFAULT 'claude'`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	// Migration: create otel_metrics table
 	_, err = db.Exec(`
 		CREATE TABLE IF NOT EXISTS otel_metrics (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -137,6 +137,7 @@ type createSessionRequest struct {
 	Prompt      string `json:"prompt,omitempty"`
 	OutputMode  string `json:"outputMode,omitempty"`
 	Worktree    bool   `json:"worktree,omitempty"`
+	Provider    string `json:"provider,omitempty"`
 }
 
 type sendImageData struct {
@@ -176,7 +177,7 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "name and projectPath are required")
 		return
 	}
-	sess, err := s.sessions.Create(req.Name, req.ProjectPath, req.Prompt, session.OutputMode(req.OutputMode), req.Worktree)
+	sess, err := s.sessions.Create(req.Name, req.ProjectPath, req.Prompt, session.OutputMode(req.OutputMode), req.Worktree, session.ProviderName(req.Provider))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -21,6 +21,7 @@ type Manager struct {
 	db              *sql.DB
 	tmux            *tmux.Client
 	claudeCommand   string
+	codexCommand    string
 	apiPort         int
 	systemPrompt    string
 	streamProcesses map[string]*StreamProcess
@@ -42,10 +43,28 @@ func NewManager(db *sql.DB, tmuxClient *tmux.Client, claudeCommand string, apiPo
 		db:              db,
 		tmux:            tmuxClient,
 		claudeCommand:   claudeCommand,
+		codexCommand:    "codex",
 		apiPort:         apiPort,
 		systemPrompt:    systemPrompt,
 		streamProcesses: make(map[string]*StreamProcess),
 		logger:          logger.With("component", "session_manager"),
+	}
+}
+
+// SetCodexCommand sets the codex command for the manager.
+func (m *Manager) SetCodexCommand(cmd string) {
+	if cmd != "" {
+		m.codexCommand = cmd
+	}
+}
+
+// getProvider returns a Provider for the given provider name.
+func (m *Manager) getProvider(name ProviderName) Provider {
+	switch name {
+	case ProviderCodex:
+		return GetProvider(ProviderCodex, m.codexCommand)
+	default:
+		return GetProvider(ProviderClaude, m.claudeCommand)
 	}
 }
 
@@ -59,7 +78,7 @@ func (m *Manager) SystemPrompt() string {
 // before the server was restarted.
 func (m *Manager) RecoverStreamProcesses() {
 	rows, err := m.db.Query(
-		`SELECT id, project_path FROM sessions WHERE status = ? AND output_mode = ?`,
+		`SELECT id, project_path, provider FROM sessions WHERE status = ? AND output_mode = ?`,
 		string(StatusWorking), string(OutputModeStream),
 	)
 	if err != nil {
@@ -69,18 +88,19 @@ func (m *Manager) RecoverStreamProcesses() {
 	defer rows.Close()
 
 	for rows.Next() {
-		var id, projectPath string
-		if err := rows.Scan(&id, &projectPath); err != nil {
+		var id, projectPath, providerStr string
+		if err := rows.Scan(&id, &projectPath, &providerStr); err != nil {
 			m.logger.Error("recover stream processes: scan failed", "error", err)
 			continue
 		}
-		mcpPath, err := writeMCPConfig(id, m.apiPort)
+		provider := m.getProvider(ProviderName(providerStr))
+		mcpPath, err := provider.SetupMCP(id, m.apiPort)
 		if err != nil {
 			m.logger.Error("recover stream processes: mcp config failed", "sessionId", id, "error", err)
 			continue
 		}
-		claudeSessionID := ReadClaudeSessionID(id)
-		sp, err := StartStreamProcess(id, projectPath, mcpPath, m.systemPrompt, true, false, claudeSessionID)
+		cliSessionID := ReadCLISessionID(id, provider)
+		sp, err := StartStreamProcess(id, projectPath, mcpPath, m.systemPrompt, true, false, provider, cliSessionID)
 		if err != nil {
 			m.logger.Error("recover stream processes: start failed", "sessionId", id, "error", err)
 			continue
@@ -92,16 +112,22 @@ func (m *Manager) RecoverStreamProcesses() {
 	}
 }
 
-func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode, worktree bool) (*Session, error) {
+func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode, worktree bool, providerName ...ProviderName) (*Session, error) {
 	if outputMode == "" {
 		outputMode = OutputModeTerminal
 	}
+
+	pn := ProviderClaude
+	if len(providerName) > 0 && providerName[0] != "" {
+		pn = providerName[0]
+	}
+	provider := m.getProvider(pn)
 
 	id := uuid.New().String()
 	tmuxSession := tmux.SessionPrefix + name
 
 	// Generate MCP config for this session
-	mcpConfigPath, err := writeMCPConfig(id, m.apiPort)
+	mcpConfigPath, err := provider.SetupMCP(id, m.apiPort)
 	if err != nil {
 		return nil, fmt.Errorf("write mcp config: %w", err)
 	}
@@ -112,8 +138,8 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 	}
 
 	if outputMode == OutputModeStream {
-		// Stream mode: start Go subprocess instead of claude TUI
-		sp, err := StartStreamProcess(id, projectPath, mcpConfigPath, m.systemPrompt, false, worktree)
+		// Stream mode: start Go subprocess instead of CLI TUI
+		sp, err := StartStreamProcess(id, projectPath, mcpConfigPath, m.systemPrompt, false, worktree, provider)
 		if err != nil {
 			_ = m.tmux.KillSession(name)
 			return nil, fmt.Errorf("start stream process: %w", err)
@@ -129,18 +155,23 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 			}
 		}
 	} else {
-		// Terminal mode: launch claude TUI in tmux
+		// Terminal mode: launch CLI TUI in tmux
 		time.Sleep(300 * time.Millisecond)
-		otelPrefix := otelEnvPrefix(m.apiPort)
-		claudeCmd := otelPrefix + m.claudeCommand + " --session-id " + id + " --mcp-config " + mcpConfigPath + " --append-system-prompt " + shellQuote(m.systemPrompt)
+		claudeCmd := provider.BuildTerminalCommand(TerminalOpts{
+			SessionID:     id,
+			MCPConfigPath: mcpConfigPath,
+			SystemPrompt:  m.systemPrompt,
+			Resume:        false,
+			APIPort:       m.apiPort,
+		})
 		if err := m.tmux.SendKeysOnce(tmuxSession, claudeCmd); err != nil {
-			return nil, fmt.Errorf("launch claude: %w", err)
+			return nil, fmt.Errorf("launch cli: %w", err)
 		}
 
-		// Wait for claude to start and handle trust prompt, then send initial prompt
+		// Wait for CLI to start and handle trust prompt, then send initial prompt
 		if prompt != "" {
 			if err := m.waitForClaudeReady(tmuxSession, 30*time.Second); err != nil {
-				return nil, fmt.Errorf("wait for claude: %w", err)
+				return nil, fmt.Errorf("wait for cli: %w", err)
 			}
 			if err := m.tmux.SendKeys(tmuxSession, prompt); err != nil {
 				return nil, fmt.Errorf("send initial prompt: %w", err)
@@ -158,14 +189,15 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 		Status:        StatusWorking,
 		Type:          TypeWorker,
 		OutputMode:    outputMode,
+		Provider:      pn,
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}
 
 	if _, err := m.db.Exec(
-		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, s.TmuxSession, string(s.Status), string(s.Type), string(s.OutputMode), s.CreatedAt, s.UpdatedAt,
+		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, s.TmuxSession, string(s.Status), string(s.Type), string(s.OutputMode), string(s.Provider), s.CreatedAt, s.UpdatedAt,
 	); err != nil {
 		// Cleanup tmux session on DB error
 		_ = m.tmux.KillSession(name)
@@ -177,7 +209,7 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 
 func (m *Manager) List() ([]Session, error) {
 	rows, err := m.db.Query(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, current_task, goal, goals, created_at, updated_at
 		 FROM sessions ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -191,13 +223,18 @@ func (m *Manager) List() ([]Session, error) {
 		var status string
 		var sessionType string
 		var outputMode string
+		var providerStr string
 		var prompt, currentTask, goal, goalsJSON sql.NullString
-		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		s.Status = Status(status)
 		s.Type = SessionType(sessionType)
 		s.OutputMode = OutputMode(outputMode)
+		s.Provider = ProviderName(providerStr)
+		if s.Provider == "" {
+			s.Provider = ProviderClaude
+		}
 		if prompt.Valid {
 			s.InitialPrompt = prompt.String
 		}
@@ -259,11 +296,12 @@ func (m *Manager) Get(id string) (*Session, error) {
 	var status string
 	var sessionType string
 	var outputMode string
+	var providerStr string
 	var prompt, currentTask, goal, goalsJSON sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, current_task, goal, goals, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id,
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
@@ -273,6 +311,10 @@ func (m *Manager) Get(id string) (*Session, error) {
 	s.Status = Status(status)
 	s.Type = SessionType(sessionType)
 	s.OutputMode = OutputMode(outputMode)
+	s.Provider = ProviderName(providerStr)
+	if s.Provider == "" {
+		s.Provider = ProviderClaude
+	}
 	if prompt.Valid {
 		s.InitialPrompt = prompt.String
 	}
@@ -363,6 +405,8 @@ func (m *Manager) Clear(id string) error {
 		return err
 	}
 
+	provider := m.getProvider(s.Provider)
+
 	// Stop existing stream process if any
 	m.stopStreamProcess(id)
 
@@ -382,7 +426,7 @@ func (m *Manager) Clear(id string) error {
 	}
 
 	// Generate fresh MCP config
-	mcpConfigPath, err := writeMCPConfig(id, m.apiPort)
+	mcpConfigPath, err := provider.SetupMCP(id, m.apiPort)
 	if err != nil {
 		return fmt.Errorf("write mcp config: %w", err)
 	}
@@ -395,7 +439,7 @@ func (m *Manager) Clear(id string) error {
 	if s.OutputMode == OutputModeStream {
 		// Start fresh with a new CLI session ID to avoid resuming the old conversation
 		freshCLISessionID := uuid.New().String()
-		sp, err := StartStreamProcess(id, s.ProjectPath, mcpConfigPath, m.systemPrompt, false, false, freshCLISessionID)
+		sp, err := StartStreamProcess(id, s.ProjectPath, mcpConfigPath, m.systemPrompt, false, false, provider, freshCLISessionID)
 		if err != nil {
 			return fmt.Errorf("start stream process: %w", err)
 		}
@@ -404,10 +448,15 @@ func (m *Manager) Clear(id string) error {
 		m.streamMu.Unlock()
 	} else {
 		time.Sleep(300 * time.Millisecond)
-		otelPrefix := otelEnvPrefix(m.apiPort)
-		claudeCmd := otelPrefix + m.claudeCommand + " --session-id " + id + " --mcp-config " + mcpConfigPath + " --append-system-prompt " + shellQuote(m.systemPrompt)
+		claudeCmd := provider.BuildTerminalCommand(TerminalOpts{
+			SessionID:     id,
+			MCPConfigPath: mcpConfigPath,
+			SystemPrompt:  m.systemPrompt,
+			Resume:        false,
+			APIPort:       m.apiPort,
+		})
 		if err := m.tmux.SendKeysOnce(s.TmuxSession, claudeCmd); err != nil {
-			return fmt.Errorf("launch claude: %w", err)
+			return fmt.Errorf("launch cli: %w", err)
 		}
 	}
 
@@ -431,10 +480,11 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 		m.streamMu.Unlock()
 		if !ok {
 			// Auto-recover: restart stream process after server restart
-			mcpPath, _ := writeMCPConfig(s.ID, m.apiPort)
-			claudeSessionID := ReadClaudeSessionID(s.ID)
+			provider := m.getProvider(s.Provider)
+			mcpPath, _ := provider.SetupMCP(s.ID, m.apiPort)
+			cliSessionID := ReadCLISessionID(s.ID, provider)
 			var err error
-			sp, err = StartStreamProcess(s.ID, s.ProjectPath, mcpPath, m.systemPrompt, true, false, claudeSessionID)
+			sp, err = StartStreamProcess(s.ID, s.ProjectPath, mcpPath, m.systemPrompt, true, false, provider, cliSessionID)
 			if err != nil {
 				return fmt.Errorf("restart stream process: %w", err)
 			}
@@ -595,11 +645,12 @@ func (m *Manager) GetController() (*Session, error) {
 	var status string
 	var sessionType string
 	var outputMode string
+	var providerStr string
 	var prompt, currentTask, goal, goalsJSON sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, current_task, goal, goals, created_at, updated_at
 		 FROM sessions WHERE type = ? LIMIT 1`, string(TypeController),
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -609,6 +660,10 @@ func (m *Manager) GetController() (*Session, error) {
 	s.Status = Status(status)
 	s.Type = SessionType(sessionType)
 	s.OutputMode = OutputMode(outputMode)
+	s.Provider = ProviderName(providerStr)
+	if s.Provider == "" {
+		s.Provider = ProviderClaude
+	}
 	if prompt.Valid {
 		s.InitialPrompt = prompt.String
 	}
@@ -641,11 +696,13 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 		_ = m.Delete(existing.ID)
 	}
 
+	provider := m.getProvider(ProviderClaude)
+
 	id := uuid.New().String()
 	name := "controller"
 	tmuxSession := tmux.SessionPrefix + name
 
-	mcpConfigPath, err := writeMCPConfig(id, m.apiPort)
+	mcpConfigPath, err := provider.SetupMCP(id, m.apiPort)
 	if err != nil {
 		return nil, fmt.Errorf("write mcp config: %w", err)
 	}
@@ -654,8 +711,8 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 		return nil, fmt.Errorf("create controller tmux session: %w", err)
 	}
 
-	// Stream mode: start Go subprocess instead of claude TUI
-	sp, err := StartStreamProcess(id, projectPath, mcpConfigPath, m.systemPrompt, false, false)
+	// Stream mode: start Go subprocess instead of CLI TUI
+	sp, err := StartStreamProcess(id, projectPath, mcpConfigPath, m.systemPrompt, false, false, provider)
 	if err != nil {
 		_ = m.tmux.KillSession(name)
 		return nil, fmt.Errorf("start stream process for controller: %w", err)
@@ -673,14 +730,15 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 		Status:      StatusWorking,
 		Type:        TypeController,
 		OutputMode:  OutputModeStream,
+		Provider:    ProviderClaude,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
 
 	_, err = m.db.Exec(
-		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, s.TmuxSession, string(s.Status), string(s.Type), string(s.OutputMode), s.CreatedAt, s.UpdatedAt,
+		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, s.TmuxSession, string(s.Status), string(s.Type), string(s.OutputMode), string(s.Provider), s.CreatedAt, s.UpdatedAt,
 	)
 	if err != nil {
 		_ = m.tmux.KillSession(name)
@@ -761,13 +819,15 @@ func (m *Manager) CompleteGoal(id string) (*CompleteGoalResult, error) {
 	return result, nil
 }
 
-// Reconnect restarts the Claude process for an existing session,
-// preserving the Claude session ID (--resume) and injecting a fresh MCP config.
+// Reconnect restarts the CLI process for an existing session,
+// preserving the CLI session ID (--resume) and injecting a fresh MCP config.
 func (m *Manager) Reconnect(id string) error {
 	s, err := m.Get(id)
 	if err != nil {
 		return err
 	}
+
+	provider := m.getProvider(s.Provider)
 
 	// Stop existing stream process if any
 	m.stopStreamProcess(id)
@@ -779,7 +839,7 @@ func (m *Manager) Reconnect(id string) error {
 	}
 
 	// Generate fresh MCP config
-	mcpConfigPath, err := writeMCPConfig(id, m.apiPort)
+	mcpConfigPath, err := provider.SetupMCP(id, m.apiPort)
 	if err != nil {
 		return fmt.Errorf("write mcp config: %w", err)
 	}
@@ -790,8 +850,8 @@ func (m *Manager) Reconnect(id string) error {
 	}
 
 	if s.OutputMode == OutputModeStream {
-		claudeSessionID := ReadClaudeSessionID(id)
-		sp, err := StartStreamProcess(id, s.ProjectPath, mcpConfigPath, m.systemPrompt, true, false, claudeSessionID)
+		cliSessionID := ReadCLISessionID(id, provider)
+		sp, err := StartStreamProcess(id, s.ProjectPath, mcpConfigPath, m.systemPrompt, true, false, provider, cliSessionID)
 		if err != nil {
 			return fmt.Errorf("start stream process: %w", err)
 		}
@@ -800,10 +860,15 @@ func (m *Manager) Reconnect(id string) error {
 		m.streamMu.Unlock()
 	} else {
 		time.Sleep(300 * time.Millisecond)
-		otelPrefix := otelEnvPrefix(m.apiPort)
-		claudeCmd := otelPrefix + m.claudeCommand + " --resume --session-id " + id + " --mcp-config " + mcpConfigPath + " --append-system-prompt " + shellQuote(m.systemPrompt)
+		claudeCmd := provider.BuildTerminalCommand(TerminalOpts{
+			SessionID:     id,
+			MCPConfigPath: mcpConfigPath,
+			SystemPrompt:  m.systemPrompt,
+			Resume:        true,
+			APIPort:       m.apiPort,
+		})
 		if err := m.tmux.SendKeysOnce(s.TmuxSession, claudeCmd); err != nil {
-			return fmt.Errorf("launch claude: %w", err)
+			return fmt.Errorf("launch cli: %w", err)
 		}
 	}
 

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -31,19 +31,20 @@ const (
 )
 
 type Session struct {
-	ID            string      `json:"id"`
-	Name          string      `json:"name"`
-	ProjectPath   string      `json:"projectPath"`
-	InitialPrompt string      `json:"initialPrompt,omitempty"`
-	TmuxSession   string      `json:"tmuxSession"`
-	Status        Status      `json:"status"`
-	Type          SessionType `json:"type"`
-	OutputMode    OutputMode  `json:"outputMode"`
-	CurrentTask   string      `json:"currentTask,omitempty"`
-	Goal          string      `json:"goal,omitempty"`
-	Goals         GoalStack   `json:"goals,omitempty"`
-	CreatedAt     time.Time   `json:"createdAt"`
-	UpdatedAt     time.Time   `json:"updatedAt"`
+	ID            string       `json:"id"`
+	Name          string       `json:"name"`
+	ProjectPath   string       `json:"projectPath"`
+	InitialPrompt string       `json:"initialPrompt,omitempty"`
+	TmuxSession   string       `json:"tmuxSession"`
+	Status        Status       `json:"status"`
+	Type          SessionType  `json:"type"`
+	OutputMode    OutputMode   `json:"outputMode"`
+	Provider      ProviderName `json:"provider"`
+	CurrentTask   string       `json:"currentTask,omitempty"`
+	Goal          string       `json:"goal,omitempty"`
+	Goals         GoalStack    `json:"goals,omitempty"`
+	CreatedAt     time.Time    `json:"createdAt"`
+	UpdatedAt     time.Time    `json:"updatedAt"`
 }
 
 type GoalEntry struct {

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -1,0 +1,64 @@
+package session
+
+import (
+	"os/exec"
+)
+
+// ProviderName identifies which CLI provider to use.
+type ProviderName string
+
+const (
+	ProviderClaude ProviderName = "claude"
+	ProviderCodex  ProviderName = "codex"
+)
+
+// StreamOpts contains parameters for building a stream-mode command.
+type StreamOpts struct {
+	SessionID      string
+	ProjectPath    string
+	MCPConfigPath  string
+	SystemPrompt   string
+	Resume         bool
+	Worktree       bool
+	CLISessionID   string // provider-specific session ID (for resume)
+}
+
+// TerminalOpts contains parameters for building a terminal-mode command.
+type TerminalOpts struct {
+	SessionID     string
+	MCPConfigPath string
+	SystemPrompt  string
+	Resume        bool
+	APIPort       int
+}
+
+// Provider abstracts CLI-specific behavior so agmux can support multiple AI CLIs.
+type Provider interface {
+	// BuildStreamCommand constructs the exec.Cmd for stream-json mode.
+	BuildStreamCommand(opts StreamOpts) *exec.Cmd
+	// ParseSessionID extracts a CLI session ID from a JSONL line.
+	ParseSessionID(jsonlLine []byte) (string, bool)
+	// BuildTerminalCommand returns the shell command string for terminal mode.
+	BuildTerminalCommand(opts TerminalOpts) string
+	// SetupMCP writes MCP config for this provider. Returns config file path.
+	SetupMCP(sessionID string, port int) (string, error)
+	// CleanupMCP removes MCP config for this provider.
+	CleanupMCP(sessionID string) error
+	// AppendOTelEnv appends OTel environment variables to the given env slice.
+	AppendOTelEnv(env []string, port int) []string
+	// OTelEnvPrefix returns a shell env prefix string for terminal mode.
+	OTelEnvPrefix(port int) string
+	// Name returns the provider name.
+	Name() ProviderName
+}
+
+// GetProvider returns a Provider instance for the given name.
+// Defaults to ClaudeProvider if name is empty or unrecognized.
+func GetProvider(name ProviderName, command string) Provider {
+	switch name {
+	case ProviderCodex:
+		return NewCodexProvider(command)
+	default:
+		return NewClaudeProvider(command)
+	}
+}

--- a/internal/session/provider_claude.go
+++ b/internal/session/provider_claude.go
@@ -1,0 +1,152 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/myuon/agmux/internal/config"
+	"github.com/myuon/agmux/internal/db"
+)
+
+// ClaudeProvider implements Provider for Claude Code CLI.
+type ClaudeProvider struct {
+	command string // e.g. "claude --dangerously-skip-permissions"
+}
+
+// NewClaudeProvider creates a ClaudeProvider with the given command.
+// If command is empty, defaults to "claude --dangerously-skip-permissions".
+func NewClaudeProvider(command string) *ClaudeProvider {
+	if command == "" {
+		command = "claude --dangerously-skip-permissions"
+	}
+	return &ClaudeProvider{command: command}
+}
+
+func (p *ClaudeProvider) Name() ProviderName {
+	return ProviderClaude
+}
+
+func (p *ClaudeProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
+	sessionFlag := "--session-id"
+	resumeID := opts.SessionID
+	if opts.Resume {
+		if opts.CLISessionID != "" {
+			sessionFlag = "--resume"
+			resumeID = opts.CLISessionID
+		}
+	} else if opts.CLISessionID != "" {
+		resumeID = opts.CLISessionID
+	}
+
+	args := []string{
+		"-p",
+		"--verbose",
+		"--output-format", "stream-json",
+		"--input-format", "stream-json",
+		sessionFlag, resumeID,
+		"--dangerously-skip-permissions",
+	}
+	if opts.MCPConfigPath != "" {
+		args = append(args, "--mcp-config", opts.MCPConfigPath)
+	}
+	args = append(args, "--append-system-prompt", opts.SystemPrompt)
+	if opts.Worktree {
+		args = append(args, "--worktree")
+	}
+
+	cmd := exec.Command("claude", args...)
+	cmd.Dir = opts.ProjectPath
+	// Filter out CLAUDECODE env var to avoid nested session detection
+	for _, env := range os.Environ() {
+		if !strings.HasPrefix(env, "CLAUDECODE=") {
+			cmd.Env = append(cmd.Env, env)
+		}
+	}
+	return cmd
+}
+
+func (p *ClaudeProvider) ParseSessionID(jsonlLine []byte) (string, bool) {
+	var msg struct {
+		Type      string `json:"type"`
+		SessionID string `json:"session_id"`
+	}
+	if json.Unmarshal(jsonlLine, &msg) == nil && msg.Type == "system" && msg.SessionID != "" {
+		return msg.SessionID, true
+	}
+	return "", false
+}
+
+func (p *ClaudeProvider) BuildTerminalCommand(opts TerminalOpts) string {
+	otelPrefix := p.OTelEnvPrefix(opts.APIPort)
+	cmd := otelPrefix + p.command
+	if opts.Resume {
+		cmd += " --resume --session-id " + opts.SessionID
+	} else {
+		cmd += " --session-id " + opts.SessionID
+	}
+	cmd += " --mcp-config " + opts.MCPConfigPath
+	cmd += " --append-system-prompt " + shellQuote(opts.SystemPrompt)
+	return cmd
+}
+
+func (p *ClaudeProvider) SetupMCP(sessionID string, port int) (string, error) {
+	return writeMCPConfig(sessionID, port)
+}
+
+func (p *ClaudeProvider) CleanupMCP(sessionID string) error {
+	dir, err := db.AgmuxDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "mcp-configs", sessionID+".json")
+	return os.Remove(path)
+}
+
+func (p *ClaudeProvider) AppendOTelEnv(env []string, port int) []string {
+	if port == 0 {
+		cfg, err := config.Load()
+		if err == nil && cfg.Server.Port != 0 {
+			port = cfg.Server.Port
+		} else {
+			port = 4321
+		}
+	}
+
+	otelVars := map[string]string{
+		"CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+		"OTEL_METRICS_EXPORTER":       "otlp",
+		"OTEL_LOGS_EXPORTER":          "otlp",
+		"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+		"OTEL_EXPORTER_OTLP_ENDPOINT": fmt.Sprintf("http://localhost:%d", port),
+		"OTEL_METRIC_EXPORT_INTERVAL": "30000",
+		"OTEL_LOGS_EXPORT_INTERVAL":   "5000",
+	}
+
+	existing := make(map[string]bool)
+	for _, e := range env {
+		key := strings.SplitN(e, "=", 2)[0]
+		existing[key] = true
+	}
+
+	for k, v := range otelVars {
+		if !existing[k] {
+			env = append(env, k+"="+v)
+		}
+	}
+
+	return env
+}
+
+func (p *ClaudeProvider) OTelEnvPrefix(port int) string {
+	if port == 0 {
+		port = 4321
+	}
+	return fmt.Sprintf(
+		"CLAUDE_CODE_ENABLE_TELEMETRY=1 OTEL_METRICS_EXPORTER=otlp OTEL_LOGS_EXPORTER=otlp OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:%d ",
+		port,
+	)
+}

--- a/internal/session/provider_codex.go
+++ b/internal/session/provider_codex.go
@@ -1,0 +1,58 @@
+package session
+
+import (
+	"os/exec"
+)
+
+// CodexProvider is a stub implementation of Provider for OpenAI Codex CLI.
+// Full implementation will be added in a future PR.
+type CodexProvider struct {
+	command string
+}
+
+// NewCodexProvider creates a CodexProvider with the given command.
+func NewCodexProvider(command string) *CodexProvider {
+	if command == "" {
+		command = "codex"
+	}
+	return &CodexProvider{command: command}
+}
+
+func (p *CodexProvider) Name() ProviderName {
+	return ProviderCodex
+}
+
+func (p *CodexProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
+	// Stub: will be implemented when Codex CLI support is added
+	cmd := exec.Command(p.command)
+	cmd.Dir = opts.ProjectPath
+	return cmd
+}
+
+func (p *CodexProvider) ParseSessionID(jsonlLine []byte) (string, bool) {
+	// Stub
+	return "", false
+}
+
+func (p *CodexProvider) BuildTerminalCommand(opts TerminalOpts) string {
+	// Stub
+	return p.command
+}
+
+func (p *CodexProvider) SetupMCP(sessionID string, port int) (string, error) {
+	// Codex doesn't support MCP yet; reuse the same config format for now
+	return writeMCPConfig(sessionID, port)
+}
+
+func (p *CodexProvider) CleanupMCP(sessionID string) error {
+	return nil
+}
+
+func (p *CodexProvider) AppendOTelEnv(env []string, port int) []string {
+	// Stub: no OTel for Codex yet
+	return env
+}
+
+func (p *CodexProvider) OTelEnvPrefix(port int) string {
+	return ""
+}

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -9,14 +9,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/myuon/agmux/internal/db"
 )
 
-// StreamProcess manages a claude CLI process running in stream-json mode.
+// StreamProcess manages a CLI process running in stream-json mode.
 type StreamProcess struct {
 	cmd       *exec.Cmd
 	stdin     io.WriteCloser
@@ -24,15 +23,14 @@ type StreamProcess struct {
 	mu        sync.RWMutex
 	done      chan struct{}
 	file      *os.File
-	sessionID string // claude session ID (may differ from agmux session ID after resume)
+	sessionID string // CLI session ID (may differ from agmux session ID after resume)
+	provider  Provider
 }
 
-// ReadClaudeSessionID reads the Claude-assigned session ID from a stream JSONL file.
-// It looks for a "system" init message which indicates a successful session start.
-// Only returns the session_id from a "system" message; result-only session IDs
-// indicate failed sessions that cannot be resumed.
+// ReadCLISessionID reads the CLI-assigned session ID from a stream JSONL file.
+// It delegates parsing to the given provider.
 // Returns empty string if no successful session was found.
-func ReadClaudeSessionID(agmuxSessionID string) string {
+func ReadCLISessionID(agmuxSessionID string, provider Provider) string {
 	streamsDir, err := db.StreamsDir()
 	if err != nil {
 		return ""
@@ -44,26 +42,22 @@ func ReadClaudeSessionID(agmuxSessionID string) string {
 	}
 	defer f.Close()
 
-	var lastSystemSessionID string
+	var lastSessionID string
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	for scanner.Scan() {
-		var msg struct {
-			Type      string `json:"type"`
-			SessionID string `json:"session_id"`
-		}
-		if json.Unmarshal([]byte(scanner.Text()), &msg) == nil && msg.Type == "system" && msg.SessionID != "" {
-			lastSystemSessionID = msg.SessionID
+		if sid, ok := provider.ParseSessionID([]byte(scanner.Text())); ok {
+			lastSessionID = sid
 		}
 	}
-	return lastSystemSessionID
+	return lastSessionID
 }
 
-// StartStreamProcess starts a claude CLI subprocess in stream-json mode.
+// StartStreamProcess starts a CLI subprocess in stream-json mode.
 // If resume is true, it uses --resume to continue an existing conversation;
 // otherwise it uses --session-id to start a new one.
-// claudeSessionID is only used when resume=true — it's the Claude-assigned session ID.
-func StartStreamProcess(sessionID, projectPath, mcpConfigPath, systemPrompt string, resume bool, worktree bool, claudeSessionID ...string) (*StreamProcess, error) {
+// cliSessionID is only used when resume=true -- it's the CLI-assigned session ID.
+func StartStreamProcess(sessionID, projectPath, mcpConfigPath, systemPrompt string, resume bool, worktree bool, provider Provider, cliSessionID ...string) (*StreamProcess, error) {
 	streamsDir, err := db.StreamsDir()
 	if err != nil {
 		return nil, fmt.Errorf("get streams dir: %w", err)
@@ -75,48 +69,24 @@ func StartStreamProcess(sessionID, projectPath, mcpConfigPath, systemPrompt stri
 		return nil, fmt.Errorf("open stream file: %w", err)
 	}
 
-	sessionFlag := "--session-id"
-	resumeID := sessionID
-	if resume {
-		csid := ""
-		if len(claudeSessionID) > 0 {
-			csid = claudeSessionID[0]
-		}
-		if csid != "" {
-			sessionFlag = "--resume"
-			resumeID = csid
-		}
-		// If no Claude session ID found, fall back to starting a new session
-		// (e.g., when the original session failed before a successful turn)
-	} else if len(claudeSessionID) > 0 && claudeSessionID[0] != "" {
-		// Use provided CLI session ID (e.g. fresh ID after context clear)
-		resumeID = claudeSessionID[0]
+	csid := ""
+	if len(cliSessionID) > 0 {
+		csid = cliSessionID[0]
 	}
-	args := []string{
-		"-p",
-		"--verbose",
-		"--output-format", "stream-json",
-		"--input-format", "stream-json",
-		sessionFlag, resumeID,
-		"--dangerously-skip-permissions",
+
+	opts := StreamOpts{
+		SessionID:     sessionID,
+		ProjectPath:   projectPath,
+		MCPConfigPath: mcpConfigPath,
+		SystemPrompt:  systemPrompt,
+		Resume:        resume,
+		Worktree:      worktree,
+		CLISessionID:  csid,
 	}
-	if mcpConfigPath != "" {
-		args = append(args, "--mcp-config", mcpConfigPath)
-	}
-	args = append(args, "--append-system-prompt", systemPrompt)
-	if worktree {
-		args = append(args, "--worktree")
-	}
-	cmd := exec.Command("claude", args...)
-	cmd.Dir = projectPath
-	// Filter out CLAUDECODE env var to avoid nested session detection
-	for _, env := range os.Environ() {
-		if !strings.HasPrefix(env, "CLAUDECODE=") {
-			cmd.Env = append(cmd.Env, env)
-		}
-	}
+
+	cmd := provider.BuildStreamCommand(opts)
 	// Inject OTel environment variables for telemetry collection
-	cmd.Env = appendOTelEnv(cmd.Env)
+	cmd.Env = provider.AppendOTelEnv(cmd.Env, 0)
 
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
@@ -135,14 +105,15 @@ func StartStreamProcess(sessionID, projectPath, mcpConfigPath, systemPrompt stri
 
 	if err := cmd.Start(); err != nil {
 		f.Close()
-		return nil, fmt.Errorf("start claude process: %w", err)
+		return nil, fmt.Errorf("start cli process: %w", err)
 	}
 
 	sp := &StreamProcess{
-		cmd:   cmd,
-		stdin: stdinPipe,
-		done:  make(chan struct{}),
-		file:  f,
+		cmd:      cmd,
+		stdin:    stdinPipe,
+		done:     make(chan struct{}),
+		file:     f,
+		provider: provider,
 	}
 
 	// Read existing lines from file for continuity
@@ -179,14 +150,10 @@ func (sp *StreamProcess) readLoop(stdout io.Reader) {
 			continue
 		}
 
-		// Capture session_id from init message
-		var msg struct {
-			Type      string `json:"type"`
-			SessionID string `json:"session_id"`
-		}
-		if json.Unmarshal([]byte(line), &msg) == nil && msg.Type == "system" && msg.SessionID != "" {
+		// Capture session_id via provider
+		if sid, ok := sp.provider.ParseSessionID([]byte(line)); ok {
 			sp.mu.Lock()
-			sp.sessionID = msg.SessionID
+			sp.sessionID = sid
 			sp.mu.Unlock()
 		}
 
@@ -202,7 +169,7 @@ func (sp *StreamProcess) readLoop(stdout io.Reader) {
 	}
 }
 
-// SessionID returns the claude session ID assigned by the process.
+// SessionID returns the CLI session ID assigned by the process.
 func (sp *StreamProcess) SessionID() string {
 	sp.mu.RLock()
 	defer sp.mu.RUnlock()


### PR DESCRIPTION
## Summary
- Providerインターフェースを導入し、CLI依存(Claude Code)を抽象化
- ClaudeProviderに既存のコマンド構築・セッションIDパース・MCP設定・OTel設定ロジックを移植
- CodexProviderのスタブを追加（将来のOpenAI Codex CLI対応の準備）
- DBにproviderカラムを追加し、APIでセッション作成時にprovider指定が可能に

## Test plan
- [x] `make build` が通ること
- [x] `make test` が通ること
- [ ] 既存のClaude機能（stream/terminalモード）が正常に動作すること

Closes #169