### PR TITLE
fix: replace hardcoded 4321 port fallback with config-based lookup

### DIFF
--- a/internal/session/otel_env.go
+++ b/internal/session/otel_env.go
@@ -17,7 +17,7 @@ func appendOTelEnv(env []string) []string {
 
 	port := cfg.Server.Port
 	if port == 0 {
-		port = 4321
+		port = config.Default().Server.Port
 	}
 
 	otelVars := map[string]string{
@@ -51,7 +51,12 @@ func appendOTelEnv(env []string) []string {
 func otelEnvPrefix(apiPort int) string {
 	port := apiPort
 	if port == 0 {
-		port = 4321
+		cfg, err := config.Load()
+		if err == nil {
+			port = cfg.Server.Port
+		} else {
+			port = config.Default().Server.Port
+		}
 	}
 
 	return fmt.Sprintf(

--- a/internal/session/provider_claude.go
+++ b/internal/session/provider_claude.go
@@ -115,10 +115,10 @@ func (p *ClaudeProvider) CleanupMCP(sessionID string) error {
 func (p *ClaudeProvider) AppendOTelEnv(env []string, port int) []string {
 	if port == 0 {
 		cfg, err := config.Load()
-		if err == nil && cfg.Server.Port != 0 {
+		if err == nil {
 			port = cfg.Server.Port
 		} else {
-			port = 4321
+			port = config.Default().Server.Port
 		}
 	}
 
@@ -154,7 +154,12 @@ func (p *ClaudeProvider) NormalizeStreamLine(line []byte) []byte {
 
 func (p *ClaudeProvider) OTelEnvPrefix(port int) string {
 	if port == 0 {
-		port = 4321
+		cfg, err := config.Load()
+		if err == nil {
+			port = cfg.Server.Port
+		} else {
+			port = config.Default().Server.Port
+		}
 	}
 	return fmt.Sprintf(
 		"CLAUDE_CODE_ENABLE_TELEMETRY=1 OTEL_METRICS_EXPORTER=otlp OTEL_LOGS_EXPORTER=otlp OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:%d ",


### PR DESCRIPTION
## Summary
- Replace all hardcoded `port = 4321` fallback values in `provider_claude.go` and `otel_env.go` with `config.Load()` / `config.Default().Server.Port`
- Ensures port configuration is always sourced from config, maintaining a single source of truth

Closes #219

## Test plan
- [x] `make build` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)