### PR TITLE
fix: Codex CLI session ID not preserved across resume/recovery

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -496,7 +496,22 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			provider := m.getProvider(s.Provider)
 			mcpPath, _ := provider.SetupMCP(s.ID, m.apiPort)
 			cliSessionID := ReadCLISessionID(s.ID, provider)
+
 			var err error
+			if s.Provider == ProviderCodex && cliSessionID != "" {
+				// For Codex, start resume directly with the prompt as a positional arg.
+				// Codex exec exits after processing, so we can't send via stdin later.
+				sp, err = StartStreamProcessWithPrompt(s.ID, s.ProjectPath, mcpPath, m.systemPrompt, text, true, false, provider, cliSessionID)
+				if err != nil {
+					return fmt.Errorf("restart stream process: %w", err)
+				}
+				sp.recordUserMessage(text)
+				m.streamMu.Lock()
+				m.streamProcesses[id] = sp
+				m.streamMu.Unlock()
+				return nil
+			}
+
 			sp, err = StartStreamProcess(s.ID, s.ProjectPath, mcpPath, m.systemPrompt, true, false, provider, cliSessionID)
 			if err != nil {
 				return fmt.Errorf("restart stream process: %w", err)

--- a/internal/session/provider_codex.go
+++ b/internal/session/provider_codex.go
@@ -223,14 +223,15 @@ func (p *CodexProvider) buildAssistantToolUse(command, output string) []byte {
 }
 
 // NewCodexThreadStartedJSON creates a JSONL line for a thread.started event (for testing).
+// Matches real Codex CLI output format: {"type":"thread.started","thread_id":"..."}
 func NewCodexThreadStartedJSON(threadID string) string {
 	evt := struct {
-		Type   string `json:"type"`
-		Thread struct {
-			ID string `json:"id"`
-		} `json:"thread"`
-	}{Type: "thread.started"}
-	evt.Thread.ID = threadID
+		Type     string `json:"type"`
+		ThreadID string `json:"thread_id"`
+	}{
+		Type:     "thread.started",
+		ThreadID: threadID,
+	}
 	b, _ := json.Marshal(evt)
 	return string(b)
 }

