### PR TITLE
fix: embed user PATH in launchd plist for daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,9 @@ install: build-frontend
 	go install ./cmd/agmux
 
 restart: install
-	-lsof -ti :$(PORT) | xargs kill
-	@echo "Waiting for port $(PORT) to be released..."
-	@while lsof -ti :$(PORT) > /dev/null 2>&1; do sleep 1; done
-	@nohup agmux serve --port $(PORT) > /tmp/agmux-$(PORT).log 2>&1 &
+	@launchctl kickstart -k "gui/$$(id -u)/com.myuon.agmux"
 	@sleep 2
-	@if lsof -ti :$(PORT) > /dev/null 2>&1; then echo "agmux restarted on port $(PORT) (pid $$(lsof -ti :$(PORT)))"; else echo "ERROR: agmux failed to start. Check /tmp/agmux-$(PORT).log"; cat /tmp/agmux-$(PORT).log; exit 1; fi
+	@if lsof -ti :$(PORT) > /dev/null 2>&1; then echo "agmux restarted via launchd (pid $$(lsof -ti :$(PORT)))"; else echo "ERROR: agmux failed to start. Check ~/.agmux/agmux.log"; tail -20 ~/.agmux/agmux.log; exit 1; fi
 
 preview:
 ifndef PR

--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -25,6 +25,11 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>{{ .Path }}</string>
+    </dict>
     <key>StandardOutPath</key>
     <string>{{ .StdoutLog }}</string>
     <key>StandardErrorPath</key>
@@ -36,6 +41,7 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 type plistData struct {
 	Label      string
 	BinaryPath string
+	Path       string
 	StdoutLog  string
 	StderrLog  string
 }
@@ -74,6 +80,7 @@ func Install() error {
 	data := plistData{
 		Label:      plistLabel,
 		BinaryPath: binPath,
+		Path:       os.Getenv("PATH"),
 		StdoutLog:  filepath.Join(logd, "server.log"),
 		StderrLog:  filepath.Join(logd, "agmux.log"),
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -930,8 +930,8 @@ func (s *Server) restartServer(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "restarting"})
 
 	// Trigger rebuild and restart via `make restart` in a detached process.
-	// We must use Start (not Run) and Setpgid so the make process survives
-	// when `make restart` kills this server process via lsof/kill.
+	// `make restart` rebuilds the binary and uses launchctl kickstart to
+	// restart the launchd-managed agmux service.
 	go func() {
 		time.Sleep(500 * time.Millisecond) // give the response time to flush
 


### PR DESCRIPTION
## Summary
- launchdはユーザーのシェルPATHを継承しないため、daemonから`claude`コマンドが見つからないエラーが発生していた
- `daemon install`実行時のPATHをplistの`EnvironmentVariables`に埋め込むよう修正
- `make restart`をlaunchctl kickstart方式に更新

## Test plan
- [ ] `agmux daemon uninstall` → `agmux daemon install` で再インストール
- [ ] `~/.agmux/` のplistにPATHが含まれていることを確認
- [ ] daemonからセッション起動してclaudeプロセスが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)