### PR TITLE
fix: copy main DB snapshot for preview environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ endif
 		git worktree remove "$$WORKTREE_DIR" --force; \
 		exit 1; \
 	fi; \
-	sqlite3 ~/.agmux/agmux.db ".backup ~/.agmux/agmux-$$PREVIEW_PORT.db" || { \
+	AGMUX_DIR="$$HOME/.agmux"; \
+	sqlite3 "$$AGMUX_DIR/agmux.db" ".backup $$AGMUX_DIR/agmux-$$PREVIEW_PORT.db" || { \
 		echo "ERROR: Failed to create DB snapshot."; \
 		git worktree remove "$$WORKTREE_DIR" --force; \
 		exit 1; \


### PR DESCRIPTION
## Summary
- preview起動時に `sqlite3 .backup` でメインDBのスナップショットをpreview用DBパスにコピー
- preview停止時にスナップショットDBファイルを自動削除
- `sqlite3` 未インストール時のエラーハンドリングを追加

Closes #237

## Test plan
- [ ] `make preview PR=<number>` でpreview環境にメインDBのセッションデータが表示されることを確認
- [ ] preview環境でのデータ操作がメインDBに影響しないことを確認
- [ ] `make preview-stop PR=<number>` でスナップショットDBが削除されることを確認
- [ ] メインサーバー起動中でもスナップショット取得が安全に行えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)