### PR TITLE
feat: stream_event incremental text display

### DIFF
--- a/frontend/src/components/session/StreamOutputView.tsx
+++ b/frontend/src/components/session/StreamOutputView.tsx
@@ -11,8 +11,9 @@ const roleStyles: Record<string, { bg: string; label: string; text: string }> = 
 
 type StreamViewMode = "markdown" | "json";
 
-export function StreamOutputView({ lines, className, onAnswer, sessionId, escalationId, escalationTimedOut, escalationTimeoutSeconds, onEscalationResponded }: {
+export function StreamOutputView({ lines, partialText, className, onAnswer, sessionId, escalationId, escalationTimedOut, escalationTimeoutSeconds, onEscalationResponded }: {
   lines: unknown[];
+  partialText?: string;
   className?: string;
   onAnswer?: (text: string) => void;
   sessionId?: string;
@@ -28,7 +29,7 @@ export function StreamOutputView({ lines, className, onAnswer, sessionId, escala
     .map((line) => line as StreamEntry)
     .filter((e) => e.type === "user" || e.type === "assistant" || e.type === "system");
 
-  const groups = mergeStreamEntries(entries);
+  const groups = mergeStreamEntries(entries, partialText || undefined);
 
   return (
     <div className={`flex flex-col ${className || ""}`}>

--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -21,6 +21,19 @@ export interface StreamContentBlock {
   source?: { type: string; media_type: string; data: string };
 }
 
+// stream_event from --include-partial-messages (real-time deltas via WebSocket only)
+export interface StreamEvent {
+  type: "stream_event";
+  event: {
+    type: string;
+    index?: number;
+    delta?: {
+      type: string;
+      text?: string;
+    };
+  };
+}
+
 // AskUserQuestion input types
 export interface AskUserQuestionOption {
   label: string;
@@ -111,7 +124,8 @@ export type DisplayGroup =
   | { role: "system"; items: StreamDisplayItem[] };
 
 // Merge assistant/user entries into display items, pairing tool_use with tool_result by id
-export function mergeStreamEntries(entries: StreamEntry[]): DisplayGroup[] {
+// partialText: incremental text from stream_event deltas (shown as "typing" in the last assistant group)
+export function mergeStreamEntries(entries: StreamEntry[], partialText?: string): DisplayGroup[] {
   // First pass: collect all tool_results keyed by tool_use_id, and track Skill tool IDs
   const resultMap = new Map<string, string>();
   const resultImageMap = new Map<string, Array<{ mediaType: string; data: string }>>();
@@ -365,6 +379,17 @@ export function mergeStreamEntries(entries: StreamEntry[]): DisplayGroup[] {
       } else {
         groups.push({ role, items });
       }
+    }
+  }
+
+  // Append incremental partial text to the last assistant group (or create one)
+  if (partialText) {
+    const last = groups[groups.length - 1];
+    const partialItem: StreamDisplayItem = { kind: "text", text: partialText };
+    if (last && last.role === "assistant") {
+      last.items.push(partialItem);
+    } else {
+      groups.push({ role: "assistant", items: [partialItem] });
     }
   }
 

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -27,6 +27,7 @@ export function SessionPage() {
   const [output, setOutput] = useState("");
   const [message, setMessage] = useState("");
   const [streamLines, setStreamLines] = useState<unknown[]>([]);
+  const [partialText, setPartialText] = useState("");
   const [diffFiles, setDiffFiles] = useState<DiffFile[]>([]);
   const [pendingImages, setPendingImages] = useState<{ data: string; mediaType: string; preview: string }[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -93,7 +94,26 @@ export function SessionPage() {
     if (msg.type === "stream_update") {
       const data = msg.data as { sessionId: string; lines: unknown[]; total: number };
       if (data.sessionId === sessionId && data.lines.length > 0) {
-        setStreamLines((prev) => [...prev, ...data.lines]);
+        const regular: unknown[] = [];
+        for (const line of data.lines) {
+          const entry = line as Record<string, unknown>;
+          if (entry.type === "stream_event") {
+            // Extract text delta from content_block_delta events
+            const evt = entry.event as { type?: string; delta?: { type?: string; text?: string } } | undefined;
+            if (evt?.type === "content_block_delta" && evt.delta?.type === "text_delta" && evt.delta.text) {
+              setPartialText((prev) => prev + evt.delta!.text!);
+            }
+          } else {
+            // Clear partial text when a complete assistant message arrives
+            if (entry.type === "assistant") {
+              setPartialText("");
+            }
+            regular.push(line);
+          }
+        }
+        if (regular.length > 0) {
+          setStreamLines((prev) => [...prev, ...regular]);
+        }
         streamCursorRef.current = data.total;
       }
     }
@@ -292,6 +312,7 @@ export function SessionPage() {
                   try {
                     await api.clearSession(session.id);
                     setStreamLines([]);
+                    setPartialText("");
                     setOutput("");
                     streamCursorRef.current = 0;
                     api.getSession(session.id).then(setSession);
@@ -664,7 +685,7 @@ export function SessionPage() {
         </div>
       ) : isStream ? (
         <div className="flex flex-col flex-1 min-h-0">
-          <StreamOutputView lines={streamLines} className="flex-1 min-h-0" sessionId={sessionId} escalationId={pendingEscalationId ?? undefined} escalationTimedOut={escalationTimedOut} escalationTimeoutSeconds={escalationTimeoutSeconds} onEscalationResponded={() => { setPendingEscalationId(null); setEscalationTimedOut(false); }} onAnswer={async (text) => {
+          <StreamOutputView lines={streamLines} partialText={partialText} className="flex-1 min-h-0" sessionId={sessionId} escalationId={pendingEscalationId ?? undefined} escalationTimedOut={escalationTimedOut} escalationTimeoutSeconds={escalationTimeoutSeconds} onEscalationResponded={() => { setPendingEscalationId(null); setEscalationTimedOut(false); }} onAnswer={async (text) => {
             if (!sessionId) return;
             await api.sendToSession(sessionId, text);
           }} />

--- a/internal/session/provider_claude.go
+++ b/internal/session/provider_claude.go
@@ -49,6 +49,7 @@ func (p *ClaudeProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
 		"--input-format", "stream-json",
 		sessionFlag, resumeID,
 		"--dangerously-skip-permissions",
+		"--include-partial-messages",
 	}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -223,11 +223,25 @@ func (sp *StreamProcess) readLoop(stdout io.Reader) {
 		}
 		normalizedStr := string(normalized)
 
+		// stream_event lines are only delivered via WebSocket (real-time),
+		// not persisted to .jsonl or included in the lines slice.
+		isStreamEvent := false
+		if len(normalized) > 0 && normalized[0] == '{' {
+			var peek struct {
+				Type string `json:"type"`
+			}
+			if json.Unmarshal(normalized, &peek) == nil && peek.Type == "stream_event" {
+				isStreamEvent = true
+			}
+		}
+
 		sp.mu.Lock()
-		sp.lines = append(sp.lines, normalizedStr)
+		if !isStreamEvent {
+			sp.lines = append(sp.lines, normalizedStr)
+			sp.file.WriteString(normalizedStr + "\n")
+			sp.file.Sync()
+		}
 		total := len(sp.lines)
-		sp.file.WriteString(normalizedStr + "\n")
-		sp.file.Sync()
 		cb := sp.onNewLines
 		sp.mu.Unlock()
 


### PR DESCRIPTION
## Summary
- **Backend**: `--include-partial-messages` フラグを Claude CLI に追加し、`stream_event` 行を WebSocket 経由でのみ配信（.jsonl ファイルや REST API には含めない）
- **Frontend**: `content_block_delta` イベントからテキスト断片を抽出・蓄積し、最後の assistant グループに増分テキストとして表示。完成済み `assistant` メッセージ到着時にバッファをクリア
- **型定義**: `StreamEvent` インターフェースを追加、`mergeStreamEntries()` に `partialText` パラメータを追加

## Test plan
- [ ] `make build` が通ること
- [ ] `go test ./internal/...` が通ること
- [ ] セッション画面で assistant の応答がリアルタイムに増分表示されること
- [ ] 完成メッセージ到着後に増分テキストがクリアされること
- [ ] REST API (`/api/sessions/:id/stream`) に stream_event が含まれないこと

Closes #244
Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)