### PR TITLE
feat: normalize Codex stream events to Claude-compatible format

### DIFF
--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -50,6 +50,11 @@ type Provider interface {
 	OTelEnvPrefix(port int) string
 	// Name returns the provider name.
 	Name() ProviderName
+	// NormalizeStreamLine converts a provider-specific JSONL line into
+	// Claude-compatible stream-json format. If the line should be kept as-is,
+	// it returns the original bytes unchanged. If the line should be dropped,
+	// it returns nil.
+	NormalizeStreamLine(line []byte) []byte
 }
 
 // GetProvider returns a Provider instance for the given name.

--- a/internal/session/provider_claude.go
+++ b/internal/session/provider_claude.go
@@ -141,6 +141,11 @@ func (p *ClaudeProvider) AppendOTelEnv(env []string, port int) []string {
 	return env
 }
 
+func (p *ClaudeProvider) NormalizeStreamLine(line []byte) []byte {
+	// Claude lines are already in the expected format; return as-is.
+	return line
+}
+
 func (p *ClaudeProvider) OTelEnvPrefix(port int) string {
 	if port == 0 {
 		port = 4321

--- a/internal/session/provider_codex.go
+++ b/internal/session/provider_codex.go
@@ -124,6 +124,103 @@ func (p *CodexProvider) OTelEnvPrefix(port int) string {
 	return ""
 }
 
+// NormalizeStreamLine converts a Codex JSONL event into Claude-compatible
+// stream-json format so the frontend can render it uniformly.
+func (p *CodexProvider) NormalizeStreamLine(line []byte) []byte {
+	var envelope struct {
+		Type string          `json:"type"`
+		Item json.RawMessage `json:"item"`
+	}
+	if json.Unmarshal(line, &envelope) != nil {
+		return line
+	}
+
+	switch envelope.Type {
+	case "item.completed":
+		return p.normalizeItemCompleted(envelope.Item, line)
+	case "item.started":
+		// Skip in-progress events; they have no useful content yet.
+		return nil
+	default:
+		// thread.started, turn.started, turn.completed, etc. – keep as-is.
+		return line
+	}
+}
+
+func (p *CodexProvider) normalizeItemCompleted(raw json.RawMessage, original []byte) []byte {
+	var item struct {
+		Type             string  `json:"type"`
+		Text             string  `json:"text"`
+		Command          string  `json:"command"`
+		AggregatedOutput string  `json:"aggregated_output"`
+		ExitCode         *int    `json:"exit_code"`
+		Status           string  `json:"status"`
+	}
+	if json.Unmarshal(raw, &item) != nil {
+		return original
+	}
+
+	switch item.Type {
+	case "agent_message":
+		return p.buildAssistantText(item.Text)
+	case "command_execution":
+		return p.buildAssistantToolUse(item.Command, item.AggregatedOutput)
+	default:
+		return original
+	}
+}
+
+func (p *CodexProvider) buildAssistantText(text string) []byte {
+	msg := struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string `json:"role"`
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"message"`
+	}{Type: "assistant"}
+	msg.Message.Role = "assistant"
+	msg.Message.Content = []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}{{Type: "text", Text: text}}
+	b, _ := json.Marshal(msg)
+	return b
+}
+
+func (p *CodexProvider) buildAssistantToolUse(command, output string) []byte {
+	type toolUseBlock struct {
+		Type  string            `json:"type"`
+		Name  string            `json:"name,omitempty"`
+		Input map[string]string `json:"input,omitempty"`
+	}
+	type toolResultBlock struct {
+		Type    string `json:"type"`
+		Content string `json:"content"`
+	}
+
+	// We need a heterogeneous content array, so use json.RawMessage.
+	tu := toolUseBlock{Type: "tool_use", Name: "Bash", Input: map[string]string{"command": command}}
+	tr := toolResultBlock{Type: "tool_result", Content: output}
+
+	tuJSON, _ := json.Marshal(tu)
+	trJSON, _ := json.Marshal(tr)
+
+	msg := struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string            `json:"role"`
+			Content []json.RawMessage `json:"content"`
+		} `json:"message"`
+	}{Type: "assistant"}
+	msg.Message.Role = "assistant"
+	msg.Message.Content = []json.RawMessage{tuJSON, trJSON}
+	b, _ := json.Marshal(msg)
+	return b
+}
+
 // NewCodexThreadStartedJSON creates a JSONL line for a thread.started event (for testing).
 func NewCodexThreadStartedJSON(threadID string) string {
 	evt := struct {

--- a/internal/session/provider_codex_test.go
+++ b/internal/session/provider_codex_test.go
@@ -327,3 +327,97 @@ func TestCodexBuildTerminalCommand_NoMCPConfig(t *testing.T) {
 		t.Errorf("should not have --mcp-config when path is empty, got %s", cmd)
 	}
 }
+
+func TestCodexProvider_NormalizeStreamLine(t *testing.T) {
+	p := NewCodexProvider("")
+
+	tests := []struct {
+		name     string
+		input    string
+		wantNil  bool   // true if the line should be dropped
+		wantJSON string // expected JSON (empty means keep original)
+	}{
+		{
+			name:  "agent_message becomes assistant text",
+			input: `{"type":"item.completed","item":{"type":"agent_message","text":"Hello world"}}`,
+			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello world"}]}}`,
+		},
+		{
+			name:  "command_execution becomes tool_use + tool_result",
+			input: `{"type":"item.completed","item":{"type":"command_execution","command":"ls","aggregated_output":"file1\nfile2","exit_code":0,"status":"completed"}}`,
+			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}},{"type":"tool_result","content":"file1\nfile2"}]}}`,
+		},
+		{
+			name:    "item.started is dropped",
+			input:   `{"type":"item.started","item":{"type":"command_execution","command":"ls","aggregated_output":"","exit_code":null,"status":"in_progress"}}`,
+			wantNil: true,
+		},
+		{
+			name:  "turn.started passes through",
+			input: `{"type":"turn.started"}`,
+		},
+		{
+			name:  "turn.completed passes through",
+			input: `{"type":"turn.completed","usage":{"input_tokens":123,"output_tokens":456}}`,
+		},
+		{
+			name:  "thread.started passes through",
+			input: `{"type":"thread.started","thread":{"id":"thr_xxx"}}`,
+		},
+		{
+			name:  "invalid JSON passes through",
+			input: `not json at all`,
+		},
+		{
+			name:  "unknown item type passes through",
+			input: `{"type":"item.completed","item":{"type":"unknown_type","data":"something"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.NormalizeStreamLine([]byte(tt.input))
+
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil, got %s", string(result))
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+
+			if tt.wantJSON != "" {
+				// Compare as parsed JSON for stable comparison
+				var got, want interface{}
+				if err := json.Unmarshal(result, &got); err != nil {
+					t.Fatalf("failed to parse result JSON: %v\nresult: %s", err, string(result))
+				}
+				if err := json.Unmarshal([]byte(tt.wantJSON), &want); err != nil {
+					t.Fatalf("failed to parse expected JSON: %v", err)
+				}
+				gotBytes, _ := json.Marshal(got)
+				wantBytes, _ := json.Marshal(want)
+				if string(gotBytes) != string(wantBytes) {
+					t.Errorf("JSON mismatch\ngot:  %s\nwant: %s", string(gotBytes), string(wantBytes))
+				}
+			} else {
+				// Should be unchanged
+				if string(result) != tt.input {
+					t.Errorf("expected line to pass through unchanged\ngot:  %s\nwant: %s", string(result), tt.input)
+				}
+			}
+		})
+	}
+}
+
+func TestClaudeProvider_NormalizeStreamLine(t *testing.T) {
+	p := NewClaudeProvider("")
+	input := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}`
+	result := p.NormalizeStreamLine([]byte(input))
+	if string(result) != input {
+		t.Errorf("ClaudeProvider should pass through unchanged\ngot:  %s\nwant: %s", string(result), input)
+	}
+}

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -150,16 +150,25 @@ func (sp *StreamProcess) readLoop(stdout io.Reader) {
 			continue
 		}
 
-		// Capture session_id via provider
+		// Capture session_id via provider (before normalization so
+		// provider-specific events like thread.started are still visible).
 		if sid, ok := sp.provider.ParseSessionID([]byte(line)); ok {
 			sp.mu.Lock()
 			sp.sessionID = sid
 			sp.mu.Unlock()
 		}
 
+		// Normalize the line into Claude-compatible format.
+		normalized := sp.provider.NormalizeStreamLine([]byte(line))
+		if normalized == nil {
+			// Provider says to drop this line (e.g. in-progress events).
+			continue
+		}
+		normalizedStr := string(normalized)
+
 		sp.mu.Lock()
-		sp.lines = append(sp.lines, line)
-		sp.file.WriteString(line + "\n")
+		sp.lines = append(sp.lines, normalizedStr)
+		sp.file.WriteString(normalizedStr + "\n")
 		sp.file.Sync()
 		sp.mu.Unlock()
 	}


### PR DESCRIPTION
## Summary
- Add `NormalizeStreamLine` to `Provider` interface to convert Codex JSONL events into Claude stream-json format before DB storage
- Codex `agent_message` events become `assistant` text blocks, `command_execution` becomes `tool_use`+`tool_result` blocks
- `item.started` (in-progress) events are dropped; other events (`thread.started`, `turn.*`) pass through unchanged
- Claude provider returns lines as-is (no-op implementation)

Closes #191

## Test plan
- [x] Unit tests for all Codex event types (agent_message, command_execution, item.started, pass-through events)
- [x] Unit test verifying Claude provider is a no-op
- [x] `make build` passes
- [x] `make test` passes (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)