### PR TITLE
feat: CodexProvider stream mode実装

### DIFF
--- a/internal/session/provider_codex.go
+++ b/internal/session/provider_codex.go
@@ -1,11 +1,16 @@
 package session
 
 import (
+	"encoding/json"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/myuon/agmux/internal/db"
 )
 
-// CodexProvider is a stub implementation of Provider for OpenAI Codex CLI.
-// Full implementation will be added in a future PR.
+// CodexProvider implements Provider for OpenAI Codex CLI.
 type CodexProvider struct {
 	command string
 }
@@ -23,36 +28,106 @@ func (p *CodexProvider) Name() ProviderName {
 }
 
 func (p *CodexProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
-	// Stub: will be implemented when Codex CLI support is added
-	cmd := exec.Command(p.command)
+	var args []string
+
+	if opts.Resume && opts.CLISessionID != "" {
+		// Resume an existing session
+		args = append(args, "exec", "resume", opts.CLISessionID,
+			"--json",
+			"--sandbox", "danger-full-access",
+		)
+	} else {
+		// Start a new session
+		args = append(args, "exec",
+			"--json",
+			"--sandbox", "danger-full-access",
+		)
+	}
+
+	if opts.MCPConfigPath != "" {
+		args = append(args, "--mcp-config", opts.MCPConfigPath)
+	}
+	if opts.SystemPrompt != "" {
+		args = append(args, "--instructions", opts.SystemPrompt)
+	}
+
+	// For non-resume, the prompt is required as the last positional argument.
+	// We pass an initial prompt via stdin, so use a placeholder here.
+	if !(opts.Resume && opts.CLISessionID != "") {
+		args = append(args, "Follow the instructions given via stdin")
+	}
+
+	cmd := exec.Command(p.command, args...)
 	cmd.Dir = opts.ProjectPath
+	// Filter out CLAUDECODE env var to avoid nested session detection
+	for _, env := range os.Environ() {
+		if !strings.HasPrefix(env, "CLAUDECODE=") {
+			cmd.Env = append(cmd.Env, env)
+		}
+	}
 	return cmd
 }
 
 func (p *CodexProvider) ParseSessionID(jsonlLine []byte) (string, bool) {
-	// Stub
+	// Codex emits: {"type":"thread.started","thread":{"id":"thr_xxx"}}
+	var msg struct {
+		Type   string `json:"type"`
+		Thread struct {
+			ID string `json:"id"`
+		} `json:"thread"`
+	}
+	if json.Unmarshal(jsonlLine, &msg) == nil && msg.Type == "thread.started" && msg.Thread.ID != "" {
+		return msg.Thread.ID, true
+	}
 	return "", false
 }
 
 func (p *CodexProvider) BuildTerminalCommand(opts TerminalOpts) string {
-	// Stub
-	return p.command
+	cmd := p.command + " exec --json --sandbox danger-full-access"
+	if opts.Resume {
+		// TODO: terminal resume for Codex is not yet fully supported
+		cmd += " resume " + opts.SessionID
+	}
+	if opts.MCPConfigPath != "" {
+		cmd += " --mcp-config " + opts.MCPConfigPath
+	}
+	if opts.SystemPrompt != "" {
+		cmd += " --instructions " + shellQuote(opts.SystemPrompt)
+	}
+	return cmd
 }
 
 func (p *CodexProvider) SetupMCP(sessionID string, port int) (string, error) {
-	// Codex doesn't support MCP yet; reuse the same config format for now
 	return writeMCPConfig(sessionID, port)
 }
 
 func (p *CodexProvider) CleanupMCP(sessionID string) error {
-	return nil
+	dir, err := db.AgmuxDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "mcp-configs", sessionID+".json")
+	return os.Remove(path)
 }
 
 func (p *CodexProvider) AppendOTelEnv(env []string, port int) []string {
-	// Stub: no OTel for Codex yet
+	// Codex CLI does not support OTel yet
 	return env
 }
 
 func (p *CodexProvider) OTelEnvPrefix(port int) string {
 	return ""
+}
+
+// NewCodexThreadStartedJSON creates a JSONL line for a thread.started event (for testing).
+func NewCodexThreadStartedJSON(threadID string) string {
+	evt := struct {
+		Type   string `json:"type"`
+		Thread struct {
+			ID string `json:"id"`
+		} `json:"thread"`
+	}{Type: "thread.started"}
+	evt.Thread.ID = threadID
+	b, _ := json.Marshal(evt)
+	return string(b)
 }