--- a/internal/session/provider_codex_test.go
+++ b/internal/session/provider_codex_test.go
@@ -182,10 +182,8 @@ func TestCodexProvider_BuildTerminalCommand(t *testing.T) {
 func TestNewCodexThreadStartedJSON(t *testing.T) {
 	line := NewCodexThreadStartedJSON("thr_test123")
 	var evt struct {
-		Type   string `json:"type"`
-		Thread struct {
-			ID string `json:"id"`
-		} `json:"thread"`
+		Type     string `json:"type"`
+		ThreadID string `json:"thread_id"`
 	}
 	if err := json.Unmarshal([]byte(line), &evt); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
@@ -193,8 +191,21 @@ func TestNewCodexThreadStartedJSON(t *testing.T) {
 	if evt.Type != "thread.started" {
 		t.Errorf("expected type 'thread.started', got %q", evt.Type)
 	}
-	if evt.Thread.ID != "thr_test123" {
-		t.Errorf("expected thread.id 'thr_test123', got %q", evt.Thread.ID)
+	if evt.ThreadID != "thr_test123" {
+		t.Errorf("expected thread_id 'thr_test123', got %q", evt.ThreadID)
+	}
+}
+
+func TestNewCodexThreadStartedJSON_ParseSessionID(t *testing.T) {
+	// Verify that NewCodexThreadStartedJSON output is parseable by ParseSessionID
+	p := NewCodexProvider("")
+	line := NewCodexThreadStartedJSON("019cdd95-78da-7f33-8521-ae4ca1eb40d7")
+	id, ok := p.ParseSessionID([]byte(line))
+	if !ok {
+		t.Fatal("ParseSessionID should return true for NewCodexThreadStartedJSON output")
+	}
+	if id != "019cdd95-78da-7f33-8521-ae4ca1eb40d7" {
+		t.Errorf("expected thread ID '019cdd95-78da-7f33-8521-ae4ca1eb40d7', got %q", id)
 	}
 }
 

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -143,6 +143,7 @@ func startStreamProcessWithOpts(opts StreamOpts, provider Provider) (*StreamProc
 		stdin:      stdinPipe,
 		done:       make(chan struct{}),
 		file:       f,
+		sessionID:  opts.CLISessionID, // Initialize from opts so resume/recovery can use it immediately
 		provider:   provider,
 		streamOpts: opts,
 	}

--- a/internal/session/stream_process_codex_test.go
+++ b/internal/session/stream_process_codex_test.go
@@ -1,0 +1,268 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/myuon/agmux/internal/db"
+)
+
+func TestReadCLISessionID_Codex(t *testing.T) {
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	provider := NewCodexProvider("")
+	sessionID := "test-codex-read-cli-" + t.Name()
+
+	// Write a JSONL file that simulates Codex output (normalized format)
+	streamPath := filepath.Join(streamsDir, sessionID+".jsonl")
+	content := `{"type":"user","message":{"role":"user","content":"hello"}}
+{"type":"thread.started","thread_id":"019cdd95-78da-7f33-8521-ae4ca1eb40d7"}
+{"type":"turn.started"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi there!"}]}}
+`
+	if err := os.WriteFile(streamPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(streamPath)
+
+	// ReadCLISessionID should extract the thread_id
+	got := ReadCLISessionID(sessionID, provider)
+	want := "019cdd95-78da-7f33-8521-ae4ca1eb40d7"
+	if got != want {
+		t.Errorf("ReadCLISessionID() = %q, want %q", got, want)
+	}
+}
+
+func TestReadCLISessionID_Codex_NoThreadStarted(t *testing.T) {
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	provider := NewCodexProvider("")
+	sessionID := "test-codex-no-thread-" + t.Name()
+
+	streamPath := filepath.Join(streamsDir, sessionID+".jsonl")
+	content := `{"type":"user","message":{"role":"user","content":"hello"}}
+{"type":"turn.started"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi"}]}}
+`
+	if err := os.WriteFile(streamPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(streamPath)
+
+	got := ReadCLISessionID(sessionID, provider)
+	if got != "" {
+		t.Errorf("ReadCLISessionID() = %q, want empty string", got)
+	}
+}
+
+func TestReadCLISessionID_Codex_MultipleThreads(t *testing.T) {
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	provider := NewCodexProvider("")
+	sessionID := "test-codex-multi-thread-" + t.Name()
+
+	streamPath := filepath.Join(streamsDir, sessionID+".jsonl")
+	content := `{"type":"thread.started","thread_id":"first-thread-id"}
+{"type":"turn.started"}
+{"type":"thread.started","thread_id":"second-thread-id"}
+{"type":"turn.started"}
+`
+	if err := os.WriteFile(streamPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(streamPath)
+
+	// Should return the LAST thread_id
+	got := ReadCLISessionID(sessionID, provider)
+	want := "second-thread-id"
+	if got != want {
+		t.Errorf("ReadCLISessionID() = %q, want %q", got, want)
+	}
+}
+
+func TestReadCLISessionID_Codex_FileNotFound(t *testing.T) {
+	provider := NewCodexProvider("")
+	got := ReadCLISessionID("nonexistent-session-id-xyz", provider)
+	if got != "" {
+		t.Errorf("ReadCLISessionID() = %q, want empty string", got)
+	}
+}
+
+func TestReadCLISessionID_Codex_WithHelperJSON(t *testing.T) {
+	// Verify that NewCodexThreadStartedJSON output is parseable by ReadCLISessionID
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	provider := NewCodexProvider("")
+	sessionID := "test-codex-helper-" + t.Name()
+
+	threadLine := NewCodexThreadStartedJSON("thr_helper_test")
+	streamPath := filepath.Join(streamsDir, sessionID+".jsonl")
+	if err := os.WriteFile(streamPath, []byte(threadLine+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(streamPath)
+
+	got := ReadCLISessionID(sessionID, provider)
+	want := "thr_helper_test"
+	if got != want {
+		t.Errorf("ReadCLISessionID() = %q, want %q", got, want)
+	}
+}
+
+func TestCodexProvider_BuildStreamCommand_ResumeExactArgs(t *testing.T) {
+	p := NewCodexProvider("codex")
+
+	// Verify the exact argument order for resume with followup
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:     "sess-1",
+		ProjectPath:   "/tmp/project",
+		Resume:        true,
+		CLISessionID:  "thr_abc123",
+		InitialPrompt: "follow up message",
+	})
+
+	args := cmd.Args
+	// Expected: codex exec resume --json thr_abc123 "follow up message"
+	expected := []string{"codex", "exec", "resume", "--json", "thr_abc123", "follow up message"}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("args[%d] = %q, want %q (full args: %v)", i, args[i], want, args)
+		}
+	}
+}
+
+func TestCodexProvider_BuildStreamCommand_ResumeNoPromptExactArgs(t *testing.T) {
+	p := NewCodexProvider("codex")
+
+	// Resume without followup prompt
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:    "sess-1",
+		ProjectPath:  "/tmp/project",
+		Resume:       true,
+		CLISessionID: "thr_abc123",
+	})
+
+	args := cmd.Args
+	// Expected: codex exec resume --json thr_abc123
+	expected := []string{"codex", "exec", "resume", "--json", "thr_abc123"}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("args[%d] = %q, want %q (full args: %v)", i, args[i], want, args)
+		}
+	}
+}
+
+func TestStreamProcess_SessionIDInitializedFromOpts(t *testing.T) {
+	// Verify that when CLISessionID is provided in opts, sp.sessionID is initialized.
+	// This is critical for recovery/resume: sp.sessionID must be set so sendCodex can use it.
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "test-init-sid-" + t.Name()
+	streamPath := filepath.Join(streamsDir, sessionID+".jsonl")
+	// Ensure cleanup
+	defer os.Remove(streamPath)
+
+	// Use a stub provider that runs "true" (exits immediately)
+	provider := &stubCodexProvider{CodexProvider: *NewCodexProvider("")}
+
+	sp, err := StartStreamProcess(sessionID, t.TempDir(), "", "", true, false, provider, "pre-existing-thread-id")
+	if err != nil {
+		t.Fatalf("StartStreamProcess failed: %v", err)
+	}
+	defer sp.Stop()
+
+	// The sessionID should be initialized from opts
+	got := sp.SessionID()
+	if got != "pre-existing-thread-id" {
+		t.Errorf("SessionID() = %q, want %q", got, "pre-existing-thread-id")
+	}
+}
+
+func TestStreamProcess_SessionIDUpdatedByReadLoop(t *testing.T) {
+	// Verify that readLoop updates sp.sessionID when it sees thread.started
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "test-readloop-sid-" + t.Name()
+	streamPath := filepath.Join(streamsDir, sessionID+".jsonl")
+	defer os.Remove(streamPath)
+
+	threadID := "019cdd95-new-thread-from-readloop"
+	// Use a stub that outputs a thread.started event
+	provider := &stubCodexProviderWithOutput{
+		CodexProvider: *NewCodexProvider(""),
+		output:        `{"type":"thread.started","thread_id":"` + threadID + `"}`,
+	}
+
+	sp, err := StartStreamProcess(sessionID, t.TempDir(), "", "", false, false, provider)
+	if err != nil {
+		t.Fatalf("StartStreamProcess failed: %v", err)
+	}
+	defer sp.Stop()
+
+	// Wait for process to finish
+	<-sp.Done()
+
+	got := sp.SessionID()
+	if got != threadID {
+		t.Errorf("SessionID() = %q, want %q", got, threadID)
+	}
+
+	// Also verify the thread.started event was written to the JSONL file
+	fileContent, err := os.ReadFile(streamPath)
+	if err != nil {
+		t.Fatalf("failed to read stream file: %v", err)
+	}
+	if len(fileContent) == 0 {
+		t.Fatal("stream file is empty, expected thread.started event")
+	}
+}
+
+// stubCodexProvider wraps CodexProvider but overrides BuildStreamCommand to use "true"
+// (exits immediately with success).
+type stubCodexProvider struct {
+	CodexProvider
+}
+
+func (p *stubCodexProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
+	cmd := exec.Command("true")
+	cmd.Dir = opts.ProjectPath
+	return cmd
+}
+
+// stubCodexProviderWithOutput overrides BuildStreamCommand to echo specified output.
+type stubCodexProviderWithOutput struct {
+	CodexProvider
+	output string
+}
+
+func (p *stubCodexProviderWithOutput) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
+	cmd := exec.Command("echo", p.output)
+	cmd.Dir = opts.ProjectPath
+	return cmd
+}


