### PR TITLE
feat: add get_goal MCP tool to retrieve current goal state

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -106,6 +106,14 @@ func (s *Server) handleMethod(method string, params json.RawMessage) (interface{
 					},
 				},
 				map[string]interface{}{
+					"name":        "get_goal",
+					"description": "現在のゴール情報を取得します。currentTask、goal、goalsスタックを返します。コンテキストが圧縮された後などに自分が何をやっていたか確認するのに使えます。",
+					"inputSchema": map[string]interface{}{
+						"type":       "object",
+						"properties": map[string]interface{}{},
+					},
+				},
+				map[string]interface{}{
 					"name":        "complete_goal",
 					"description": "現在のゴールを達成済みとしてポップします。親ゴールがあればそれがアクティブになります。",
 					"inputSchema": map[string]interface{}{
@@ -154,6 +162,8 @@ func (s *Server) callTool(name string, args json.RawMessage) (interface{}, *json
 	switch name {
 	case "create_goal":
 		return s.handleCreateGoal(args)
+	case "get_goal":
+		return s.handleGetGoal()
 	case "complete_goal":
 		return s.handleCompleteGoal()
 	case "set_session_context":
@@ -185,6 +195,28 @@ func (s *Server) handleCreateGoal(args json.RawMessage) (interface{}, *jsonRPCEr
 		msg = "Subgoal created successfully."
 	}
 	return toolResult(msg, false), nil
+}
+
+func (s *Server) handleGetGoal() (interface{}, *jsonRPCError) {
+	result, err := s.apiGetGoal()
+	if err != nil {
+		return toolResult(fmt.Sprintf("Error: %v", err), true), nil
+	}
+
+	if result.CurrentTask == "" && result.Goal == "" && len(result.Goals) == 0 {
+		return toolResult("No goal is currently set.", false), nil
+	}
+
+	lines := []string{}
+	lines = append(lines, fmt.Sprintf("currentTask: %s", result.CurrentTask))
+	lines = append(lines, fmt.Sprintf("goal: %s", result.Goal))
+	if len(result.Goals) > 0 {
+		lines = append(lines, fmt.Sprintf("goal stack (%d entries):", len(result.Goals)))
+		for i, g := range result.Goals {
+			lines = append(lines, fmt.Sprintf("  [%d] %s — %s", i, g.CurrentTask, g.Goal))
+		}
+	}
+	return toolResult(strings.Join(lines, "\n"), false), nil
 }
 
 func (s *Server) handleCompleteGoal() (interface{}, *jsonRPCError) {
@@ -260,6 +292,41 @@ func (s *Server) apiEscalate(message string, timeoutSeconds int) (string, bool, 
 		return "", false, fmt.Errorf("decode response: %w", err)
 	}
 	return result.Response, result.TimedOut, nil
+}
+
+type goalResponse struct {
+	CurrentTask string `json:"currentTask"`
+	Goal        string `json:"goal"`
+	Goals       []struct {
+		CurrentTask string `json:"currentTask"`
+		Goal        string `json:"goal"`
+	} `json:"goals"`
+}
+
+func (s *Server) apiGetGoal() (*goalResponse, error) {
+	url := fmt.Sprintf("%s/api/sessions/%s/goals", s.apiURL, s.sessionID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result goalResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &result, nil
 }
 
 func (s *Server) apiCreateGoal(currentTask, goal string, subgoal bool) error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -80,6 +80,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/stop", s.stopSession)
 		r.Post("/sessions/{id}/send", s.sendToSession)
 		r.Put("/sessions/{id}/context", s.updateSessionContext)
+		r.Get("/sessions/{id}/goals", s.getGoals)
 		r.Post("/sessions/{id}/goals", s.createGoal)
 		r.Post("/sessions/{id}/goals/complete", s.completeGoal)
 		r.Post("/sessions/{id}/reconnect", s.reconnectSession)
@@ -286,6 +287,20 @@ type createGoalRequest struct {
 	CurrentTask string `json:"currentTask"`
 	Goal        string `json:"goal"`
 	Subgoal     bool   `json:"subgoal"`
+}
+
+func (s *Server) getGoals(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	sess, err := s.sessions.Get(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"currentTask": sess.CurrentTask,
+		"goal":        sess.Goal,
+		"goals":       sess.Goals,
+	})
 }
 
 func (s *Server) createGoal(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Add `get_goal` MCP tool that returns the session's current `currentTask`, `goal`, and goal stack
- Add `GET /api/sessions/{id}/goals` server endpoint to serve goal data
- Useful for sessions to confirm their current goal after context compression

Closes #182

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [ ] Start a session, set a goal via `create_goal`, then call `get_goal` to verify it returns the correct state
- [ ] Verify `get_goal` returns "No goal is currently set." when no goal exists
- [ ] Verify goal stack is correctly displayed when subgoals are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)