### PR TITLE
fix: skip limit injection for image files in log-reads hook

### DIFF
--- a/.claude/hooks/log-reads.sh
+++ b/.claude/hooks/log-reads.sh
@@ -12,8 +12,16 @@ LOG_DIR="$HOME/.claude/logs"
 mkdir -p "$LOG_DIR"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)	$TOOL_NAME	$FILE_PATH	pattern=$PATTERN	limit=$LIMIT	session=$SESSION" >> "$LOG_DIR/file-access.log"
 
-# Readツール: 大きいファイルにlimitを自動注入
+# Readツール: 大きいファイルにlimitを自動注入（画像ファイルはスキップ）
 if [ "$TOOL_NAME" = "Read" ] && [ -z "$LIMIT" ] && [ -f "$FILE_PATH" ]; then
+  EXT="${FILE_PATH##*.}"
+  EXT_LOWER=$(echo "$EXT" | tr '[:upper:]' '[:lower:]')
+  case "$EXT_LOWER" in
+    png|jpg|jpeg|gif|webp|bmp|ico|svg|tiff|tif|avif)
+      # 画像ファイルはバイナリなのでlimit注入をスキップ
+      exit 0
+      ;;
+  esac
   FILE_SIZE=$(wc -c < "$FILE_PATH" 2>/dev/null || echo 0)
   if [ "$FILE_SIZE" -gt 100000 ]; then
     echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\",\"updatedInput\":{\"file_path\":$(echo "$FILE_PATH" | jq -Rs .),\"limit\":500},\"additionalContext\":\"Note: File is $(( FILE_SIZE / 1024 ))KB. Reading limited to 500 lines. Use offset/limit to read other sections.\"}}"


### PR DESCRIPTION
## Summary
- `log-reads.sh` フックが100KB超ファイルに `limit: 500` を自動注入していたが、画像ファイル（バイナリ）では行数制限が正しく機能せずトークン上限エラーになっていた
- 画像拡張子（png, jpg, jpeg, gif, webp, bmp, ico, svg, tiff, tif, avif）の場合はlimit注入をスキップするように修正

## Test plan
- [ ] 100KB超の画像ファイルをReadしてもlimit注入されないこと
- [ ] 100KB超のテキストファイルには従来通りlimit=500が注入されること

Closes #175