### PR TITLE
fix: ensure Codex followup messages restart process correctly

### DIFF
--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -361,12 +361,26 @@ func (sp *StreamProcess) sendCodex(message string) error {
 	sp.file.Sync()
 	sp.mu.Unlock()
 
-	// Wait for current process to finish (with timeout)
+	// Read the done channel under lock to avoid races with restartForCodex
+	sp.mu.RLock()
+	doneCh := sp.done
+	sp.mu.RUnlock()
+
+	// Check if the process has already finished (non-blocking).
+	// If it has, skip the wait and proceed directly to restart.
 	select {
-	case <-sp.done:
-		// Process has finished, we can restart
-	case <-time.After(10 * time.Minute):
-		return fmt.Errorf("timeout waiting for codex process to finish")
+	case <-doneCh:
+		// Process already finished, proceed to restart immediately
+		slog.Default().Info("codex process already finished, restarting for followup")
+	default:
+		// Process still running, wait with timeout
+		slog.Default().Info("codex process still running, waiting for it to finish")
+		select {
+		case <-doneCh:
+			slog.Default().Info("codex process finished, proceeding to restart")
+		case <-time.After(10 * time.Minute):
+			return fmt.Errorf("timeout waiting for codex process to finish")
+		}
 	}
 
 	// Get the CLI session ID for resume
@@ -378,14 +392,21 @@ func (sp *StreamProcess) sendCodex(message string) error {
 		return fmt.Errorf("no CLI session ID available for codex resume")
 	}
 
+	slog.Default().Info("restarting codex for followup", "cliSessionID", cliSessionID, "message", message)
 	return sp.restartForCodex(message, cliSessionID)
 }
 
 // restartForCodex spawns a new codex exec resume process for a followup message.
 func (sp *StreamProcess) restartForCodex(message, cliSessionID string) error {
-	// Clean up the old process (already exited since done channel was closed)
-	sp.stdin.Close()
-	_ = sp.cmd.Wait()
+	// Clean up the old process (already exited since done channel was closed).
+	// Read cmd/stdin under lock for safety, then perform blocking ops outside lock.
+	sp.mu.RLock()
+	oldCmd := sp.cmd
+	oldStdin := sp.stdin
+	sp.mu.RUnlock()
+
+	oldStdin.Close()
+	_ = oldCmd.Wait()
 
 	opts := sp.streamOpts
 	opts.Resume = true
@@ -410,6 +431,8 @@ func (sp *StreamProcess) restartForCodex(message, cliSessionID string) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start codex resume process: %w", err)
 	}
+
+	slog.Default().Info("codex resume process started", "pid", cmd.Process.Pid, "cliSessionID", cliSessionID)
 
 	sp.mu.Lock()
 	sp.cmd = cmd
