### PR TITLE
fix: add -a flag to go install to prevent stale frontend embed cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 	go test ./...
 
 install: build-frontend
-	go install ./cmd/agmux
+	go install -a ./cmd/agmux
 
 restart: install
 	@launchctl kickstart -k "gui/$$(id -u)/com.myuon.agmux"


### PR DESCRIPTION
## Summary
- `go install` のビルドキャッシュが `//go:embed` で参照している `frontend/dist` の変更を検知できず、古いフロントエンドアセットが埋め込まれる問題を修正
- `go install -a` フラグを追加し、常にフルリビルドを強制することで最新のフロントエンドが反映されるようにした

## Test plan
- [ ] `make install` が成功すること
- [ ] フロントエンドを変更後、`make restart` 1回で変更が反映されること

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)