### PR TITLE
fix: persist Codex CLI session ID to DB (#197)

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -122,6 +122,12 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: add cli_session_id column if missing (for Codex session resume)
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN cli_session_id TEXT NOT NULL DEFAULT ''`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	// Migration: create otel_metrics table
 	_, err = db.Exec(`
 		CREATE TABLE IF NOT EXISTS otel_metrics (

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -78,7 +78,7 @@ func (m *Manager) SystemPrompt() string {
 // before the server was restarted.
 func (m *Manager) RecoverStreamProcesses() {
 	rows, err := m.db.Query(
-		`SELECT id, project_path, provider FROM sessions WHERE status = ? AND output_mode = ?`,
+		`SELECT id, project_path, provider, cli_session_id FROM sessions WHERE status = ? AND output_mode = ?`,
 		string(StatusWorking), string(OutputModeStream),
 	)
 	if err != nil {
@@ -88,8 +88,8 @@ func (m *Manager) RecoverStreamProcesses() {
 	defer rows.Close()
 
 	for rows.Next() {
-		var id, projectPath, providerStr string
-		if err := rows.Scan(&id, &projectPath, &providerStr); err != nil {
+		var id, projectPath, providerStr, dbCliSessionID string
+		if err := rows.Scan(&id, &projectPath, &providerStr, &dbCliSessionID); err != nil {
 			m.logger.Error("recover stream processes: scan failed", "error", err)
 			continue
 		}
@@ -99,12 +99,17 @@ func (m *Manager) RecoverStreamProcesses() {
 			m.logger.Error("recover stream processes: mcp config failed", "sessionId", id, "error", err)
 			continue
 		}
-		cliSessionID := ReadCLISessionID(id, provider)
+		// Prefer DB-stored cli_session_id; fall back to JSONL file scan
+		cliSessionID := dbCliSessionID
+		if cliSessionID == "" {
+			cliSessionID = ReadCLISessionID(id, provider)
+		}
 		sp, err := StartStreamProcess(id, projectPath, mcpPath, m.systemPrompt, true, false, provider, cliSessionID)
 		if err != nil {
 			m.logger.Error("recover stream processes: start failed", "sessionId", id, "error", err)
 			continue
 		}
+		m.wireSessionIDCallback(id, sp)
 		m.streamMu.Lock()
 		m.streamProcesses[id] = sp
 		m.streamMu.Unlock()
@@ -164,6 +169,7 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 				}
 			}
 		}
+		m.wireSessionIDCallback(id, sp)
 		m.streamMu.Lock()
 		m.streamProcesses[id] = sp
 		m.streamMu.Unlock()
@@ -222,7 +228,7 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 
 func (m *Manager) List() ([]Session, error) {
 	rows, err := m.db.Query(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, cli_session_id, current_task, goal, goals, created_at, updated_at
 		 FROM sessions ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -238,7 +244,7 @@ func (m *Manager) List() ([]Session, error) {
 		var outputMode string
 		var providerStr string
 		var prompt, currentTask, goal, goalsJSON sql.NullString
-		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &s.CliSessionID, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		s.Status = Status(status)
@@ -312,9 +318,9 @@ func (m *Manager) Get(id string) (*Session, error) {
 	var providerStr string
 	var prompt, currentTask, goal, goalsJSON sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, cli_session_id, current_task, goal, goals, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id,
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &s.CliSessionID, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
@@ -381,6 +387,16 @@ func (m *Manager) Delete(id string) error {
 
 	_, err = m.db.Exec("DELETE FROM sessions WHERE id = ?", id)
 	return err
+}
+
+// wireSessionIDCallback sets up the onSessionID callback on a stream process
+// so that when the CLI session ID is captured, it gets persisted to the DB.
+func (m *Manager) wireSessionIDCallback(sessionID string, sp *StreamProcess) {
+	sp.SetOnSessionID(func(cliSessionID string) {
+		if err := m.UpdateCliSessionID(sessionID, cliSessionID); err != nil {
+			m.logger.Error("failed to persist cli session id", "sessionId", sessionID, "cliSessionId", cliSessionID, "error", err)
+		}
+	})
 }
 
 func (m *Manager) stopStreamProcess(id string) {
@@ -456,6 +472,7 @@ func (m *Manager) Clear(id string) error {
 		if err != nil {
 			return fmt.Errorf("start stream process: %w", err)
 		}
+		m.wireSessionIDCallback(id, sp)
 		m.streamMu.Lock()
 		m.streamProcesses[id] = sp
 		m.streamMu.Unlock()
@@ -473,8 +490,8 @@ func (m *Manager) Clear(id string) error {
 		}
 	}
 
-	// Reset task/goal and set status to working
-	_, err = m.db.Exec("UPDATE sessions SET status = ?, current_task = NULL, goal = NULL, goals = '[]', updated_at = ? WHERE id = ?", string(StatusWorking), time.Now(), id)
+	// Reset task/goal/cli_session_id and set status to working
+	_, err = m.db.Exec("UPDATE sessions SET status = ?, current_task = NULL, goal = NULL, goals = '[]', cli_session_id = '', updated_at = ? WHERE id = ?", string(StatusWorking), time.Now(), id)
 	return err
 }
 
@@ -495,7 +512,11 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			// Auto-recover: restart stream process after server restart
 			provider := m.getProvider(s.Provider)
 			mcpPath, _ := provider.SetupMCP(s.ID, m.apiPort)
-			cliSessionID := ReadCLISessionID(s.ID, provider)
+			// Prefer DB-stored cli_session_id; fall back to JSONL file scan
+			cliSessionID := s.CliSessionID
+			if cliSessionID == "" {
+				cliSessionID = ReadCLISessionID(s.ID, provider)
+			}
 
 			var err error
 			if s.Provider == ProviderCodex && cliSessionID != "" {
@@ -506,6 +527,7 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 					return fmt.Errorf("restart stream process: %w", err)
 				}
 				sp.recordUserMessage(text)
+				m.wireSessionIDCallback(id, sp)
 				m.streamMu.Lock()
 				m.streamProcesses[id] = sp
 				m.streamMu.Unlock()
@@ -516,6 +538,7 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			if err != nil {
 				return fmt.Errorf("restart stream process: %w", err)
 			}
+			m.wireSessionIDCallback(id, sp)
 			m.streamMu.Lock()
 			m.streamProcesses[id] = sp
 			m.streamMu.Unlock()
@@ -676,9 +699,9 @@ func (m *Manager) GetController() (*Session, error) {
 	var providerStr string
 	var prompt, currentTask, goal, goalsJSON sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, cli_session_id, current_task, goal, goals, created_at, updated_at
 		 FROM sessions WHERE type = ? LIMIT 1`, string(TypeController),
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &s.CliSessionID, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -745,6 +768,7 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 		_ = m.tmux.KillSession(name)
 		return nil, fmt.Errorf("start stream process for controller: %w", err)
 	}
+	m.wireSessionIDCallback(id, sp)
 	m.streamMu.Lock()
 	m.streamProcesses[id] = sp
 	m.streamMu.Unlock()
@@ -778,6 +802,12 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 
 func (m *Manager) UpdateStatus(id string, status Status) error {
 	_, err := m.db.Exec("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", string(status), time.Now(), id)
+	return err
+}
+
+// UpdateCliSessionID persists the CLI-assigned session ID to the database.
+func (m *Manager) UpdateCliSessionID(id string, cliSessionID string) error {
+	_, err := m.db.Exec("UPDATE sessions SET cli_session_id = ?, updated_at = ? WHERE id = ?", cliSessionID, time.Now(), id)
 	return err
 }
 
@@ -878,11 +908,16 @@ func (m *Manager) Reconnect(id string) error {
 	}
 
 	if s.OutputMode == OutputModeStream {
-		cliSessionID := ReadCLISessionID(id, provider)
+		// Prefer DB-stored cli_session_id; fall back to JSONL file scan
+		cliSessionID := s.CliSessionID
+		if cliSessionID == "" {
+			cliSessionID = ReadCLISessionID(id, provider)
+		}
 		sp, err := StartStreamProcess(id, s.ProjectPath, mcpConfigPath, m.systemPrompt, true, false, provider, cliSessionID)
 		if err != nil {
 			return fmt.Errorf("start stream process: %w", err)
 		}
+		m.wireSessionIDCallback(id, sp)
 		m.streamMu.Lock()
 		m.streamProcesses[id] = sp
 		m.streamMu.Unlock()

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -40,6 +40,7 @@ type Session struct {
 	Type          SessionType  `json:"type"`
 	OutputMode    OutputMode   `json:"outputMode"`
 	Provider      ProviderName `json:"provider"`
+	CliSessionID  string       `json:"cliSessionId,omitempty"`
 	CurrentTask   string       `json:"currentTask,omitempty"`
 	Goal          string       `json:"goal,omitempty"`
 	Goals         GoalStack    `json:"goals,omitempty"`

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -28,6 +28,10 @@ type StreamProcess struct {
 
 	// Fields for Codex followup support (process restart on new messages)
 	streamOpts StreamOpts // saved opts for rebuilding commands
+
+	// onSessionID is called when the CLI session ID is first captured from stdout.
+	// This allows the manager to persist it to the DB.
+	onSessionID func(cliSessionID string)
 }
 
 // ReadCLISessionID reads the CLI-assigned session ID from a stream JSONL file.
@@ -187,7 +191,11 @@ func (sp *StreamProcess) readLoop(stdout io.Reader) {
 		if sid, ok := sp.provider.ParseSessionID([]byte(line)); ok {
 			sp.mu.Lock()
 			sp.sessionID = sid
+			cb := sp.onSessionID
 			sp.mu.Unlock()
+			if cb != nil {
+				cb(sid)
+			}
 		}
 
 		// Normalize the line into Claude-compatible format.
@@ -215,6 +223,13 @@ func (sp *StreamProcess) SessionID() string {
 	sp.mu.RLock()
 	defer sp.mu.RUnlock()
 	return sp.sessionID
+}
+
+// SetOnSessionID sets a callback that fires when the CLI session ID is captured from stdout.
+func (sp *StreamProcess) SetOnSessionID(fn func(cliSessionID string)) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.onSessionID = fn
 }
 
 // ImageData represents a base64-encoded image to be sent with a message.


### PR DESCRIPTION
## Summary
- Added `cli_session_id` column to the sessions DB table (with migration)
- Added `CliSessionID` field to the `Session` struct (exposed as `cliSessionId` in JSON API)
- Added `onSessionID` callback on `StreamProcess` that fires when `readLoop` captures a thread_id from Codex's `thread.started` event, persisting it to the DB immediately
- All recovery paths (RecoverStreamProcesses, SendKeysWithImages auto-recover, Reconnect) now prefer the DB-stored `cli_session_id` over JSONL file scan
- `Clear` resets `cli_session_id` along with other session state

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all existing tests continue to pass)
- [ ] Create a Codex stream session, verify `cliSessionId` appears in GET /sessions/:id response after first message completes
- [ ] Send a followup message to the Codex session, verify it resumes correctly with `codex exec resume <session_id>`
- [ ] Restart the server, verify followup messages still work (DB-persisted session ID used for recovery)

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)