### PR TITLE
fix: use os.Executable() for daemon plist binary path

### DIFF
--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -64,9 +64,16 @@ func logDir() (string, error) {
 
 // Install generates the launchd plist and loads the agent.
 func Install() error {
-	binPath, err := exec.LookPath("agmux")
+	// Use the currently running binary so the plist always references
+	// the installed agmux that the user actually invoked.
+	binPath, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("agmux binary not found in PATH; install it first or specify the path manually")
+		return fmt.Errorf("failed to determine current executable path: %w", err)
+	}
+	// Resolve symlinks to get the real path
+	binPath, err = filepath.EvalSymlinks(binPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve executable path: %w", err)
 	}
 
 	logd, err := logDir()


### PR DESCRIPTION
## Summary
- Replace `exec.LookPath("agmux")` with `os.Executable()` + `filepath.EvalSymlinks()` in daemon install
- Ensures the launchd plist always references the currently running agmux binary, not a potentially stale one found in PATH

Closes #238

## Test plan
- [ ] Run `agmux daemon install` and verify the plist references the correct binary path
- [ ] Verify `make build` and `make test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)