### PR TITLE
refactor: unify settings.json and changes views with shared FileCodeViewer

### DIFF
--- a/frontend/src/components/session/DiffDropdown.tsx
+++ b/frontend/src/components/session/DiffDropdown.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { FileDiff } from "lucide-react";
 import { Modal } from "../ui/Modal";
+import { FileCodeViewer } from "../ui/FileCodeViewer";
 import type { DiffFile } from "../../api/client";
 
 const statusBadgeColor: Record<string, string> = {
@@ -13,18 +14,10 @@ const statusBadgeColor: Record<string, string> = {
 
 export function DiffDropdown({ files }: { files: DiffFile[] }) {
   const [open, setOpen] = useState(false);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
   if (files.length === 0) return null;
 
-  const toggle = (path: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(path)) next.delete(path);
-      else next.add(path);
-      return next;
-    });
-  };
+  const statusMap = new Map(files.map((f) => [f.path, f.status]));
 
   return (
     <>
@@ -41,45 +34,35 @@ export function DiffDropdown({ files }: { files: DiffFile[] }) {
         onClose={() => setOpen(false)}
         title={<span className="flex items-center gap-2"><FileDiff className="w-4 h-4 text-orange-500" />Changes ({files.length} files)</span>}
       >
-        <div className="border border-gray-200 rounded-lg overflow-hidden">
-          {files.map((file) => (
-            <div key={file.path} className="border-b border-gray-100 last:border-b-0">
-              <button
-                onClick={() => toggle(file.path)}
-                className="w-full flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-gray-50 text-left min-w-0"
-              >
-                <span className={`px-1.5 py-0.5 rounded font-mono text-[10px] font-bold shrink-0 ${statusBadgeColor[file.status] || "bg-gray-100 text-gray-600"}`}>
-                  {file.status}
-                </span>
-                <span className="font-mono text-gray-700 truncate min-w-0">{file.path}</span>
-                {file.diff && (
-                  <span className="ml-auto text-gray-400 shrink-0">{expanded.has(file.path) ? "\u25BC" : "\u25B6"}</span>
-                )}
-              </button>
-              {expanded.has(file.path) && file.diff && (
-                <pre className="bg-gray-50 text-gray-800 text-xs p-3 overflow-x-auto whitespace-pre font-mono border-t border-gray-200">
-                  {file.diff.split("\n").map((line, i) => (
-                    <span
-                      key={i}
-                      className={
-                        line.startsWith("+") && !line.startsWith("+++")
-                          ? "text-green-700 bg-green-50"
-                          : line.startsWith("-") && !line.startsWith("---")
-                            ? "text-red-700 bg-red-50"
-                            : line.startsWith("@@")
-                              ? "text-blue-600"
-                              : ""
-                      }
-                    >
-                      {line}
-                      {"\n"}
-                    </span>
-                  ))}
-                </pre>
-              )}
-            </div>
-          ))}
-        </div>
+        <FileCodeViewer
+          files={files.map((f) => ({ name: f.path, content: f.diff || "" }))}
+          collapsible
+          fileHeaderExtra={(file) => {
+            const status = statusMap.get(file.name) || "?";
+            return (
+              <span className={`px-1.5 py-0.5 rounded font-mono text-[10px] font-bold shrink-0 ${statusBadgeColor[status] || "bg-gray-100 text-gray-600"}`}>
+                {status}
+              </span>
+            );
+          }}
+          renderLine={(line, i) => (
+            <span
+              key={i}
+              className={
+                line.startsWith("+") && !line.startsWith("+++")
+                  ? "text-green-700 bg-green-50"
+                  : line.startsWith("-") && !line.startsWith("---")
+                    ? "text-red-700 bg-red-50"
+                    : line.startsWith("@@")
+                      ? "text-blue-600"
+                      : ""
+              }
+            >
+              {line}
+              {"\n"}
+            </span>
+          )}
+        />
       </Modal>
     </>
   );

--- a/frontend/src/components/ui/FileCodeViewer.tsx
+++ b/frontend/src/components/ui/FileCodeViewer.tsx
@@ -10,6 +10,12 @@ interface FileCodeViewerProps {
   lineClickable?: boolean;
   /** No content message */
   emptyMessage?: string;
+  /** Enable collapsible file list (expand/collapse per file) */
+  collapsible?: boolean;
+  /** Extra element rendered before the file name in the header (e.g. status badge) */
+  fileHeaderExtra?: (file: { name: string; content: string }) => ReactNode;
+  /** Custom line renderer for code display (e.g. diff coloring) */
+  renderLine?: (line: string, index: number) => ReactNode;
 }
 
 export function FileCodeViewer({
@@ -18,16 +24,105 @@ export function FileCodeViewer({
   renderContent,
   lineClickable = false,
   emptyMessage = "No content",
+  collapsible = false,
+  fileHeaderExtra,
+  renderLine,
 }: FileCodeViewerProps) {
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [selectedLine, setSelectedLine] = useState<number | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
   if (files.length === 0) {
     return <div className="text-gray-400 text-sm">{emptyMessage}</div>;
   }
 
+  const toggle = (name: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
   const multiFile = files.length > 1;
 
+  if (collapsible) {
+    return (
+      <div className="border border-gray-200 rounded-lg overflow-hidden">
+        {files.map((file) => {
+          const content = formatContent
+            ? formatContent(file.content)
+            : file.content;
+          const isExpanded = expanded.has(file.name);
+
+          return (
+            <div key={file.name} className="border-b border-gray-100 last:border-b-0">
+              <button
+                onClick={() => toggle(file.name)}
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-gray-50 text-left min-w-0"
+              >
+                {fileHeaderExtra?.(file)}
+                <span className="font-mono text-gray-700 truncate min-w-0">{file.name}</span>
+                <span className="ml-auto text-gray-400 shrink-0">{isExpanded ? "\u25BC" : "\u25B6"}</span>
+              </button>
+              {isExpanded && (
+                renderContent ? (
+                  <div className="border-t border-gray-200 p-3">
+                    {renderContent(file.content)}
+                  </div>
+                ) : (
+                  <pre className="bg-gray-50 text-gray-800 text-xs p-3 overflow-x-auto whitespace-pre font-mono border-t border-gray-200">
+                    {content.split("\n").map((line, i) => {
+                      if (renderLine) return renderLine(line, i);
+
+                      const lineNum = i + 1;
+                      const isSelected =
+                        lineClickable &&
+                        selectedFile === file.name &&
+                        selectedLine === lineNum;
+
+                      return (
+                        <div
+                          key={i}
+                          className={`flex ${lineClickable ? "cursor-pointer" : ""} ${isSelected ? "bg-yellow-100" : "hover:bg-gray-50"}`}
+                          onClick={
+                            lineClickable
+                              ? () => {
+                                  if (isSelected) {
+                                    setSelectedFile(null);
+                                    setSelectedLine(null);
+                                  } else {
+                                    setSelectedFile(file.name);
+                                    setSelectedLine(lineNum);
+                                    navigator.clipboard.writeText(
+                                      `${file.name}:L${lineNum}`,
+                                    );
+                                  }
+                                }
+                              : undefined
+                          }
+                        >
+                          <span
+                            className={`select-none w-10 text-right pr-3 shrink-0 ${isSelected ? "text-yellow-600" : "text-gray-300"}`}
+                          >
+                            {lineNum}
+                          </span>
+                          <span className="flex-1">{line}</span>
+                        </div>
+                      );
+                    })}
+                  </pre>
+                )
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // Non-collapsible mode (original behavior)
   return (
     <div className="space-y-6">
       {files.map((file, fileIdx) => {

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -760,6 +760,7 @@ export function SessionPage() {
         ) : (
           <FileCodeViewer
             files={settingsJSONFiles}
+            collapsible
             formatContent={(content) => {
               try {
                 return JSON.stringify(JSON.parse(content), null, 2);


### PR DESCRIPTION
## Summary
- FileCodeViewerに`collapsible`、`fileHeaderExtra`、`renderLine`プロパティを追加
- DiffDropdownの独自expand/collapseロジックをFileCodeViewerに統合し、共通コンポーネントとして利用
- settings.jsonモーダルでも同じcollapsibleモードを使用するように変更

## Test plan
- [ ] settings.jsonモーダルがexpand/collapse式のファイル一覧で表示される
- [ ] changesモーダルが従来通りステータスバッジ付きdiff表示で動作する
- [ ] 複数ファイルの展開・折りたたみが正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)