### PR TITLE
feat: detect silent claude process exit and update status

### DIFF
--- a/internal/monitor/checker.go
+++ b/internal/monitor/checker.go
@@ -97,6 +97,27 @@ func (sc *StatusChecker) check() {
 			continue
 		}
 
+		// For stream mode, check if the underlying process is still alive.
+		// This is a safety net -- the onProcessExit callback should normally handle this,
+		// but the checker catches edge cases (e.g., callback not wired after server restart).
+		if s.OutputMode == session.OutputModeStream && !sc.sessions.IsStreamProcessAlive(s.ID) {
+			// No active stream process found -- the process has exited
+			if s.Status != session.StatusStopped {
+				sc.logger.Info(fmt.Sprintf("%s (%s): stream process not alive, %s → stopped",
+					s.Name, shortID, s.Status),
+					slog.String("category", "status_checker"),
+					slog.String("sessionId", s.ID),
+				)
+				if err := sc.sessions.UpdateStatus(s.ID, session.StatusStopped); err != nil {
+					sc.logger.Error("status checker: update error", "name", s.Name, "sessionId", s.ID, "error", err)
+					continue
+				}
+				s.Status = session.StatusStopped
+				changed = true
+			}
+			continue
+		}
+
 		// Mode-based status detection
 		result := sc.monitor.CheckStatus(s)
 		if result.Status != s.Status {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -436,6 +436,34 @@ func (m *Manager) wireSessionIDCallback(sessionID string, sp *StreamProcess) {
 	if m.onNewLines != nil {
 		sp.SetOnNewLines(m.onNewLines)
 	}
+	sp.SetOnProcessExit(func(sid string, exitErr error) {
+		errMsg := "<nil>"
+		if exitErr != nil {
+			errMsg = exitErr.Error()
+		}
+		m.logger.Warn("claude process exited unexpectedly, updating status to stopped",
+			"sessionId", sid,
+			"exitError", errMsg,
+		)
+		if err := m.UpdateStatus(sid, StatusStopped); err != nil {
+			m.logger.Error("failed to update status after process exit", "sessionId", sid, "error", err)
+		}
+		// Clean up the stream process from the map
+		m.streamMu.Lock()
+		delete(m.streamProcesses, sid)
+		m.streamMu.Unlock()
+	})
+}
+
+// IsStreamProcessAlive returns true if a stream process exists and has not exited.
+func (m *Manager) IsStreamProcessAlive(id string) bool {
+	m.streamMu.Lock()
+	sp, ok := m.streamProcesses[id]
+	m.streamMu.Unlock()
+	if !ok {
+		return false
+	}
+	return !sp.IsExited()
 }
 
 func (m *Manager) stopStreamProcess(id string) {

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -21,13 +21,17 @@ type StreamProcess struct {
 	stdin     io.WriteCloser
 	lines     []string
 	mu        sync.RWMutex
-	done      chan struct{}
+	done      chan struct{} // closed when readLoop finishes (stdout EOF)
+	exited    chan struct{} // closed when the process has fully exited (Wait returned)
 	file      *os.File
 	sessionID string // CLI session ID (may differ from agmux session ID after resume)
 	provider  Provider
 
 	// Fields for Codex followup support (process restart on new messages)
 	streamOpts StreamOpts // saved opts for rebuilding commands
+
+	// stopped is true when Stop() was called explicitly (not an unexpected exit)
+	stopped bool
 
 	// onSessionID is called when the CLI session ID is first captured from stdout.
 	// This allows the manager to persist it to the DB.
@@ -36,6 +40,10 @@ type StreamProcess struct {
 	// onNewLines is called when new lines are appended to the stream.
 	// The callback receives the session ID and the new lines.
 	onNewLines func(sessionID string, newLines []string, total int)
+
+	// onProcessExit is called when the CLI process exits unexpectedly.
+	// The callback receives the agmux session ID and the exit error (nil if exited cleanly).
+	onProcessExit func(sessionID string, exitErr error)
 }
 
 // ReadCLISessionID reads the CLI-assigned session ID from a stream JSONL file.
@@ -151,6 +159,7 @@ func StartStreamProcessWithOpts(opts StreamOpts, provider Provider) (*StreamProc
 		cmd:        cmd,
 		stdin:      stdinPipe,
 		done:       make(chan struct{}),
+		exited:     make(chan struct{}),
 		file:       f,
 		sessionID:  opts.CLISessionID, // Initialize from opts so resume/recovery can use it immediately
 		provider:   provider,
@@ -162,6 +171,9 @@ func StartStreamProcessWithOpts(opts StreamOpts, provider Provider) (*StreamProc
 
 	// Start stdout reader goroutine
 	go sp.readLoop(stdoutPipe)
+
+	// Start process exit monitor goroutine
+	go sp.monitorExit()
 
 	return sp, nil
 }
@@ -229,6 +241,39 @@ func (sp *StreamProcess) readLoop(stdout io.Reader) {
 	}
 }
 
+// monitorExit waits for the process to exit and fires the onProcessExit callback
+// if the exit was unexpected (i.e., Stop() was not called).
+func (sp *StreamProcess) monitorExit() {
+	// Wait for readLoop to finish first (stdout is closed)
+	<-sp.done
+
+	// Wait for the process to actually exit and capture the exit error
+	exitErr := sp.cmd.Wait()
+
+	defer close(sp.exited)
+
+	sp.mu.RLock()
+	stopped := sp.stopped
+	cb := sp.onProcessExit
+	sp.mu.RUnlock()
+
+	// Only fire callback if this was NOT an explicit Stop()
+	if !stopped && cb != nil {
+		agmuxSessionID := sp.streamOpts.SessionID
+		if exitErr != nil {
+			slog.Default().Warn("stream process exited unexpectedly",
+				"sessionId", agmuxSessionID,
+				"error", exitErr,
+			)
+		} else {
+			slog.Default().Warn("stream process exited unexpectedly with exit code 0",
+				"sessionId", agmuxSessionID,
+			)
+		}
+		cb(agmuxSessionID, exitErr)
+	}
+}
+
 // SessionID returns the CLI session ID assigned by the process.
 func (sp *StreamProcess) SessionID() string {
 	sp.mu.RLock()
@@ -248,6 +293,13 @@ func (sp *StreamProcess) SetOnNewLines(fn func(sessionID string, newLines []stri
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 	sp.onNewLines = fn
+}
+
+// SetOnProcessExit sets a callback that fires when the CLI process exits unexpectedly.
+func (sp *StreamProcess) SetOnProcessExit(fn func(sessionID string, exitErr error)) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.onProcessExit = fn
 }
 
 // ImageData represents a base64-encoded image to be sent with a message.
@@ -391,10 +443,12 @@ func (sp *StreamProcess) sendCodex(message string) error {
 		cb(sp.streamOpts.SessionID, []string{line}, total)
 	}
 
-	// Read the done channel under lock to avoid races with restartForCodex
-	sp.mu.RLock()
+	// Mark as stopped to prevent monitorExit from firing the callback
+	// (Codex process exit is expected; we will restart it)
+	sp.mu.Lock()
+	sp.stopped = true
 	doneCh := sp.done
-	sp.mu.RUnlock()
+	sp.mu.Unlock()
 
 	// Check if the process has already finished (non-blocking).
 	// If it has, skip the wait and proceed directly to restart.
@@ -429,14 +483,14 @@ func (sp *StreamProcess) sendCodex(message string) error {
 // restartForCodex spawns a new codex exec resume process for a followup message.
 func (sp *StreamProcess) restartForCodex(message, cliSessionID string) error {
 	// Clean up the old process (already exited since done channel was closed).
-	// Read cmd/stdin under lock for safety, then perform blocking ops outside lock.
+	// Wait for monitorExit to finish calling Wait() before proceeding.
 	sp.mu.RLock()
-	oldCmd := sp.cmd
 	oldStdin := sp.stdin
+	exitedCh := sp.exited
 	sp.mu.RUnlock()
 
 	oldStdin.Close()
-	_ = oldCmd.Wait()
+	<-exitedCh // wait for monitorExit to call Wait() and close exited
 
 	opts := sp.streamOpts
 	opts.Resume = true
@@ -468,9 +522,12 @@ func (sp *StreamProcess) restartForCodex(message, cliSessionID string) error {
 	sp.cmd = cmd
 	sp.stdin = stdinPipe
 	sp.done = make(chan struct{})
+	sp.exited = make(chan struct{})
+	sp.stopped = false // reset so monitorExit can detect unexpected exits on the new process
 	sp.mu.Unlock()
 
 	go sp.readLoop(stdoutPipe)
+	go sp.monitorExit()
 
 	return nil
 }
@@ -546,23 +603,23 @@ func (sp *StreamProcess) TotalLines() int {
 
 // Stop gracefully stops the stream process.
 func (sp *StreamProcess) Stop() {
+	// Mark as explicitly stopped so monitorExit won't fire the callback
+	sp.mu.Lock()
+	sp.stopped = true
+	sp.mu.Unlock()
+
 	// Close stdin to signal EOF to the process
 	sp.stdin.Close()
 
-	// Wait for process to exit with timeout
-	waitDone := make(chan error, 1)
-	go func() {
-		waitDone <- sp.cmd.Wait()
-	}()
-
+	// Wait for process to exit with timeout (monitorExit calls Wait and closes exited)
 	select {
-	case <-waitDone:
+	case <-sp.exited:
 		// Process exited gracefully
 	case <-time.After(5 * time.Second):
 		// Force kill
 		slog.Default().Warn("stream process did not exit gracefully, killing")
 		sp.cmd.Process.Kill()
-		<-waitDone
+		<-sp.exited
 	}
 
 	sp.file.Close()
@@ -573,4 +630,17 @@ func (sp *StreamProcess) Done() <-chan struct{} {
 	sp.mu.RLock()
 	defer sp.mu.RUnlock()
 	return sp.done
+}
+
+// IsExited returns true if the process has fully exited (Wait returned).
+func (sp *StreamProcess) IsExited() bool {
+	sp.mu.RLock()
+	ch := sp.exited
+	sp.mu.RUnlock()
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## Summary
- Add `onProcessExit` callback to `StreamProcess` that fires when the CLI process exits unexpectedly (not via explicit `Stop()`)
- Wire the callback in `Manager.wireSessionIDCallback` to automatically update session status to `stopped` and clean up the stream process map
- Add safety-net check in `StatusChecker` that detects dead stream processes during periodic polling, catching edge cases where the callback was not wired
- Refactor process lifecycle: `monitorExit` goroutine owns `cmd.Wait()`, preventing double-Wait races between `Stop()` and exit monitoring

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [ ] Start a stream session, kill the claude process externally, verify status changes to `stopped`
- [ ] Verify explicit `Stop()` still works correctly (no double callback)
- [ ] Verify Codex followup restart flow still works (callback suppressed during restart)

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)