### PR TITLE
feat: add --include-partial-messages flag and stream_event WebSocket delivery

### DIFF
--- a/internal/session/provider_claude.go
+++ b/internal/session/provider_claude.go
@@ -47,6 +47,7 @@ func (p *ClaudeProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
 		"--verbose",
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
+		"--include-partial-messages",
 		sessionFlag, resumeID,
 		"--dangerously-skip-permissions",
 	}

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -192,6 +192,17 @@ func (sp *StreamProcess) loadExistingLines(path string) {
 	}
 }
 
+// isStreamEvent returns true if the JSON line has "type": "stream_event".
+func isStreamEvent(line []byte) bool {
+	var peek struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(line, &peek); err != nil {
+		return false
+	}
+	return peek.Type == "stream_event"
+}
+
 func (sp *StreamProcess) readLoop(stdout io.Reader) {
 	defer close(sp.done)
 
@@ -222,6 +233,19 @@ func (sp *StreamProcess) readLoop(stdout io.Reader) {
 			continue
 		}
 		normalizedStr := string(normalized)
+
+		// stream_event lines are delivered via WebSocket only —
+		// skip file persistence and lines slice to prevent bloat.
+		if isStreamEvent([]byte(normalizedStr)) {
+			sp.mu.Lock()
+			total := len(sp.lines)
+			cb := sp.onNewLines
+			sp.mu.Unlock()
+			if cb != nil {
+				cb(sp.streamOpts.SessionID, []string{normalizedStr}, total)
+			}
+			continue
+		}
 
 		sp.mu.Lock()
 		sp.lines = append(sp.lines, normalizedStr)


### PR DESCRIPTION
## Summary
- `provider_claude.go`: `BuildStreamCommand()` に `--include-partial-messages` フラグを追加
- `stream_process.go`: `readLoop()` で `type: "stream_event"` の行を判別し、WebSocket配信(`onNewLines`)のみ行い、`.jsonl` ファイルや `lines` スライスには追加しない

## Test plan
- [x] `make test` 通過確認
- [x] `make build` 通過確認

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)