### PR TITLE
feat: add read-only session mode

### DIFF
--- a/cmd/agmux/hook.go
+++ b/cmd/agmux/hook.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func hookCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "hook",
+		Short:  "Hook commands for Claude Code integration",
+		Hidden: true,
+	}
+
+	cmd.AddCommand(readOnlyGuardCmd())
+	return cmd
+}
+
+// preToolUseInput represents the JSON input from Claude Code's preToolUse hook.
+type preToolUseInput struct {
+	ToolName string          `json:"tool_name"`
+	Input    json.RawMessage `json:"tool_input"`
+}
+
+// hookDecision represents the JSON output for Claude Code hooks.
+type hookDecision struct {
+	Decision string `json:"decision"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+func readOnlyGuardCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "read-only-guard",
+		Short:  "preToolUse hook that blocks file modifications in read-only sessions",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("read stdin: %w", err)
+			}
+
+			var hook preToolUseInput
+			if err := json.Unmarshal(input, &hook); err != nil {
+				// If we can't parse input, approve by default
+				return outputDecision(hookDecision{Decision: "approve"})
+			}
+
+			switch hook.ToolName {
+			case "Edit", "Write", "NotebookEdit":
+				return outputDecision(hookDecision{
+					Decision: "block",
+					Reason:   "Read-only session: file modifications are not allowed",
+				})
+			case "Bash":
+				return handleBashGuard(hook.Input)
+			default:
+				// All other tools (Read, Grep, Glob, Agent, etc.) are allowed
+				return outputDecision(hookDecision{Decision: "approve"})
+			}
+		},
+	}
+}
+
+func handleBashGuard(rawInput json.RawMessage) error {
+	var bashInput struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(rawInput, &bashInput); err != nil {
+		// Can't parse, approve by default
+		return outputDecision(hookDecision{Decision: "approve"})
+	}
+
+	command := bashInput.Command
+	if isDestructiveBashCommand(command) {
+		return outputDecision(hookDecision{
+			Decision: "block",
+			Reason:   "Read-only session: file modifications are not allowed",
+		})
+	}
+
+	return outputDecision(hookDecision{Decision: "approve"})
+}
+
+// blockedCommands are commands that modify the filesystem.
+var blockedCommands = []string{
+	"rm", "mv", "cp", "sed", "awk", "tee",
+	"chmod", "chown", "mkdir", "rmdir", "touch",
+	"truncate", "dd", "install",
+}
+
+// allowedCommands are safe commands that should never be blocked.
+var allowedCommands = []string{
+	"gh", "git", "ls", "cat", "head", "tail",
+	"echo", "printf", "grep", "find", "which",
+	"pwd", "cd", "env", "export", "make", "go",
+	"npm", "npx", "node", "python", "curl", "wget",
+	"jq", "wc", "sort", "uniq", "diff", "date", "whoami",
+}
+
+func isDestructiveBashCommand(command string) bool {
+	// Check for redirections (file write operators)
+	if strings.Contains(command, ">>") || containsRedirect(command) {
+		return true
+	}
+
+	// Extract the first command word from each piped/chained segment
+	segments := splitCommandSegments(command)
+	for _, seg := range segments {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+
+		// Strip leading env assignments (e.g. "FOO=bar cmd")
+		cmdWord := extractCommandWord(seg)
+		if cmdWord == "" {
+			continue
+		}
+
+		// Check if it's explicitly allowed
+		if isAllowedCommand(cmdWord) {
+			continue
+		}
+
+		// Check if it's explicitly blocked
+		if isBlockedCommand(cmdWord) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// containsRedirect checks for > redirect operator (but not >>).
+// We need to be careful not to match >> which is already checked,
+// and not to match things like grep patterns.
+func containsRedirect(command string) bool {
+	for i := 0; i < len(command); i++ {
+		if command[i] == '>' {
+			// Check it's not >> (already handled above)
+			if i+1 < len(command) && command[i+1] == '>' {
+				return true // >> is also destructive
+			}
+			// Check it's not part of a heredoc <<
+			if i > 0 && command[i-1] == '<' {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// splitCommandSegments splits a command by pipes, &&, ||, and ;
+func splitCommandSegments(command string) []string {
+	var segments []string
+	var current strings.Builder
+	inSingle := false
+	inDouble := false
+
+	for i := 0; i < len(command); i++ {
+		ch := command[i]
+		switch {
+		case ch == '\'' && !inDouble:
+			inSingle = !inSingle
+			current.WriteByte(ch)
+		case ch == '"' && !inSingle:
+			inDouble = !inDouble
+			current.WriteByte(ch)
+		case !inSingle && !inDouble && ch == '|':
+			if i+1 < len(command) && command[i+1] == '|' {
+				// ||
+				segments = append(segments, current.String())
+				current.Reset()
+				i++ // skip next |
+			} else {
+				// |
+				segments = append(segments, current.String())
+				current.Reset()
+			}
+		case !inSingle && !inDouble && ch == '&':
+			if i+1 < len(command) && command[i+1] == '&' {
+				segments = append(segments, current.String())
+				current.Reset()
+				i++ // skip next &
+			} else {
+				current.WriteByte(ch)
+			}
+		case !inSingle && !inDouble && ch == ';':
+			segments = append(segments, current.String())
+			current.Reset()
+		default:
+			current.WriteByte(ch)
+		}
+	}
+	if current.Len() > 0 {
+		segments = append(segments, current.String())
+	}
+	return segments
+}
+
+// extractCommandWord gets the first actual command word, skipping env assignments and sudo/nohup.
+func extractCommandWord(segment string) string {
+	fields := strings.Fields(segment)
+	for _, f := range fields {
+		// Skip env var assignments
+		if strings.Contains(f, "=") && !strings.HasPrefix(f, "-") {
+			continue
+		}
+		// Skip sudo, nohup, etc.
+		if f == "sudo" || f == "nohup" || f == "nice" || f == "time" {
+			continue
+		}
+		// Get basename (e.g. /usr/bin/rm -> rm)
+		parts := strings.Split(f, "/")
+		return parts[len(parts)-1]
+	}
+	return ""
+}
+
+func isAllowedCommand(cmd string) bool {
+	for _, c := range allowedCommands {
+		if cmd == c {
+			return true
+		}
+	}
+	return false
+}
+
+func isBlockedCommand(cmd string) bool {
+	for _, c := range blockedCommands {
+		if cmd == c {
+			return true
+		}
+	}
+	return false
+}
+
+func outputDecision(d hookDecision) error {
+	return json.NewEncoder(os.Stdout).Encode(d)
+}

--- a/cmd/agmux/hook_test.go
+++ b/cmd/agmux/hook_test.go
@@ -1,0 +1,68 @@
+package main
+
+import "testing"
+
+func TestIsDestructiveBashCommand(t *testing.T) {
+	tests := []struct {
+		command     string
+		destructive bool
+	}{
+		// Blocked commands
+		{"rm -rf /tmp/foo", true},
+		{"mv file1 file2", true},
+		{"cp file1 file2", true},
+		{"sed -i 's/foo/bar/' file", true},
+		{"tee output.txt", true},
+		{"touch newfile", true},
+		{"mkdir -p /tmp/foo", true},
+		{"chmod 755 file", true},
+		{"truncate -s 0 file", true},
+
+		// Redirects
+		{"echo hello > file.txt", true},
+		{"echo hello >> file.txt", true},
+
+		// Allowed commands
+		{"gh issue list", false},
+		{"git status", false},
+		{"git diff", false},
+		{"ls -la", false},
+		{"cat file.txt", false},
+		{"grep foo file.txt", false},
+		{"find . -name '*.go'", false},
+		{"pwd", false},
+		{"make test", false},
+		{"go test ./...", false},
+		{"npm run test", false},
+		{"curl https://example.com", false},
+		{"jq '.foo' file.json", false},
+		{"wc -l file.txt", false},
+
+		// Pipe with safe commands
+		{"git log | head -20", false},
+		{"cat file.txt | grep foo", false},
+
+		// Chained with safe commands
+		{"git status && git diff", false},
+
+		// Mixed: blocked in chain
+		{"git status && rm file", true},
+		{"ls && cp file1 file2", true},
+
+		// Env vars prefix
+		{"FOO=bar ls", false},
+		{"FOO=bar rm file", true},
+
+		// Sudo
+		{"sudo rm -rf /", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			got := isDestructiveBashCommand(tt.command)
+			if got != tt.destructive {
+				t.Errorf("isDestructiveBashCommand(%q) = %v, want %v", tt.command, got, tt.destructive)
+			}
+		})
+	}
+}

--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -43,6 +43,7 @@ func main() {
 	rootCmd.AddCommand(mcpCmd())
 	rootCmd.AddCommand(logsCmd())
 	rootCmd.AddCommand(daemonCmd())
+	rootCmd.AddCommand(hookCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -240,6 +241,7 @@ func sessionCmd() *cobra.Command {
 	cmd.AddCommand(sessionDeleteCmd())
 	cmd.AddCommand(sessionSendCmd())
 	cmd.AddCommand(sessionCaptureCmd())
+	cmd.AddCommand(sessionReadOnlyCmd())
 
 	return cmd
 }
@@ -251,6 +253,7 @@ func sessionCreateCmd() *cobra.Command {
 	var worktree bool
 	var provider string
 	var model string
+	var readOnly bool
 
 	cmd := &cobra.Command{
 		Use:   "create <name>",
@@ -265,7 +268,7 @@ func sessionCreateCmd() *cobra.Command {
 			if outputMode == session.OutputModeStream {
 				// Stream mode: delegate to the running agmux server so the
 				// child process outlives this CLI invocation.
-				return createSessionViaAPI(args[0], projectPath, prompt, mode, worktree, provider, model)
+				return createSessionViaAPI(args[0], projectPath, prompt, mode, worktree, provider, model, readOnly)
 			}
 
 			cfg, _ := config.Load()
@@ -273,7 +276,7 @@ func sessionCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			s, err := mgr.Create(args[0], projectPath, prompt, outputMode, worktree, session.CreateOpts{Provider: session.ProviderName(provider), Model: model})
+			s, err := mgr.Create(args[0], projectPath, prompt, outputMode, worktree, session.CreateOpts{Provider: session.ProviderName(provider), Model: model, ReadOnly: readOnly})
 			if err != nil {
 				return err
 			}
@@ -288,13 +291,14 @@ func sessionCreateCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&worktree, "worktree", "w", false, "Create a git worktree for the session")
 	cmd.Flags().StringVar(&provider, "provider", "claude", "Provider: claude or codex")
 	cmd.Flags().StringVar(&model, "model", "", "Model to use (e.g. claude-sonnet-4-5, o4-mini)")
+	cmd.Flags().BoolVar(&readOnly, "read-only", false, "Create session in read-only mode (blocks file modifications)")
 
 	return cmd
 }
 
 // createSessionViaAPI sends a POST /api/sessions request to the running agmux server
 // so that the stream process is owned by the server, not this short-lived CLI process.
-func createSessionViaAPI(name, projectPath, prompt, mode string, worktree bool, provider, model string) error {
+func createSessionViaAPI(name, projectPath, prompt, mode string, worktree bool, provider, model string, readOnly bool) error {
 	cfg, _ := config.Load()
 	port := cfg.Server.Port
 
@@ -313,6 +317,9 @@ func createSessionViaAPI(name, projectPath, prompt, mode string, worktree bool, 
 	}
 	if model != "" {
 		payload["model"] = model
+	}
+	if readOnly {
+		payload["readOnly"] = true
 	}
 	body, _ := json.Marshal(payload)
 
@@ -518,6 +525,41 @@ func sessionCaptureCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func sessionReadOnlyCmd() *cobra.Command {
+	var off bool
+
+	cmd := &cobra.Command{
+		Use:   "read-only <id>",
+		Short: "Enable or disable read-only mode for a session",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, _ := config.Load()
+			mgr, _, err := initManager(cfg, cfg.Server.Port, nil)
+			if err != nil {
+				return err
+			}
+			id, err := mgr.ResolveID(args[0])
+			if err != nil {
+				return err
+			}
+			readOnly := !off
+			if err := mgr.UpdateReadOnly(id, readOnly); err != nil {
+				return err
+			}
+			if readOnly {
+				fmt.Println("Read-only mode enabled.")
+			} else {
+				fmt.Println("Read-only mode disabled.")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&off, "off", false, "Disable read-only mode")
+
+	return cmd
 }
 
 func logsCmd() *cobra.Command {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -27,10 +27,17 @@ export const api = {
     outputMode?: "terminal" | "stream";
     provider?: string;
     model?: string;
+    readOnly?: boolean;
   }) =>
     request<Session>("/sessions", {
       method: "POST",
       body: JSON.stringify(data),
+    }),
+
+  updateReadOnly: (id: string, readOnly: boolean) =>
+    request<Session>(`/sessions/${id}/read-only`, {
+      method: "PUT",
+      body: JSON.stringify({ readOnly }),
     }),
 
   getCodexModels: () =>

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -10,6 +10,7 @@ interface Props {
     outputMode?: "terminal" | "stream";
     provider?: string;
     model?: string;
+    readOnly?: boolean;
   }) => void;
 }
 
@@ -26,6 +27,7 @@ export function CreateSession({ onClose, onCreate }: Props) {
   const [outputMode, setOutputMode] = useState<"terminal" | "stream">("terminal");
   const [provider, setProvider] = useState("claude");
   const [model, setModel] = useState("");
+  const [readOnly, setReadOnly] = useState(false);
   const [codexModels, setCodexModels] = useState<CodexModel[]>([]);
   const [claudeModels, setClaudeModels] = useState<ModelOption[]>([]);
   const [loadingModels, setLoadingModels] = useState(false);
@@ -67,6 +69,7 @@ export function CreateSession({ onClose, onCreate }: Props) {
       outputMode,
       provider,
       model: (provider === "codex" || provider === "claude") && model ? model : undefined,
+      readOnly: readOnly || undefined,
     });
   };
 
@@ -195,6 +198,17 @@ export function CreateSession({ onClose, onCreate }: Props) {
               </select>
             </div>
           )}
+          <div>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={readOnly}
+                onChange={(e) => setReadOnly(e.target.checked)}
+              />
+              <span className="font-medium text-gray-700">Read Only</span>
+              <span className="text-gray-400 text-xs">(blocks file modifications)</span>
+            </label>
+          </div>
           <div className="flex justify-end gap-2">
             <button
               type="button"

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -92,6 +92,11 @@ export function SessionList({ sessions, onRestartController }: Props) {
                       Controller
                     </span>
                   )}
+                  {s.readOnly && (
+                    <span className="px-1.5 py-0.5 text-[10px] font-medium bg-amber-100 text-amber-700 rounded">
+                      Read Only
+                    </span>
+                  )}
                   {s.provider && s.provider !== "claude" && (
                     <span className={`px-1.5 py-0.5 text-[10px] font-medium rounded ${
                       s.provider === "codex"

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -4,7 +4,7 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
   Square, RefreshCw, Trash2, ArrowLeft, GitBranch, GitPullRequest, FolderOpen,
-  Sparkles, Settings,
+  Sparkles, Settings, Lock, Unlock,
   ListTodo, Target, RotateCcw, ImagePlus, SendHorizonal, Plus, Slash,
   Code, Eye, X,
 } from "lucide-react";
@@ -324,6 +324,23 @@ export function SessionPage() {
               >
                 <RefreshCw className="w-4 h-4" /> Reconnect
               </button>
+              <button
+                type="button"
+                className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+                onMouseDown={async (e) => {
+                  e.preventDefault();
+                  setShowActionMenu(false);
+                  try {
+                    const updated = await api.updateReadOnly(session.id, !session.readOnly);
+                    setSession(updated);
+                  } catch {
+                    alert("Failed to update read-only mode");
+                  }
+                }}
+              >
+                {session.readOnly ? <Unlock className="w-4 h-4" /> : <Lock className="w-4 h-4" />}
+                {session.readOnly ? "Disable Read Only" : "Enable Read Only"}
+              </button>
               {session.status !== "stopped" && session.type !== "controller" && (
                 <button
                   type="button"
@@ -514,6 +531,11 @@ export function SessionPage() {
             {session.model && (
               <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-purple-100 text-purple-700">
                 {session.model}
+              </span>
+            )}
+            {session.readOnly && (
+              <span className="px-1.5 py-0.5 text-[10px] font-medium bg-amber-100 text-amber-700 rounded">
+                Read Only
               </span>
             )}
           </>

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -12,6 +12,7 @@ export interface Session {
   currentTask?: string;
   goal?: string;
   goals?: { currentTask: string; goal: string }[];
+  readOnly: boolean;
   createdAt: string;
   updatedAt: string;
   githubUrl?: string;

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -199,6 +199,12 @@ func migrate(db *sql.DB) error {
 		  AND json_extract(attributes, '$."session.id"') != ''
 	`)
 
+	// Migration: add read_only column if missing
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN read_only INTEGER NOT NULL DEFAULT 0`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	// Migration: update old status values to new ones
 	_, err = db.Exec(`UPDATE sessions SET status = 'working' WHERE status IN ('running', 'waiting', 'error')`)
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,6 +105,7 @@ func (s *Server) setupRoutes() {
 		r.Get("/sessions/{id}/goals", s.getGoals)
 		r.Post("/sessions/{id}/goals", s.createGoal)
 		r.Post("/sessions/{id}/goals/complete", s.completeGoal)
+		r.Put("/sessions/{id}/read-only", s.updateSessionReadOnly)
 		r.Post("/sessions/{id}/reconnect", s.reconnectSession)
 		r.Post("/sessions/{id}/clear", s.clearSession)
 		r.Get("/sessions/{id}/output", s.getSessionOutput)
@@ -168,6 +169,7 @@ type createSessionRequest struct {
 	Worktree    bool   `json:"worktree,omitempty"`
 	Provider    string `json:"provider,omitempty"`
 	Model       string `json:"model,omitempty"`
+	ReadOnly    bool   `json:"readOnly,omitempty"`
 }
 
 type sendImageData struct {
@@ -207,7 +209,7 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "name and projectPath are required")
 		return
 	}
-	sess, err := s.sessions.Create(req.Name, req.ProjectPath, req.Prompt, session.OutputMode(req.OutputMode), req.Worktree, session.CreateOpts{Provider: session.ProviderName(req.Provider), Model: req.Model})
+	sess, err := s.sessions.Create(req.Name, req.ProjectPath, req.Prompt, session.OutputMode(req.OutputMode), req.Worktree, session.CreateOpts{Provider: session.ProviderName(req.Provider), Model: req.Model, ReadOnly: req.ReadOnly})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -493,6 +495,27 @@ func (s *Server) respondEscalation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) updateSessionReadOnly(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req struct {
+		ReadOnly bool `json:"readOnly"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := s.sessions.UpdateReadOnly(id, req.ReadOnly); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	sess, err := s.sessions.Get(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, sess)
 }
 
 func (s *Server) reconnectSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -84,7 +84,7 @@ func (m *Manager) SystemPrompt() string {
 // before the server was restarted.
 func (m *Manager) RecoverStreamProcesses() {
 	rows, err := m.db.Query(
-		`SELECT id, project_path, provider, cli_session_id, model FROM sessions WHERE status = ? AND output_mode = ?`,
+		`SELECT id, project_path, provider, cli_session_id, model, read_only FROM sessions WHERE status = ? AND output_mode = ?`,
 		string(StatusWorking), string(OutputModeStream),
 	)
 	if err != nil {
@@ -95,7 +95,8 @@ func (m *Manager) RecoverStreamProcesses() {
 
 	for rows.Next() {
 		var id, projectPath, providerStr, dbCliSessionID, dbModel string
-		if err := rows.Scan(&id, &projectPath, &providerStr, &dbCliSessionID, &dbModel); err != nil {
+		var dbReadOnly bool
+		if err := rows.Scan(&id, &projectPath, &providerStr, &dbCliSessionID, &dbModel, &dbReadOnly); err != nil {
 			m.logger.Error("recover stream processes: scan failed", "error", err)
 			continue
 		}
@@ -118,6 +119,7 @@ func (m *Manager) RecoverStreamProcesses() {
 			Resume:        true,
 			CLISessionID:  cliSessionID,
 			Model:         dbModel,
+			ReadOnly:      dbReadOnly,
 		}, provider)
 		if err != nil {
 			m.logger.Error("recover stream processes: start failed", "sessionId", id, "error", err)
@@ -135,6 +137,7 @@ func (m *Manager) RecoverStreamProcesses() {
 type CreateOpts struct {
 	Provider ProviderName
 	Model    string
+	ReadOnly bool
 }
 
 func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode, worktree bool, opts ...CreateOpts) (*Session, error) {
@@ -144,11 +147,13 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 
 	pn := ProviderClaude
 	model := ""
+	readOnly := false
 	if len(opts) > 0 {
 		if opts[0].Provider != "" {
 			pn = opts[0].Provider
 		}
 		model = opts[0].Model
+		readOnly = opts[0].ReadOnly
 	}
 	provider := m.getProvider(pn)
 
@@ -176,6 +181,7 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 			Resume:        false,
 			Worktree:      worktree,
 			Model:         model,
+			ReadOnly:      readOnly,
 		}
 		var sp *StreamProcess
 		if pn == ProviderCodex && prompt != "" {
@@ -245,14 +251,15 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 		OutputMode:    outputMode,
 		Provider:      pn,
 		Model:         model,
+		ReadOnly:      readOnly,
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}
 
 	if _, err := m.db.Exec(
-		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, s.TmuxSession, string(s.Status), string(s.Type), string(s.OutputMode), string(s.Provider), s.Model, s.CreatedAt, s.UpdatedAt,
+		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, read_only, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, s.TmuxSession, string(s.Status), string(s.Type), string(s.OutputMode), string(s.Provider), s.Model, s.ReadOnly, s.CreatedAt, s.UpdatedAt,
 	); err != nil {
 		// Cleanup tmux session on DB error
 		_ = m.tmux.KillSession(name)
@@ -264,7 +271,7 @@ func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode
 
 func (m *Manager) List() ([]Session, error) {
 	rows, err := m.db.Query(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, cli_session_id, model, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, cli_session_id, model, current_task, goal, goals, read_only, created_at, updated_at
 		 FROM sessions ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -280,7 +287,7 @@ func (m *Manager) List() ([]Session, error) {
 		var outputMode string
 		var providerStr string
 		var prompt, currentTask, goal, goalsJSON sql.NullString
-		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &s.ReadOnly, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		s.Status = Status(status)
@@ -354,9 +361,9 @@ func (m *Manager) Get(id string) (*Session, error) {
 	var providerStr string
 	var prompt, currentTask, goal, goalsJSON sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, cli_session_id, model, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, cli_session_id, model, current_task, goal, goals, read_only, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id,
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &s.ReadOnly, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
@@ -542,6 +549,7 @@ func (m *Manager) Clear(id string) error {
 			SystemPrompt:  m.systemPrompt,
 			CLISessionID:  freshCLISessionID,
 			Model:         s.Model,
+			ReadOnly:      s.ReadOnly,
 		}, provider)
 		if err != nil {
 			return fmt.Errorf("start stream process: %w", err)
@@ -606,6 +614,7 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 					Resume:        true,
 					CLISessionID:  cliSessionID,
 					Model:         s.Model,
+					ReadOnly:      s.ReadOnly,
 				}, provider)
 				if err != nil {
 					return fmt.Errorf("restart stream process: %w", err)
@@ -626,6 +635,7 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 				Resume:        true,
 				CLISessionID:  cliSessionID,
 				Model:         s.Model,
+				ReadOnly:      s.ReadOnly,
 			}, provider)
 			if err != nil {
 				return fmt.Errorf("restart stream process: %w", err)
@@ -791,9 +801,9 @@ func (m *Manager) GetController() (*Session, error) {
 	var providerStr string
 	var prompt, currentTask, goal, goalsJSON sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, cli_session_id, model, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, cli_session_id, model, current_task, goal, goals, read_only, created_at, updated_at
 		 FROM sessions WHERE type = ? LIMIT 1`, string(TypeController),
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &s.TmuxSession, &status, &sessionType, &outputMode, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &s.ReadOnly, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -885,9 +895,9 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 	}
 
 	_, err = m.db.Exec(
-		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, s.TmuxSession, string(s.Status), string(s.Type), string(s.OutputMode), string(s.Provider), s.CreatedAt, s.UpdatedAt,
+		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, read_only, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, s.TmuxSession, string(s.Status), string(s.Type), string(s.OutputMode), string(s.Provider), s.ReadOnly, s.CreatedAt, s.UpdatedAt,
 	)
 	if err != nil {
 		_ = m.tmux.KillSession(name)
@@ -899,6 +909,12 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 
 func (m *Manager) UpdateStatus(id string, status Status) error {
 	_, err := m.db.Exec("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", string(status), time.Now(), id)
+	return err
+}
+
+// UpdateReadOnly updates the read_only flag for a session.
+func (m *Manager) UpdateReadOnly(id string, readOnly bool) error {
+	_, err := m.db.Exec("UPDATE sessions SET read_only = ?, updated_at = ? WHERE id = ?", readOnly, time.Now(), id)
 	return err
 }
 
@@ -1018,6 +1034,7 @@ func (m *Manager) Reconnect(id string) error {
 			Resume:        true,
 			CLISessionID:  cliSessionID,
 			Model:         s.Model,
+			ReadOnly:      s.ReadOnly,
 		}, provider)
 		if err != nil {
 			return fmt.Errorf("start stream process: %w", err)

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -45,6 +45,7 @@ type Session struct {
 	CurrentTask   string       `json:"currentTask,omitempty"`
 	Goal          string       `json:"goal,omitempty"`
 	Goals         GoalStack    `json:"goals,omitempty"`
+	ReadOnly      bool         `json:"readOnly"`
 	CreatedAt     time.Time    `json:"createdAt"`
 	UpdatedAt     time.Time    `json:"updatedAt"`
 }

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -23,6 +23,7 @@ type StreamOpts struct {
 	CLISessionID   string // provider-specific session ID (for resume)
 	InitialPrompt  string // initial user prompt (used by Codex as positional arg)
 	Model          string // model to use (e.g. "claude-sonnet-4-5", "o4-mini")
+	ReadOnly       bool   // if true, inject read-only guard hook settings
 }
 
 // TerminalOpts contains parameters for building a terminal-mode command.

--- a/internal/session/provider_claude.go
+++ b/internal/session/provider_claude.go
@@ -60,6 +60,10 @@ func (p *ClaudeProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
 	if opts.Worktree {
 		args = append(args, "--worktree")
 	}
+	if opts.ReadOnly {
+		settingsJSON := `{"hooks":{"preToolUse":[{"matcher":"Edit|Write|NotebookEdit|Bash","hook":"agmux hook read-only-guard"}]}}`
+		args = append(args, "--settings", settingsJSON)
+	}
 
 	cmd := exec.Command("claude", args...)
 	cmd.Dir = opts.ProjectPath


### PR DESCRIPTION
## Summary
- Add read-only session mode that blocks file modifications (Edit, Write, NotebookEdit, destructive Bash commands) via a Claude Code preToolUse hook
- Implement `agmux hook read-only-guard` CLI subcommand for the hook
- Add `--settings` injection in BuildStreamCommand for read-only sessions
- Add `PUT /api/sessions/{id}/read-only` API endpoint and `readOnly` field to session creation
- Add Read Only checkbox in creation form, badges in list/detail, and toggle in action menu
- Add `--read-only` flag to `agmux session create` and `agmux session read-only <id> [--off]` subcommand

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] Hook test covers blocked/allowed commands
- [ ] Create a read-only session and verify file modification tools are blocked
- [ ] Toggle read-only mode and verify it persists
- [ ] Verify non-destructive commands (git, ls, grep) are allowed in read-only mode

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)