### PR TITLE
fix: delegate Codex followup sends to server API

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -409,6 +409,18 @@ func sessionSendCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// For stream mode sessions, delegate to the server API so the
+			// spawned process is owned by the long-lived server, not this
+			// short-lived CLI process.
+			s, err := mgr.Get(id)
+			if err != nil {
+				return err
+			}
+			if s.OutputMode == session.OutputModeStream {
+				return sendSessionViaAPI(id, args[1], cfg.Server.Port)
+			}
+
 			if err := mgr.SendKeys(id, args[1]); err != nil {
 				return err
 			}
@@ -416,6 +428,35 @@ func sessionSendCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// sendSessionViaAPI sends a message to a stream session via the server API
+// so that the process is owned by the server, not this short-lived CLI process.
+func sendSessionViaAPI(id, text string, port int) error {
+	body, _ := json.Marshal(map[string]string{
+		"text": text,
+	})
+
+	url := fmt.Sprintf("http://localhost:%d/api/sessions/%s/send", port, id)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to connect to agmux server on port %d (is it running?): %w", port, err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decode server response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server error: %s", result.Error)
+	}
+
+	fmt.Println("Text sent.")
+	return nil
 }
 
 func mcpCmd() *cobra.Command {


### PR DESCRIPTION
## Summary
- The CLI `session send` command was creating a local Manager with an empty `streamProcesses` map
- For Codex stream sessions, the auto-recovery path would spawn a `codex exec resume` child process, but the CLI would immediately exit, killing or orphaning the process
- Now stream-mode sessions delegate message sending to the running agmux server via the `/api/sessions/{id}/send` HTTP endpoint, matching the pattern already used by `session create`

## Test plan
- [ ] Create a Codex stream session: `agmux session create "test" --provider codex --mode stream --message "initial prompt"`
- [ ] Wait for the initial turn to complete (status becomes idle)
- [ ] Send a followup: `agmux session send <id> "followup message"`
- [ ] Verify a new `codex exec resume` process appears in `ps aux | grep codex`
- [ ] Verify stream output grows with the followup response
- [ ] `go test ./internal/session/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)