### PR TITLE
feat: フロントエンド provider選択UI + provider表示

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -25,6 +25,7 @@ export const api = {
     projectPath: string;
     prompt?: string;
     outputMode?: "terminal" | "stream";
+    provider?: string;
   }) =>
     request<Session>("/sessions", {
       method: "POST",

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -7,6 +7,7 @@ interface Props {
     projectPath: string;
     prompt?: string;
     outputMode?: "terminal" | "stream";
+    provider?: string;
   }) => void;
 }
 
@@ -15,10 +16,11 @@ export function CreateSession({ onClose, onCreate }: Props) {
   const [projectPath, setProjectPath] = useState("");
   const [prompt, setPrompt] = useState("");
   const [outputMode, setOutputMode] = useState<"terminal" | "stream">("terminal");
+  const [provider, setProvider] = useState("claude");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onCreate({ name, projectPath, prompt: prompt || undefined, outputMode });
+    onCreate({ name, projectPath, prompt: prompt || undefined, outputMode, provider });
   };
 
   return (
@@ -90,6 +92,19 @@ export function CreateSession({ onClose, onCreate }: Props) {
                 Stream
               </label>
             </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Provider
+            </label>
+            <select
+              value={provider}
+              onChange={(e) => setProvider(e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm"
+            >
+              <option value="claude">Claude</option>
+              <option value="codex">Codex</option>
+            </select>
           </div>
           <div className="flex justify-end gap-2">
             <button

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -92,6 +92,15 @@ export function SessionList({ sessions, onRestartController }: Props) {
                       Controller
                     </span>
                   )}
+                  {s.provider && s.provider !== "claude" && (
+                    <span className={`px-1.5 py-0.5 text-[10px] font-medium rounded ${
+                      s.provider === "codex"
+                        ? "bg-green-100 text-green-700"
+                        : "bg-gray-100 text-gray-600"
+                    }`}>
+                      {s.provider.charAt(0).toUpperCase() + s.provider.slice(1)}
+                    </span>
+                  )}
                   <span className="text-xs text-gray-400 ml-auto shrink-0">
                     {s.status}
                   </span>

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -421,6 +421,17 @@ export function SessionPage() {
             <StatusDot status={session.status} />
             <h2 className="text-xl sm:text-2xl font-bold">{session.name}</h2>
             <span className="text-xs text-gray-400">{session.status}</span>
+            {session.provider && (
+              <span className={`px-1.5 py-0.5 text-[10px] font-medium rounded ${
+                session.provider === "codex"
+                  ? "bg-green-100 text-green-700"
+                  : session.provider === "claude"
+                    ? "bg-blue-100 text-blue-700"
+                    : "bg-gray-100 text-gray-600"
+              }`}>
+                {session.provider.charAt(0).toUpperCase() + session.provider.slice(1)}
+              </span>
+            )}
           </>
         ) : (
           <>

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -6,6 +6,7 @@ export interface Session {
   tmuxSession: string;
   status: "working" | "idle" | "paused" | "question_waiting" | "alignment_needed" | "stopped";
   type: "worker" | "controller";
+  provider: string;
   outputMode: "terminal" | "stream";
   currentTask?: string;
   goal?: string;


### PR DESCRIPTION
## Summary
- Session型・APIクライアントに`provider`フィールドを追加
- セッション作成フォームにproviderドロップダウン（Claude / Codex）を追加
- セッション一覧でClaude以外のproviderをバッジ表示（Codex=緑系）
- セッション詳細ヘッダーにproviderバッジを表示（Claude=青、Codex=緑）

## Test plan
- [ ] セッション作成ダイアログでproviderを選択できること
- [ ] Codexを選んで作成したセッションが一覧で緑バッジ表示されること
- [ ] セッション詳細でproviderバッジが表示されること
- [ ] `make build` が通ること

Closes #172