### PR TITLE
fix: change nudge condition to tool_use + 30min staleness

### DIFF
--- a/internal/monitor/checker.go
+++ b/internal/monitor/checker.go
@@ -132,20 +132,21 @@ func (sc *StatusChecker) check() {
 					sc.onNotify(s.ID, s.Name, string(result.Status), summary)
 				}
 			}
+		}
 
-			// Auto-resume paused sessions
-			if result.Status == session.StatusPaused {
-				sc.logger.Info(fmt.Sprintf("%s (%s): auto-resuming paused session",
-					s.Name, shortID),
-					slog.String("category", "status_checker"),
-					slog.String("sessionId", s.ID),
-				)
-				if err := sc.sessions.SendKeys(s.ID, "作業を進めてください"); err != nil {
-					sc.logger.Error("status checker: auto-resume error", "name", s.Name, "sessionId", s.ID, "error", err)
-				} else {
-					_ = sc.sessions.UpdateStatus(s.ID, session.StatusWorking)
-					s.Status = session.StatusWorking
-				}
+		// Nudge: send "作業を進めてください" if last event is tool_use and 30+ min old
+		if sc.monitor.ShouldNudge(s) {
+			sc.logger.Info(fmt.Sprintf("%s (%s): nudging stalled session (tool_use + 30min)",
+				s.Name, shortID),
+				slog.String("category", "status_checker"),
+				slog.String("sessionId", s.ID),
+			)
+			if err := sc.sessions.SendKeys(s.ID, "作業を進めてください"); err != nil {
+				sc.logger.Error("status checker: nudge error", "name", s.Name, "sessionId", s.ID, "error", err)
+			} else {
+				_ = sc.sessions.UpdateStatus(s.ID, session.StatusWorking)
+				s.Status = session.StatusWorking
+				changed = true
 			}
 		}
 	}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -229,6 +230,70 @@ func filterEnv(env []string, exclude string) []string {
 		}
 	}
 	return filtered
+}
+
+// ShouldNudge checks if a session should receive a nudge message.
+// Returns true when both conditions are met:
+// 1. The last JSONL event contains a tool_use content block
+// 2. The JSONL file was last modified 30+ minutes ago
+func (m *Monitor) ShouldNudge(s *session.Session) bool {
+	if s.OutputMode != session.OutputModeStream {
+		return false
+	}
+
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		return false
+	}
+	jsonlPath := filepath.Join(streamsDir, s.ID+".jsonl")
+
+	info, err := os.Stat(jsonlPath)
+	if err != nil {
+		return false
+	}
+
+	// Condition 2: last modified 30+ minutes ago
+	if time.Since(info.ModTime()) < 30*time.Minute {
+		return false
+	}
+
+	// Condition 1: last line contains tool_use
+	lastLine := readLastLine(jsonlPath)
+	if lastLine == "" {
+		return false
+	}
+
+	return lastLineHasToolUse(lastLine)
+}
+
+// lastLineHasToolUse checks if a JSONL line contains a tool_use content block.
+func lastLineHasToolUse(line string) bool {
+	var event struct {
+		Type    string `json:"type"`
+		Message struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		return false
+	}
+	if event.Type != "assistant" {
+		return false
+	}
+
+	var contentBlocks []struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(event.Message.Content, &contentBlocks); err != nil {
+		return false
+	}
+
+	for _, block := range contentBlocks {
+		if block.Type == "tool_use" {
+			return true
+		}
+	}
+	return false
 }
 
 func truncate(s string, n int) string {

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -1,0 +1,56 @@
+package monitor
+
+import "testing"
+
+func TestLastLineHasToolUse(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{
+			name: "assistant with tool_use",
+			line: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}`,
+			want: true,
+		},
+		{
+			name: "assistant with tool_use and tool_result",
+			line: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{}},{"type":"tool_result","content":"ok"}]}}`,
+			want: true,
+		},
+		{
+			name: "assistant with text only",
+			line: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}`,
+			want: false,
+		},
+		{
+			name: "user message",
+			line: `{"type":"user","message":{"role":"user","content":"do something"}}`,
+			want: false,
+		},
+		{
+			name: "system message",
+			line: `{"type":"system","session_id":"abc123"}`,
+			want: false,
+		},
+		{
+			name: "empty string",
+			line: "",
+			want: false,
+		},
+		{
+			name: "invalid json",
+			line: `{invalid`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lastLineHasToolUse(tt.line)
+			if got != tt.want {
+				t.Errorf("lastLineHasToolUse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- ステータスチェック後の催促ロジックを変更 (#204)
- LLM分類の`paused`による自動催促を廃止
- 代わりに「最後のJSONLイベントが`tool_use` + ファイル最終更新が30分以上前」の機械的条件でのみ催促を送信
- `lastLineHasToolUse`のユニットテストを追加

## Test plan
- [x] `go build ./...` 通過
- [x] `make test` 全テスト通過
- [x] `lastLineHasToolUse` ユニットテスト（7ケース）通過

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)