### PR TITLE
feat: add daemon install/uninstall for macOS launchd

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -21,6 +21,7 @@ import (
 
 	agmux "github.com/myuon/agmux"
 	"github.com/myuon/agmux/internal/config"
+	"github.com/myuon/agmux/internal/daemon"
 	"github.com/myuon/agmux/internal/db"
 	"github.com/myuon/agmux/internal/logging"
 	"github.com/myuon/agmux/internal/mcp"
@@ -41,6 +42,7 @@ func main() {
 	rootCmd.AddCommand(serveCmd())
 	rootCmd.AddCommand(mcpCmd())
 	rootCmd.AddCommand(logsCmd())
+	rootCmd.AddCommand(daemonCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -602,6 +604,31 @@ func tailLogFile(logPath string, lines int, follow bool) error {
 			fmt.Print(line)
 		}
 	}
+}
+
+func daemonCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "daemon",
+		Short: "Manage agmux as a macOS launchd agent",
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "install",
+		Short: "Install and load launchd agent for agmux serve",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return daemon.Install()
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "uninstall",
+		Short: "Unload and remove launchd agent",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return daemon.Uninstall()
+		},
+	})
+
+	return cmd
 }
 
 // readTailLines reads the last n lines from the file.

--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -1,0 +1,136 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"text/template"
+)
+
+const plistLabel = "com.myuon.agmux"
+
+const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{{ .Label }}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{ .BinaryPath }}</string>
+        <string>serve</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{{ .StdoutLog }}</string>
+    <key>StandardErrorPath</key>
+    <string>{{ .StderrLog }}</string>
+</dict>
+</plist>
+`
+
+type plistData struct {
+	Label      string
+	BinaryPath string
+	StdoutLog  string
+	StderrLog  string
+}
+
+func plistPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", plistLabel+".plist"), nil
+}
+
+func logDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".agmux"), nil
+}
+
+// Install generates the launchd plist and loads the agent.
+func Install() error {
+	binPath, err := exec.LookPath("agmux")
+	if err != nil {
+		return fmt.Errorf("agmux binary not found in PATH; install it first or specify the path manually")
+	}
+
+	logd, err := logDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(logd, 0o755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+
+	data := plistData{
+		Label:      plistLabel,
+		BinaryPath: binPath,
+		StdoutLog:  filepath.Join(logd, "server.log"),
+		StderrLog:  filepath.Join(logd, "agmux.log"),
+	}
+
+	ppath, err := plistPath()
+	if err != nil {
+		return err
+	}
+
+	// Ensure LaunchAgents directory exists
+	if err := os.MkdirAll(filepath.Dir(ppath), 0o755); err != nil {
+		return fmt.Errorf("create LaunchAgents dir: %w", err)
+	}
+
+	f, err := os.Create(ppath)
+	if err != nil {
+		return fmt.Errorf("create plist: %w", err)
+	}
+	defer f.Close()
+
+	tmpl, err := template.New("plist").Parse(plistTemplate)
+	if err != nil {
+		return fmt.Errorf("parse template: %w", err)
+	}
+	if err := tmpl.Execute(f, data); err != nil {
+		return fmt.Errorf("execute template: %w", err)
+	}
+
+	// Load the agent
+	if out, err := exec.Command("launchctl", "load", ppath).CombinedOutput(); err != nil {
+		return fmt.Errorf("launchctl load failed: %s: %w", string(out), err)
+	}
+
+	fmt.Printf("Installed and loaded %s\n", ppath)
+	fmt.Printf("Binary: %s\n", binPath)
+	fmt.Printf("Logs:   %s/server.log, %s/agmux.log\n", logd, logd)
+	return nil
+}
+
+// Uninstall unloads the agent and removes the plist file.
+func Uninstall() error {
+	ppath, err := plistPath()
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(ppath); os.IsNotExist(err) {
+		return fmt.Errorf("plist not found at %s; nothing to uninstall", ppath)
+	}
+
+	// Unload the agent (ignore errors if not loaded)
+	_ = exec.Command("launchctl", "unload", ppath).Run()
+
+	if err := os.Remove(ppath); err != nil {
+		return fmt.Errorf("remove plist: %w", err)
+	}
+
+	fmt.Printf("Uninstalled %s\n", ppath)
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `agmux daemon install` command that generates a launchd plist in `~/Library/LaunchAgents/` and loads it via `launchctl`
- Add `agmux daemon uninstall` command that unloads and removes the plist
- Binary path is auto-resolved via `which agmux`; KeepAlive is enabled for crash recovery; logs go to existing `~/.agmux/` files

## Test plan
- [ ] Run `agmux daemon install` and verify plist is created at `~/Library/LaunchAgents/com.myuon.agmux.plist`
- [ ] Verify `launchctl list | grep agmux` shows the agent loaded
- [ ] Kill the agmux process and verify launchd restarts it
- [ ] Run `agmux daemon uninstall` and verify plist is removed and agent unloaded

Closes #187