### PR TITLE
feat: PR作成/クローズ時のpreview自動起動hook

### DIFF
--- a/.claude/hooks/preview-hook.sh
+++ b/.claude/hooks/preview-hook.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Hook script for automatic preview environment management.
+# Triggered as a PostToolUse hook on Bash commands.
+# Detects gh pr create/merge/close and runs make preview/preview-stop accordingly.
+
+set -o pipefail
+
+# Read JSON from stdin
+INPUT=$(cat)
+
+TOOL_INPUT_COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+TOOL_OUTPUT=$(echo "$INPUT" | jq -r '.tool_output // empty')
+
+# Determine the repo root (two levels up from this script's directory)
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# --- PR Create ---
+if echo "$TOOL_INPUT_COMMAND" | grep -q 'gh pr create'; then
+  PR_NUMBER=$(echo "$TOOL_OUTPUT" | grep -oE 'pull/[0-9]+' | head -1 | grep -oE '[0-9]+')
+  if [ -n "$PR_NUMBER" ]; then
+    (cd "$REPO_ROOT" && make preview PR="$PR_NUMBER" > /dev/null 2>&1 &)
+  fi
+  exit 0
+fi
+
+# --- PR Merge ---
+if echo "$TOOL_INPUT_COMMAND" | grep -q 'gh pr merge'; then
+  PR_NUMBER=$(echo "$TOOL_INPUT_COMMAND" | grep -oE 'gh pr merge\s+[0-9]+' | grep -oE '[0-9]+')
+  if [ -z "$PR_NUMBER" ]; then
+    PR_NUMBER=$(echo "$TOOL_OUTPUT" | grep -oE 'pull/[0-9]+' | head -1 | grep -oE '[0-9]+')
+  fi
+  if [ -n "$PR_NUMBER" ]; then
+    (cd "$REPO_ROOT" && make preview-stop PR="$PR_NUMBER" > /dev/null 2>&1 &)
+  fi
+  exit 0
+fi
+
+# --- PR Close ---
+if echo "$TOOL_INPUT_COMMAND" | grep -q 'gh pr close'; then
+  PR_NUMBER=$(echo "$TOOL_INPUT_COMMAND" | grep -oE 'gh pr close\s+[0-9]+' | grep -oE '[0-9]+')
+  if [ -z "$PR_NUMBER" ]; then
+    PR_NUMBER=$(echo "$TOOL_OUTPUT" | grep -oE 'pull/[0-9]+' | head -1 | grep -oE '[0-9]+')
+  fi
+  if [ -n "$PR_NUMBER" ]; then
+    (cd "$REPO_ROOT" && make preview-stop PR="$PR_NUMBER" > /dev/null 2>&1 &)
+  fi
+  exit 0
+fi


### PR DESCRIPTION
## Summary
- Add `.claude/hooks/preview-hook.sh` that automatically triggers `make preview` on `gh pr create` and `make preview-stop` on `gh pr merge`/`gh pr close`
- Hook reads JSON from stdin, extracts PR numbers, and runs make targets in background
- Users add the PostToolUse hook config to `.claude/settings.local.json` (gitignored, local dev workflow only)

## Setup
Add this to `.claude/settings.local.json`:
```json
{
  "hooks": {
    "PostToolUse": [
      {
        "matcher": "Bash",
        "hooks": [
          {
            "type": "command",
            "command": ".claude/hooks/preview-hook.sh"
          }
        ]
      }
    ]
  }
}
```

Closes #227

## Test plan
- [ ] Run `echo '{"tool_input":{"command":"gh pr create --title test"},"tool_output":"https://github.com/myuon/agmux/pull/99"}' | .claude/hooks/preview-hook.sh` and verify exit 0
- [ ] Run `echo '{"tool_input":{"command":"gh pr close 42"},"tool_output":""}' | .claude/hooks/preview-hook.sh` and verify exit 0
- [ ] Verify hook triggers `make preview` when a PR is created via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)