@@ -511,5 +534,7 @@ func (sp *StreamProcess) Stop() {
 
 // Done returns a channel that is closed when the process exits.
 func (sp *StreamProcess) Done() <-chan struct{} {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
 	return sp.done
 }

--- a/internal/session/stream_process_codex_test.go
+++ b/internal/session/stream_process_codex_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/myuon/agmux/internal/db"
@@ -240,6 +241,123 @@ func TestStreamProcess_SessionIDUpdatedByReadLoop(t *testing.T) {
 	}
 	if len(fileContent) == 0 {
 		t.Fatal("stream file is empty, expected thread.started event")
+	}
+}
+
+// TestSendCodex_FollowupAfterProcessExit verifies that sendCodex correctly
+// restarts the process when the initial Codex process has already exited.
+// This is the core bug fix for issue #199.
+func TestSendCodex_FollowupAfterProcessExit(t *testing.T) {
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "test-codex-followup-" + t.Name()
+	streamPath := filepath.Join(streamsDir, sessionID+".jsonl")
+	defer os.Remove(streamPath)
+
+	threadID := "019cdd95-followup-test-thread"
+	// Provider that outputs thread.started then exits (simulates initial Codex run)
+	provider := &stubCodexProviderWithOutput{
+		CodexProvider: *NewCodexProvider(""),
+		output:        `{"type":"thread.started","thread_id":"` + threadID + `"}`,
+	}
+
+	// Start the initial process (simulates session creation)
+	sp, err := StartStreamProcess(sessionID, t.TempDir(), "", "", false, false, provider)
+	if err != nil {
+		t.Fatalf("StartStreamProcess failed: %v", err)
+	}
+	defer sp.Stop()
+
+	// Wait for initial process to finish (simulates Codex exec completing)
+	<-sp.Done()
+
+	// Verify session ID was captured
+	if got := sp.SessionID(); got != threadID {
+		t.Fatalf("SessionID() = %q, want %q", got, threadID)
+	}
+
+	// Now send a followup message (this is the bug scenario from #199)
+	// Switch to a provider that also outputs something for the followup
+	provider.output = `{"type":"thread.started","thread_id":"` + threadID + `"}
+{"type":"item.completed","item":{"type":"agent_message","text":"followup response"}}`
+
+	err = sp.sendCodex("followup message")
+	if err != nil {
+		t.Fatalf("sendCodex() returned error: %v", err)
+	}
+
+	// Wait for the restarted process to finish
+	<-sp.Done()
+
+	// Verify stream file contains the followup user message and response
+	content, err := os.ReadFile(streamPath)
+	if err != nil {
+		t.Fatalf("failed to read stream file: %v", err)
+	}
+
+	contentStr := string(content)
+	if !strings.Contains(contentStr, `"followup message"`) {
+		t.Errorf("stream file should contain followup user message, got:\n%s", contentStr)
+	}
+	if !strings.Contains(contentStr, `followup response`) {
+		t.Errorf("stream file should contain followup response, got:\n%s", contentStr)
+	}
+}
+
+// TestSendCodex_MultipleFollowups verifies that multiple followup messages work.
+func TestSendCodex_MultipleFollowups(t *testing.T) {
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "test-codex-multi-followup-" + t.Name()
+	streamPath := filepath.Join(streamsDir, sessionID+".jsonl")
+	defer os.Remove(streamPath)
+
+	threadID := "019cdd95-multi-followup-thread"
+	provider := &stubCodexProviderWithOutput{
+		CodexProvider: *NewCodexProvider(""),
+		output:        `{"type":"thread.started","thread_id":"` + threadID + `"}`,
+	}
+
+	sp, err := StartStreamProcess(sessionID, t.TempDir(), "", "", false, false, provider)
+	if err != nil {
+		t.Fatalf("StartStreamProcess failed: %v", err)
+	}
+	defer sp.Stop()
+
+	<-sp.Done()
+
+	// Send first followup
+	provider.output = `{"type":"thread.started","thread_id":"` + threadID + `"}`
+	if err := sp.sendCodex("first followup"); err != nil {
+		t.Fatalf("first sendCodex() returned error: %v", err)
+	}
+	<-sp.Done()
+
+	// Send second followup
+	provider.output = `{"type":"thread.started","thread_id":"` + threadID + `"}`
+	if err := sp.sendCodex("second followup"); err != nil {
+		t.Fatalf("second sendCodex() returned error: %v", err)
+	}
+	<-sp.Done()
+
+	// Verify both messages are in the stream file
+	content, err := os.ReadFile(streamPath)
+	if err != nil {
+		t.Fatalf("failed to read stream file: %v", err)
+	}
+
+	contentStr := string(content)
+	if !strings.Contains(contentStr, `"first followup"`) {
+		t.Errorf("stream file should contain first followup message")
+	}
+	if !strings.Contains(contentStr, `"second followup"`) {
+		t.Errorf("stream file should contain second followup message")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #199: Codex sessions now correctly restart the process for followup messages
- The `sendCodex` method now uses proper mutex locking when reading the `done` channel, preventing data races with `restartForCodex` which reassigns the channel
- Added non-blocking select to detect already-finished processes and skip unnecessary waiting
- Added debug logging throughout the Codex followup flow for future diagnosis

## Test plan
- [x] Added `TestSendCodex_FollowupAfterProcessExit` - verifies single followup works after initial process exits
- [x] Added `TestSendCodex_MultipleFollowups` - verifies multiple sequential followups work
- [x] All 57 existing tests pass (`go test ./internal/...`)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)