### PR TITLE
feat: Codex stream mode followup message support

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -139,21 +139,34 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 
 	if outputMode == OutputModeStream {
 		// Stream mode: start Go subprocess instead of CLI TUI
-		sp, err := StartStreamProcess(id, projectPath, mcpConfigPath, m.systemPrompt, false, worktree, provider)
-		if err != nil {
-			_ = m.tmux.KillSession(name)
-			return nil, fmt.Errorf("start stream process: %w", err)
+		var sp *StreamProcess
+		if pn == ProviderCodex && prompt != "" {
+			// Codex: pass initial prompt as command-line argument (not stdin)
+			var err error
+			sp, err = StartStreamProcessWithPrompt(id, projectPath, mcpConfigPath, m.systemPrompt, prompt, false, worktree, provider)
+			if err != nil {
+				_ = m.tmux.KillSession(name)
+				return nil, fmt.Errorf("start stream process: %w", err)
+			}
+			// Record the user message in the stream for UI display
+			sp.recordUserMessage(prompt)
+		} else {
+			var err error
+			sp, err = StartStreamProcess(id, projectPath, mcpConfigPath, m.systemPrompt, false, worktree, provider)
+			if err != nil {
+				_ = m.tmux.KillSession(name)
+				return nil, fmt.Errorf("start stream process: %w", err)
+			}
+			// Send initial prompt via stream process (stdin for Claude)
+			if prompt != "" {
+				if err := sp.Send(prompt); err != nil {
+					return nil, fmt.Errorf("send initial prompt: %w", err)
+				}
+			}
 		}
 		m.streamMu.Lock()
 		m.streamProcesses[id] = sp
 		m.streamMu.Unlock()
-
-		// Send initial prompt via stream process
-		if prompt != "" {
-			if err := sp.Send(prompt); err != nil {
-				return nil, fmt.Errorf("send initial prompt: %w", err)
-			}
-		}
 	} else {
 		// Terminal mode: launch CLI TUI in tmux
 		time.Sleep(300 * time.Millisecond)

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -21,6 +21,7 @@ type StreamOpts struct {
 	Resume         bool
 	Worktree       bool
 	CLISessionID   string // provider-specific session ID (for resume)
+	InitialPrompt  string // initial user prompt (used by Codex as positional arg)
 }
 
 // TerminalOpts contains parameters for building a terminal-mode command.

--- a/internal/session/provider_codex.go
+++ b/internal/session/provider_codex.go
@@ -52,9 +52,17 @@ func (p *CodexProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
 	}
 
 	// For non-resume, the prompt is required as the last positional argument.
-	// We pass an initial prompt via stdin, so use a placeholder here.
 	if !(opts.Resume && opts.CLISessionID != "") {
-		args = append(args, "Follow the instructions given via stdin")
+		prompt := opts.InitialPrompt
+		if prompt == "" {
+			prompt = "Follow the instructions given via stdin"
+		}
+		args = append(args, prompt)
+	}
+
+	// For resume, a follow-up message can be passed as the last positional arg.
+	if opts.Resume && opts.CLISessionID != "" && opts.InitialPrompt != "" {
+		args = append(args, opts.InitialPrompt)
 	}
 
 	cmd := exec.Command(p.command, args...)

--- a/internal/session/provider_codex_test.go
+++ b/internal/session/provider_codex_test.go
@@ -203,6 +203,61 @@ func TestNewCodexThreadStartedJSON(t *testing.T) {
 	}
 }
 
+func TestCodexProvider_BuildStreamCommand_WithInitialPrompt(t *testing.T) {
+	p := NewCodexProvider("codex")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:      "sess-1",
+		ProjectPath:    "/tmp/project",
+		InitialPrompt:  "hello world",
+	})
+
+	args := cmd.Args
+	// The last arg should be the initial prompt, not the placeholder
+	lastArg := args[len(args)-1]
+	if lastArg != "hello world" {
+		t.Errorf("expected last arg to be initial prompt %q, got %q", "hello world", lastArg)
+	}
+}
+
+func TestCodexProvider_BuildStreamCommand_ResumeWithFollowup(t *testing.T) {
+	p := NewCodexProvider("codex")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:      "sess-1",
+		ProjectPath:    "/tmp/project",
+		Resume:         true,
+		CLISessionID:   "thr_abc123",
+		InitialPrompt:  "follow up message",
+	})
+
+	args := cmd.Args
+	// Should contain resume and session ID
+	if !containsArg(args, "resume") {
+		t.Errorf("expected args to contain 'resume', got: %v", args)
+	}
+	if !containsArg(args, "thr_abc123") {
+		t.Errorf("expected args to contain session ID, got: %v", args)
+	}
+	// Last arg should be the followup message
+	lastArg := args[len(args)-1]
+	if lastArg != "follow up message" {
+		t.Errorf("expected last arg to be followup message %q, got %q", "follow up message", lastArg)
+	}
+}
+
+func TestCodexProvider_BuildStreamCommand_DefaultPlaceholder(t *testing.T) {
+	p := NewCodexProvider("codex")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:   "sess-1",
+		ProjectPath: "/tmp/project",
+	})
+
+	args := cmd.Args
+	lastArg := args[len(args)-1]
+	if lastArg != "Follow the instructions given via stdin" {
+		t.Errorf("expected default placeholder prompt, got %q", lastArg)
+	}
+}
+
 func TestCodexProvider_EnvFiltersCLAUDECODE(t *testing.T) {
 	p := NewCodexProvider("codex")
 	cmd := p.BuildStreamCommand(StreamOpts{

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -25,6 +25,9 @@ type StreamProcess struct {
 	file      *os.File
 	sessionID string // CLI session ID (may differ from agmux session ID after resume)
 	provider  Provider
+
+	// Fields for Codex followup support (process restart on new messages)
+	streamOpts StreamOpts // saved opts for rebuilding commands
 }
 
 // ReadCLISessionID reads the CLI-assigned session ID from a stream JSONL file.
@@ -57,18 +60,8 @@ func ReadCLISessionID(agmuxSessionID string, provider Provider) string {
 // If resume is true, it uses --resume to continue an existing conversation;
 // otherwise it uses --session-id to start a new one.
 // cliSessionID is only used when resume=true -- it's the CLI-assigned session ID.
+// initialPrompt is an optional initial prompt (used by Codex as positional arg).
 func StartStreamProcess(sessionID, projectPath, mcpConfigPath, systemPrompt string, resume bool, worktree bool, provider Provider, cliSessionID ...string) (*StreamProcess, error) {
-	streamsDir, err := db.StreamsDir()
-	if err != nil {
-		return nil, fmt.Errorf("get streams dir: %w", err)
-	}
-
-	streamPath := filepath.Join(streamsDir, sessionID+".jsonl")
-	f, err := os.OpenFile(streamPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return nil, fmt.Errorf("open stream file: %w", err)
-	}
-
 	csid := ""
 	if len(cliSessionID) > 0 {
 		csid = cliSessionID[0]
@@ -82,6 +75,43 @@ func StartStreamProcess(sessionID, projectPath, mcpConfigPath, systemPrompt stri
 		Resume:        resume,
 		Worktree:      worktree,
 		CLISessionID:  csid,
+	}
+
+	return startStreamProcessWithOpts(opts, provider)
+}
+
+// StartStreamProcessWithPrompt is like StartStreamProcess but also sets the initial prompt.
+// This is used by Codex provider to pass the prompt as a command-line argument.
+func StartStreamProcessWithPrompt(sessionID, projectPath, mcpConfigPath, systemPrompt, initialPrompt string, resume bool, worktree bool, provider Provider, cliSessionID ...string) (*StreamProcess, error) {
+	csid := ""
+	if len(cliSessionID) > 0 {
+		csid = cliSessionID[0]
+	}
+
+	opts := StreamOpts{
+		SessionID:      sessionID,
+		ProjectPath:    projectPath,
+		MCPConfigPath:  mcpConfigPath,
+		SystemPrompt:   systemPrompt,
+		InitialPrompt:  initialPrompt,
+		Resume:         resume,
+		Worktree:       worktree,
+		CLISessionID:   csid,
+	}
+
+	return startStreamProcessWithOpts(opts, provider)
+}
+
+func startStreamProcessWithOpts(opts StreamOpts, provider Provider) (*StreamProcess, error) {
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		return nil, fmt.Errorf("get streams dir: %w", err)
+	}
+
+	streamPath := filepath.Join(streamsDir, opts.SessionID+".jsonl")
+	f, err := os.OpenFile(streamPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open stream file: %w", err)
 	}
 
 	cmd := provider.BuildStreamCommand(opts)
@@ -109,11 +139,12 @@ func StartStreamProcess(sessionID, projectPath, mcpConfigPath, systemPrompt stri
 	}
 
 	sp := &StreamProcess{
-		cmd:      cmd,
-		stdin:    stdinPipe,
-		done:     make(chan struct{}),
-		file:     f,
-		provider: provider,
+		cmd:        cmd,
+		stdin:      stdinPipe,
+		done:       make(chan struct{}),
+		file:       f,
+		provider:   provider,
+		streamOpts: opts,
 	}
 
 	// Read existing lines from file for continuity
@@ -199,7 +230,20 @@ func (sp *StreamProcess) Send(message string) error {
 // SendWithImages writes a user message with optional images to the process stdin in stream-json format.
 // When images are provided, content is sent as an array of content blocks (text + image blocks).
 // When no images are provided, content is sent as a plain string for backward compatibility.
+//
+// For Codex provider: since codex exec exits after processing, followup messages
+// require restarting the process with "codex exec resume <session_id> <message>".
 func (sp *StreamProcess) SendWithImages(message string, images []ImageData) error {
+	// For Codex, check if the process has finished and restart for followup.
+	if sp.provider.Name() == ProviderCodex {
+		return sp.sendCodex(message)
+	}
+
+	return sp.sendClaude(message, images)
+}
+
+// sendClaude handles message sending for Claude provider (stdin-based).
+func (sp *StreamProcess) sendClaude(message string, images []ImageData) error {
 	var data []byte
 	var err error
 
@@ -274,6 +318,114 @@ func (sp *StreamProcess) SendWithImages(message string, images []ImageData) erro
 
 	_, err = fmt.Fprintf(sp.stdin, "%s\n", data)
 	return err
+}
+
+// sendCodex handles message sending for Codex provider.
+// Codex exec exits after each prompt, so followup messages require
+// spawning a new "codex exec resume <session_id> <message>" process.
+func (sp *StreamProcess) sendCodex(message string) error {
+	// Record the user message to memory buffer and JSONL file
+	userMsg := struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+	}{Type: "user"}
+	userMsg.Message.Role = "user"
+	userMsg.Message.Content = message
+	data, err := json.Marshal(userMsg)
+	if err != nil {
+		return fmt.Errorf("marshal message: %w", err)
+	}
+	line := string(data)
+	sp.mu.Lock()
+	sp.lines = append(sp.lines, line)
+	sp.file.WriteString(line + "\n")
+	sp.file.Sync()
+	sp.mu.Unlock()
+
+	// Wait for current process to finish (with timeout)
+	select {
+	case <-sp.done:
+		// Process has finished, we can restart
+	case <-time.After(10 * time.Minute):
+		return fmt.Errorf("timeout waiting for codex process to finish")
+	}
+
+	// Get the CLI session ID for resume
+	sp.mu.RLock()
+	cliSessionID := sp.sessionID
+	sp.mu.RUnlock()
+
+	if cliSessionID == "" {
+		return fmt.Errorf("no CLI session ID available for codex resume")
+	}
+
+	return sp.restartForCodex(message, cliSessionID)
+}
+
+// restartForCodex spawns a new codex exec resume process for a followup message.
+func (sp *StreamProcess) restartForCodex(message, cliSessionID string) error {
+	// Clean up the old process (already exited since done channel was closed)
+	sp.stdin.Close()
+	_ = sp.cmd.Wait()
+
+	opts := sp.streamOpts
+	opts.Resume = true
+	opts.CLISessionID = cliSessionID
+	opts.InitialPrompt = message
+
+	cmd := sp.provider.BuildStreamCommand(opts)
+	cmd.Env = sp.provider.AppendOTelEnv(cmd.Env, 0)
+
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("stdin pipe for codex resume: %w", err)
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe for codex resume: %w", err)
+	}
+
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start codex resume process: %w", err)
+	}
+
+	sp.mu.Lock()
+	sp.cmd = cmd
+	sp.stdin = stdinPipe
+	sp.done = make(chan struct{})
+	sp.mu.Unlock()
+
+	go sp.readLoop(stdoutPipe)
+
+	return nil
+}
+
+// recordUserMessage records a user message to the stream file and memory buffer
+// without sending it to stdin. Used when the prompt is passed as a command-line arg.
+func (sp *StreamProcess) recordUserMessage(message string) {
+	msg := struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+	}{Type: "user"}
+	msg.Message.Role = "user"
+	msg.Message.Content = message
+	data, _ := json.Marshal(msg)
+	line := string(data)
+
+	sp.mu.Lock()
+	sp.lines = append(sp.lines, line)
+	sp.file.WriteString(line + "\n")
+	sp.file.Sync()
+	sp.mu.Unlock()
 }
 
 // GetLines returns the last N lines from the accumulated output.


### PR DESCRIPTION
## Summary
- Passes initial prompt as a command-line argument to `codex exec` instead of placeholder text
- Supports followup messages by waiting for the current codex process to finish, then spawning `codex exec resume <session_id> <message>`
- Appends new process output to the same stream file for seamless UI continuity

Closes #193

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes (including new tests for InitialPrompt and resume-with-followup)
- [ ] Manual test: create a Codex stream session and verify initial prompt works
- [ ] Manual test: send a followup message and verify new codex exec resume process starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)