### PR TITLE
fix: handle array content and thinking blocks in stream view

### DIFF
--- a/frontend/src/components/session/StreamDisplayItemView.tsx
+++ b/frontend/src/components/session/StreamDisplayItemView.tsx
@@ -24,6 +24,14 @@ export function StreamDisplayItemView({ item, onAnswer, sessionId, escalationId,
   if (item.kind === "text") {
     return <CollapsibleText text={item.text} />;
   }
+  if (item.kind === "thinking") {
+    return (
+      <details className="text-xs text-gray-400">
+        <summary className="cursor-pointer select-none hover:text-gray-600">Thinking...</summary>
+        <pre className="mt-1 whitespace-pre-wrap text-gray-500 bg-gray-50 rounded p-2 overflow-x-auto">{item.text}</pre>
+      </details>
+    );
+  }
   if (item.kind === "image") {
     return (
       <img

--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -17,6 +17,7 @@ export interface StreamContentBlock {
   name?: string;
   input?: unknown;
   content?: unknown;
+  thinking?: string;
   source?: { type: string; media_type: string; data: string };
 }
 
@@ -38,10 +39,14 @@ export type StreamDisplayItem =
   | { kind: "text"; text: string }
   | { kind: "image"; mediaType: string; data: string }
   | { kind: "tool_call"; name: string; input: unknown; result?: string; resultImages?: Array<{ mediaType: string; data: string }>; toolUseId?: string; children?: StreamDisplayItem[] }
+  | { kind: "thinking"; text: string }
   | { kind: "system_event"; eventType: string; label: string; detail?: string };
 
 export function parseStreamContentBlocks(entry: StreamEntry): StreamContentBlock[] {
-  const content = entry.message?.content;
+  // Check both entry.message.content and top-level entry.content (some entries
+  // have content at the top level without a message wrapper)
+  const raw = entry as unknown as Record<string, unknown>;
+  const content = entry.message?.content ?? raw.content;
   if (!content) return [];
   if (typeof content === "string") {
     return content ? [{ type: "text", text: content }] : [];
@@ -193,6 +198,8 @@ export function mergeStreamEntries(entries: StreamEntry[]): DisplayGroup[] {
             toolUseId: b.id,
             children: children && children.length > 0 ? children : undefined,
           });
+        } else if (b.type === "thinking" && b.thinking) {
+          items.push({ kind: "thinking", text: b.thinking });
         } else if (b.type === "text" && b.text) {
           items.push({ kind: "text", text: b.text });
         }
@@ -228,7 +235,9 @@ export function mergeStreamEntries(entries: StreamEntry[]): DisplayGroup[] {
 
     if (entry.type === "assistant") {
       for (const b of blocks) {
-        if (b.type === "text" && b.text) {
+        if (b.type === "thinking" && b.thinking) {
+          items.push({ kind: "thinking", text: b.thinking });
+        } else if (b.type === "text" && b.text) {
           items.push({ kind: "text", text: b.text });
         } else if (b.type === "tool_use") {
           // Detect plan mode transitions


### PR DESCRIPTION
## Summary
- `parseStreamContentBlocks` now checks top-level `entry.content` in addition to `entry.message.content`, fixing crashes when entries lack the `message` wrapper
- Added `thinking` block type support: parsed from content arrays and rendered as collapsible `<details>` elements
- Added `thinking` kind to `StreamDisplayItem` type union

## Test plan
- [ ] Open a session that has assistant messages with array content (tool_use, thinking blocks)
- [ ] Verify the page renders without crashing
- [ ] Verify thinking blocks appear as collapsible "Thinking..." sections
- [ ] Verify existing string-content messages still render normally

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)