### PR TITLE
feat: stream_event による増分テキスト表示

### DIFF
--- a/frontend/src/components/session/StreamDisplayItemView.tsx
+++ b/frontend/src/components/session/StreamDisplayItemView.tsx
@@ -22,6 +22,14 @@ export function StreamDisplayItemView({ item, onAnswer, sessionId, escalationId,
   onEscalationResponded?: () => void;
 }) {
   if (item.kind === "text") {
+    if (item.streaming) {
+      return (
+        <span className="whitespace-pre-wrap">
+          {item.text}
+          <span className="inline-block w-[2px] h-[1em] bg-green-500 align-middle animate-pulse ml-[1px]" />
+        </span>
+      );
+    }
     return <CollapsibleText text={item.text} />;
   }
   if (item.kind === "thinking") {

--- a/frontend/src/components/session/StreamOutputView.tsx
+++ b/frontend/src/components/session/StreamOutputView.tsx
@@ -11,8 +11,9 @@ const roleStyles: Record<string, { bg: string; label: string; text: string }> = 
 
 type StreamViewMode = "markdown" | "json";
 
-export function StreamOutputView({ lines, className, onAnswer, sessionId, escalationId, escalationTimedOut, escalationTimeoutSeconds, onEscalationResponded }: {
+export function StreamOutputView({ lines, incrementalText, className, onAnswer, sessionId, escalationId, escalationTimedOut, escalationTimeoutSeconds, onEscalationResponded }: {
   lines: unknown[];
+  incrementalText?: string;
   className?: string;
   onAnswer?: (text: string) => void;
   sessionId?: string;
@@ -28,7 +29,7 @@ export function StreamOutputView({ lines, className, onAnswer, sessionId, escala
     .map((line) => line as StreamEntry)
     .filter((e) => e.type === "user" || e.type === "assistant" || e.type === "system");
 
-  const groups = mergeStreamEntries(entries);
+  const groups = mergeStreamEntries(entries, incrementalText);
 
   return (
     <div className={`flex flex-col ${className || ""}`}>

--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -1,5 +1,16 @@
 // --- Stream mode types and helpers ---
 
+export interface StreamEvent {
+  type: "stream_event";
+  event: {
+    type: "message_start" | "content_block_start" | "content_block_delta" | "content_block_stop" | "message_delta" | "message_stop";
+    index?: number;
+    delta?: { type: string; text?: string };
+  };
+  session_id: string;
+  parent_tool_use_id: string | null;
+}
+
 export interface StreamEntry {
   type: string;
   parent_tool_use_id?: string | null;
@@ -36,7 +47,7 @@ export interface AskUserQuestionItem {
 
 // A display item for the merged stream view
 export type StreamDisplayItem =
-  | { kind: "text"; text: string }
+  | { kind: "text"; text: string; streaming?: boolean }
   | { kind: "image"; mediaType: string; data: string }
   | { kind: "tool_call"; name: string; input: unknown; result?: string; resultImages?: Array<{ mediaType: string; data: string }>; toolUseId?: string; children?: StreamDisplayItem[] }
   | { kind: "thinking"; text: string }
@@ -111,7 +122,7 @@ export type DisplayGroup =
   | { role: "system"; items: StreamDisplayItem[] };
 
 // Merge assistant/user entries into display items, pairing tool_use with tool_result by id
-export function mergeStreamEntries(entries: StreamEntry[]): DisplayGroup[] {
+export function mergeStreamEntries(entries: StreamEntry[], incrementalText?: string): DisplayGroup[] {
   // First pass: collect all tool_results keyed by tool_use_id, and track Skill tool IDs
   const resultMap = new Map<string, string>();
   const resultImageMap = new Map<string, Array<{ mediaType: string; data: string }>>();
@@ -365,6 +376,16 @@ export function mergeStreamEntries(entries: StreamEntry[]): DisplayGroup[] {
       } else {
         groups.push({ role, items });
       }
+    }
+  }
+
+  // Append incremental text buffer as a streaming text item in the last assistant group
+  if (incrementalText) {
+    const last = groups[groups.length - 1];
+    if (last && last.role === "assistant") {
+      last.items.push({ kind: "text", text: incrementalText, streaming: true });
+    } else {
+      groups.push({ role: "assistant", items: [{ kind: "text", text: incrementalText, streaming: true }] });
     }
   }
 

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -50,6 +50,7 @@ export function SessionPage() {
   const [settingsJSONLoading, setSettingsJSONLoading] = useState(false);
 
   const [providerVersion, setProviderVersion] = useState<string | null>(null);
+  const [incrementalText, setIncrementalText] = useState("");
   const terminal = useAutoScroll(output);
   const streamCursorRef = useRef<number | null>(null);
 
@@ -93,7 +94,30 @@ export function SessionPage() {
     if (msg.type === "stream_update") {
       const data = msg.data as { sessionId: string; lines: unknown[]; total: number };
       if (data.sessionId === sessionId && data.lines.length > 0) {
-        setStreamLines((prev) => [...prev, ...data.lines]);
+        const regularLines: unknown[] = [];
+        for (const line of data.lines) {
+          const entry = line as Record<string, unknown>;
+          if (entry.type === "stream_event") {
+            // Extract incremental text from content_block_delta events
+            const event = entry.event as { type: string; delta?: { type: string; text?: string } } | undefined;
+            if (event?.type === "content_block_delta" && event.delta?.type === "text_delta" && event.delta.text) {
+              setIncrementalText((prev) => prev + event.delta!.text!);
+            }
+            // message_stop signals the end of streaming; the complete assistant message will follow
+            if (event?.type === "message_stop") {
+              setIncrementalText("");
+            }
+          } else {
+            // Clear incremental text when a complete assistant message arrives
+            if (entry.type === "assistant") {
+              setIncrementalText("");
+            }
+            regularLines.push(line);
+          }
+        }
+        if (regularLines.length > 0) {
+          setStreamLines((prev) => [...prev, ...regularLines]);
+        }
         streamCursorRef.current = data.total;
       }
     }
@@ -664,7 +688,7 @@ export function SessionPage() {
         </div>
       ) : isStream ? (
         <div className="flex flex-col flex-1 min-h-0">
-          <StreamOutputView lines={streamLines} className="flex-1 min-h-0" sessionId={sessionId} escalationId={pendingEscalationId ?? undefined} escalationTimedOut={escalationTimedOut} escalationTimeoutSeconds={escalationTimeoutSeconds} onEscalationResponded={() => { setPendingEscalationId(null); setEscalationTimedOut(false); }} onAnswer={async (text) => {
+          <StreamOutputView lines={streamLines} incrementalText={incrementalText} className="flex-1 min-h-0" sessionId={sessionId} escalationId={pendingEscalationId ?? undefined} escalationTimedOut={escalationTimedOut} escalationTimeoutSeconds={escalationTimeoutSeconds} onEscalationResponded={() => { setPendingEscalationId(null); setEscalationTimedOut(false); }} onAnswer={async (text) => {
             if (!sessionId) return;
             await api.sendToSession(sessionId, text);
           }} />

--- a/internal/session/provider_claude.go
+++ b/internal/session/provider_claude.go
@@ -47,6 +47,7 @@ func (p *ClaudeProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
 		"--verbose",
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
+		"--include-partial-messages",
 		sessionFlag, resumeID,
 		"--dangerously-skip-permissions",
 	}

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -223,11 +223,29 @@ func (sp *StreamProcess) readLoop(stdout io.Reader) {
 		}
 		normalizedStr := string(normalized)
 
+		// Check if this is a stream_event (partial message from --include-partial-messages).
+		// These are sent via WebSocket only, not persisted to file or lines slice.
+		isStreamEvent := false
+		{
+			var peek struct {
+				Type string `json:"type"`
+			}
+			if json.Unmarshal(normalized, &peek) == nil && peek.Type == "stream_event" {
+				isStreamEvent = true
+			}
+		}
+
 		sp.mu.Lock()
-		sp.lines = append(sp.lines, normalizedStr)
-		total := len(sp.lines)
-		sp.file.WriteString(normalizedStr + "\n")
-		sp.file.Sync()
+		var total int
+		if isStreamEvent {
+			// stream_event: broadcast via WebSocket but skip file/lines storage
+			total = len(sp.lines)
+		} else {
+			sp.lines = append(sp.lines, normalizedStr)
+			total = len(sp.lines)
+			sp.file.WriteString(normalizedStr + "\n")
+			sp.file.Sync()
+		}
 		cb := sp.onNewLines
 		sp.mu.Unlock()
 


### PR DESCRIPTION
## Summary
- バックエンドに `--include-partial-messages` フラグを追加し、`stream_event` をWebSocket経由で配信（ファイル保存はスキップ）
- フロントエンドで `content_block_delta` イベントからテキスト断片を蓄積し、リアルタイムでストリーミング表示
- ストリーミング中のテキストにカーソルアニメーション付き

## Test plan
- [ ] `make build` が通ること
- [ ] `make test` が通ること
- [ ] セッションでアシスタントの応答がリアルタイムに増分表示されること
- [ ] 完成メッセージ到着後にストリーミングカーソルが消えること
- [ ] WebSocket再接続時にstream_eventが含まれないこと（REST APIベース）

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)