### PR TITLE
fix: デフォルトセッションモードをstreamに変更

### DIFF
--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -23,7 +23,7 @@ export function CreateSession({ onClose, onCreate }: Props) {
   const [name, setName] = useState("");
   const [projectPath, setProjectPath] = useState("");
   const [prompt, setPrompt] = useState("");
-  const [outputMode, setOutputMode] = useState<"terminal" | "stream">("terminal");
+  const [outputMode, setOutputMode] = useState<"terminal" | "stream">("stream");
   const [provider, setProvider] = useState("claude");
   const [model, setModel] = useState("");
   const [codexModels, setCodexModels] = useState<CodexModel[]>([]);

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -139,7 +139,7 @@ type CreateOpts struct {
 
 func (m *Manager) Create(name, projectPath, prompt string, outputMode OutputMode, worktree bool, opts ...CreateOpts) (*Session, error) {
 	if outputMode == "" {
-		outputMode = OutputModeTerminal
+		outputMode = OutputModeStream
 	}
 
 	pn := ProviderClaude


### PR DESCRIPTION
## Summary
- API (`POST /api/sessions`) でモード未指定時のデフォルトを `terminal` から `stream` に変更
- フロントエンドのセッション作成UIのデフォルトも `stream` に統一
- CLI (`agmux session create --mode`) は既に `stream` がデフォルトだったため変更不要

## Changed files
- `internal/session/manager.go`: `OutputModeTerminal` → `OutputModeStream` (fallback default)
- `frontend/src/components/CreateSession.tsx`: useState default `"terminal"` → `"stream"`

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)