### PR TITLE
fix: clean Go build cache to prevent stale frontend embed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ test:
 	go test ./...
 
 install: build-frontend
-	go install -a ./cmd/agmux
+	go clean -cache
+	go install ./cmd/agmux
 
 restart: install
 	@launchctl kickstart -k "gui/$$(id -u)/com.myuon.agmux"


### PR DESCRIPTION
## Summary
- Replace `go install -a` with `go clean -cache` + `go install` in the `install` Makefile target
- `go install -a` forces recompilation of Go source but Go's content-based caching for `//go:embed` directives can still serve stale embedded assets
- `go clean -cache` fully clears the build cache, ensuring `frontend/dist` is always re-embedded from the latest build output

## Test plan
- [ ] Run `make restart` and verify the latest frontend assets are served
- [ ] Confirm `go clean -cache` + `go install` produces a binary with fresh frontend content

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)