### PR DESCRIPTION
## Summary
Closes #195

- **StreamProcess.sessionID not initialized from opts**: When recovering a Codex stream process (server restart or auto-recover), `sp.sessionID` was never set from `opts.CLISessionID`, causing `sendCodex` to fail with "no CLI session ID available for codex resume". Now `sessionID` is initialized in `startStreamProcessWithOpts`.
- **`NewCodexThreadStartedJSON` generated wrong format**: The test helper produced `{"type":"thread.started","thread":{"id":"..."}}` (nested) instead of `{"type":"thread.started","thread_id":"..."}` (flat), which is what real Codex CLI outputs and what `ParseSessionID` expects. Fixed to match the real format.
- **Auto-recover for Codex started resume without prompt**: `SendKeysWithImages` auto-recovery started a `codex exec resume` process with no prompt, then tried `sendCodex` which waits for the process to finish first. For Codex, this could hang indefinitely. Now the auto-recover path passes the message directly as `InitialPrompt` via `StartStreamProcessWithPrompt`.

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] Added `TestReadCLISessionID_Codex*` tests verifying JSONL file parsing
- [x] Added `TestStreamProcess_SessionIDInitializedFromOpts` verifying recovery path
- [x] Added `TestStreamProcess_SessionIDUpdatedByReadLoop` verifying readLoop captures thread.started
- [x] Added `TestNewCodexThreadStartedJSON_ParseSessionID` verifying helper/parser compatibility
- [x] Added exact arg order tests for resume commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)