### PR TITLE
feat: separate DB path by port number

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -49,8 +49,8 @@ func main() {
 	}
 }
 
-func initManager(cfg *config.Config, logger *slog.Logger) (*session.Manager, *sql.DB, error) {
-	dbPath, err := db.DefaultDBPath()
+func initManager(cfg *config.Config, port int, logger *slog.Logger) (*session.Manager, *sql.DB, error) {
+	dbPath, err := db.DBPathForPort(port)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -102,7 +102,7 @@ func serveCmd() *cobra.Command {
 			// Set server logger for WS hub
 			server.SetServerLog(srvLogger)
 
-			mgr, database, err := initManager(cfg, logger)
+			mgr, database, err := initManager(cfg, port, logger)
 			if err != nil {
 				return err
 			}
@@ -269,7 +269,7 @@ func sessionCreateCmd() *cobra.Command {
 			}
 
 			cfg, _ := config.Load()
-			mgr, _, err := initManager(cfg, nil)
+			mgr, _, err := initManager(cfg, cfg.Server.Port, nil)
 			if err != nil {
 				return err
 			}
@@ -346,7 +346,7 @@ func sessionListCmd() *cobra.Command {
 		Short: "List all sessions",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, _ := config.Load()
-			mgr, _, err := initManager(cfg, nil)
+			mgr, _, err := initManager(cfg, cfg.Server.Port, nil)
 			if err != nil {
 				return err
 			}
@@ -378,7 +378,7 @@ func sessionStopCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, _ := config.Load()
-			mgr, _, err := initManager(cfg, nil)
+			mgr, _, err := initManager(cfg, cfg.Server.Port, nil)
 			if err != nil {
 				return err
 			}
@@ -402,7 +402,7 @@ func sessionDeleteCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, _ := config.Load()
-			mgr, _, err := initManager(cfg, nil)
+			mgr, _, err := initManager(cfg, cfg.Server.Port, nil)
 			if err != nil {
 				return err
 			}
@@ -426,7 +426,7 @@ func sessionSendCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, _ := config.Load()
-			mgr, _, err := initManager(cfg, nil)
+			mgr, _, err := initManager(cfg, cfg.Server.Port, nil)
 			if err != nil {
 				return err
 			}
@@ -502,7 +502,7 @@ func sessionCaptureCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, _ := config.Load()
-			mgr, _, err := initManager(cfg, nil)
+			mgr, _, err := initManager(cfg, cfg.Server.Port, nil)
 			if err != nil {
 				return err
 			}

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -30,6 +30,20 @@ func DefaultDBPath() (string, error) {
 	return filepath.Join(dir, "agmux.db"), nil
 }
 
+// DBPathForPort returns the DB file path based on the port number.
+// For the default port (4321), it returns ~/.agmux/agmux.db (backward compatible).
+// For other ports, it returns ~/.agmux/agmux-<port>.db.
+func DBPathForPort(port int) (string, error) {
+	dir, err := AgmuxDir()
+	if err != nil {
+		return "", err
+	}
+	if port == 4321 {
+		return filepath.Join(dir, "agmux.db"), nil
+	}
+	return filepath.Join(dir, fmt.Sprintf("agmux-%d.db", port)), nil
+}
+
 func StreamsDir() (string, error) {
 	dir, err := AgmuxDir()
 	if err != nil {

--- a/internal/db/sqlite_test.go
+++ b/internal/db/sqlite_test.go
@@ -32,6 +32,26 @@ func TestOpenAndMigrate(t *testing.T) {
 	assert.Equal(t, 0, count)
 }
 
+func TestDBPathForPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		port     int
+		wantFile string
+	}{
+		{"default port returns agmux.db", 4321, "agmux.db"},
+		{"custom port returns agmux-<port>.db", 5000, "agmux-5000.db"},
+		{"another custom port", 8080, "agmux-8080.db"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := DBPathForPort(tt.port)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFile, filepath.Base(path))
+			assert.Contains(t, path, ".agmux")
+		})
+	}
+}
+
 func TestMigrateIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")


### PR DESCRIPTION
## Summary
- Add `DBPathForPort(port int)` function that returns port-specific DB file paths
- Default port (4321) returns `~/.agmux/agmux.db` for backward compatibility
- Custom ports return `~/.agmux/agmux-<port>.db`
- Update `initManager` to accept a port parameter and use the new function
- Add unit tests for `DBPathForPort`

Closes #217

## Test plan
- [x] `TestDBPathForPort` verifies default port returns `agmux.db`
- [x] `TestDBPathForPort` verifies custom ports return `agmux-<port>.db`
- [x] `make build` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)