--- a/internal/session/provider_codex_test.go
+++ b/internal/session/provider_codex_test.go
@@ -1,0 +1,252 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCodexProvider_Name(t *testing.T) {
+	p := NewCodexProvider("")
+	if p.Name() != ProviderCodex {
+		t.Errorf("expected %q, got %q", ProviderCodex, p.Name())
+	}
+}
+
+func TestCodexProvider_DefaultCommand(t *testing.T) {
+	p := NewCodexProvider("")
+	if p.command != "codex" {
+		t.Errorf("expected default command %q, got %q", "codex", p.command)
+	}
+}
+
+func TestCodexProvider_CustomCommand(t *testing.T) {
+	p := NewCodexProvider("my-codex")
+	if p.command != "my-codex" {
+		t.Errorf("expected command %q, got %q", "my-codex", p.command)
+	}
+}
+
+func TestCodexProvider_BuildStreamCommand_NewSession(t *testing.T) {
+	p := NewCodexProvider("codex")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:   "sess-1",
+		ProjectPath: "/tmp/project",
+		SystemPrompt: "test prompt",
+	})
+
+	args := cmd.Args
+	if args[0] != "codex" {
+		t.Errorf("expected command %q, got %q", "codex", args[0])
+	}
+	if cmd.Dir != "/tmp/project" {
+		t.Errorf("expected dir %q, got %q", "/tmp/project", cmd.Dir)
+	}
+
+	// Check required args are present
+	argsStr := joinArgs(args[1:])
+	for _, expected := range []string{"exec", "--json", "--sandbox", "danger-full-access"} {
+		if !containsArg(args[1:], expected) {
+			t.Errorf("expected args to contain %q, got: %s", expected, argsStr)
+		}
+	}
+}
+
+func TestCodexProvider_BuildStreamCommand_Resume(t *testing.T) {
+	p := NewCodexProvider("codex")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:    "sess-1",
+		ProjectPath:  "/tmp/project",
+		Resume:       true,
+		CLISessionID: "thr_abc123",
+	})
+
+	args := cmd.Args
+	// Should contain "resume" and the session ID
+	if !containsArg(args, "resume") {
+		t.Errorf("expected args to contain 'resume', got: %v", args)
+	}
+	if !containsArg(args, "thr_abc123") {
+		t.Errorf("expected args to contain session ID 'thr_abc123', got: %v", args)
+	}
+}
+
+func TestCodexProvider_BuildStreamCommand_WithMCP(t *testing.T) {
+	p := NewCodexProvider("codex")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:     "sess-1",
+		ProjectPath:   "/tmp/project",
+		MCPConfigPath: "/tmp/mcp.json",
+	})
+
+	args := cmd.Args
+	found := false
+	for i, a := range args {
+		if a == "--mcp-config" && i+1 < len(args) && args[i+1] == "/tmp/mcp.json" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --mcp-config /tmp/mcp.json in args, got: %v", args)
+	}
+}
+
+func TestCodexProvider_BuildStreamCommand_WithInstructions(t *testing.T) {
+	p := NewCodexProvider("codex")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:    "sess-1",
+		ProjectPath:  "/tmp/project",
+		SystemPrompt: "be helpful",
+	})
+
+	args := cmd.Args
+	found := false
+	for i, a := range args {
+		if a == "--instructions" && i+1 < len(args) && args[i+1] == "be helpful" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --instructions 'be helpful' in args, got: %v", args)
+	}
+}
+
+func TestCodexProvider_ParseSessionID(t *testing.T) {
+	p := NewCodexProvider("")
+
+	tests := []struct {
+		name     string
+		input    string
+		wantID   string
+		wantOK   bool
+	}{
+		{
+			name:   "thread.started event",
+			input:  `{"type":"thread.started","thread":{"id":"thr_abc123"}}`,
+			wantID: "thr_abc123",
+			wantOK: true,
+		},
+		{
+			name:   "other event type",
+			input:  `{"type":"turn.started","turn":{"id":"turn_xyz"}}`,
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "invalid JSON",
+			input:  `not json`,
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "thread.started without id",
+			input:  `{"type":"thread.started","thread":{}}`,
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "claude system event should not match",
+			input:  `{"type":"system","session_id":"sess-abc"}`,
+			wantID: "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok := p.ParseSessionID([]byte(tt.input))
+			if id != tt.wantID || ok != tt.wantOK {
+				t.Errorf("ParseSessionID(%q) = (%q, %v), want (%q, %v)",
+					tt.input, id, ok, tt.wantID, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestCodexProvider_BuildTerminalCommand(t *testing.T) {
+	p := NewCodexProvider("codex")
+	cmd := p.BuildTerminalCommand(TerminalOpts{
+		SessionID:     "sess-1",
+		MCPConfigPath: "/tmp/mcp.json",
+		SystemPrompt:  "test",
+	})
+
+	if cmd == "" {
+		t.Error("expected non-empty command")
+	}
+	// Should contain key parts
+	for _, part := range []string{"codex", "exec", "--json", "--sandbox", "danger-full-access"} {
+		if !containsStr(cmd, part) {
+			t.Errorf("expected command to contain %q, got: %s", part, cmd)
+		}
+	}
+}
+
+func TestNewCodexThreadStartedJSON(t *testing.T) {
+	line := NewCodexThreadStartedJSON("thr_test123")
+	var evt struct {
+		Type   string `json:"type"`
+		Thread struct {
+			ID string `json:"id"`
+		} `json:"thread"`
+	}
+	if err := json.Unmarshal([]byte(line), &evt); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if evt.Type != "thread.started" {
+		t.Errorf("expected type 'thread.started', got %q", evt.Type)
+	}
+	if evt.Thread.ID != "thr_test123" {
+		t.Errorf("expected thread.id 'thr_test123', got %q", evt.Thread.ID)
+	}
+}
+
+func TestCodexProvider_EnvFiltersCLAUDECODE(t *testing.T) {
+	p := NewCodexProvider("codex")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:   "sess-1",
+		ProjectPath: "/tmp",
+	})
+
+	for _, env := range cmd.Env {
+		if len(env) >= 10 && env[:10] == "CLAUDECODE" {
+			t.Errorf("CLAUDECODE env var should be filtered out, found: %s", env)
+		}
+	}
+}
+
+// helpers
+
+func containsArg(args []string, target string) bool {
+	for _, a := range args {
+		if a == target {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func joinArgs(args []string) string {
+	result := ""
+	for i, a := range args {
+		if i > 0 {
+			result += " "
+		}
+		result += a
+	}
+	return result
+}


### PR DESCRIPTION
## Summary
- CodexProvider のスタブを本実装に置き換え（stream mode）
- `codex exec --json --sandbox danger-full-access` によるJSONLストリームコマンド構築
- `thread.started` イベントからセッションID（thread.id）を抽出する ParseSessionID 実装
- resume時は `codex exec resume <SESSION_ID>` パターンで既存セッションを再開
- `--mcp-config`, `--instructions` オプション対応
- CleanupMCP でMCP設定ファイルの削除を実装
- テストケース追加（コマンド構築、セッションID解析、環境変数フィルタリング等）

Closes #170

## Test plan
- [x] `make build` が通ること
- [x] `make test` が通ること
- [ ] Codex CLIがインストールされた環境で実際のストリーム動作を確認