### PR TITLE
feat: register preview hook for auto PR preview

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,5 +13,18 @@
       "Bash(ls *)",
       "Skill(commit)"
     ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/preview-hook.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Register the existing `preview-hook.sh` as a PostToolUse hook in `.claude/settings.json`
- The hook script (added in #227) detects `gh pr create/merge/close` commands and automatically runs `make preview` or `make preview-stop`
- Without this registration, the hook was never triggered -- this completes the auto-preview feature

## What was already done (in prior commits)
- `DBPathForPort()` for port-based DB isolation (commit 3310f29)
- `make preview PR=<number>` and `make preview-stop PR=<number>` targets (commit e47d3c7)
- `.claude/hooks/preview-hook.sh` script (commit 77b891e)

## What this PR adds
- Hook registration in `.claude/settings.json` so the preview hook actually fires

## Completion criteria (from #211)
- [x] PRが作られたら自動でプレビュー環境が起動する (hook triggers `make preview`)
- [x] PRがクローズされたら自動でクリーンアップされる (hook triggers `make preview-stop`)
- [x] 複数PRのプレビューが同時に動作する (port-based DB isolation)

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)