### PR TITLE
refactor: useEffect パターンの改善

### DIFF
--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -37,9 +37,7 @@ export function CreateSession({ onClose, onCreate }: Props) {
         .then((models) => {
           setCodexModels(models);
           const defaultModel = models.find((m) => m.isDefault);
-          if (defaultModel && !model) {
-            setModel(defaultModel.id);
-          }
+          setModel(defaultModel ? defaultModel.id : "");
         })
         .catch(() => setCodexModels([]))
         .finally(() => setLoadingModels(false));
@@ -47,9 +45,7 @@ export function CreateSession({ onClose, onCreate }: Props) {
       api.getClaudeModels().then((models) => {
         setClaudeModels(models);
         const defaultModel = models.find((m) => m.default);
-        if (defaultModel && !model) {
-          setModel(defaultModel.id);
-        }
+        setModel(defaultModel ? defaultModel.id : "");
       }).catch(() => {
         // Fallback if API is not available
       });

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useNavigate, useLoaderData } from "react-router-dom";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -44,7 +44,6 @@ export function SessionPage() {
   const [reconnectToast, setReconnectToast] = useState(false);
   const [disconnectToast, setDisconnectToast] = useState(false);
   const [clearToast, setClearToast] = useState<"success" | "error" | null>(null);
-  const [slashCommands, setSlashCommands] = useState<string[]>([]);
   const [showSlashMenu, setShowSlashMenu] = useState(false);
   const [showActionMenu, setShowActionMenu] = useState(false);
   const [slashFilter, setSlashFilter] = useState("");
@@ -62,17 +61,15 @@ export function SessionPage() {
   const streamCursorRef = useRef<number | null>(null);
 
   // Extract slash_commands from system init messages
-  useEffect(() => {
+  const slashCommands = useMemo(() => {
     for (const line of streamLines) {
       const entry = line as Record<string, unknown>;
       if (entry.type === "system" && entry.subtype === "init") {
         const cmds = entry.slash_commands as string[] | undefined;
-        if (cmds && cmds.length > 0) {
-          setSlashCommands(cmds);
-        }
-        break;
+        return cmds && cmds.length > 0 ? cmds : [];
       }
     }
+    return [];
   }, [streamLines]);
 
   // Track active session name for notification suppression
@@ -149,12 +146,13 @@ export function SessionPage() {
   useEffect(() => {
     if (connectionState === "disconnected") {
       setDisconnectToast(true);
-    } else if (connectionState === "connected" && disconnectToast) {
+    } else if (connectionState === "connected") {
       setDisconnectToast(false);
       setReconnectToast(true);
-      setTimeout(() => setReconnectToast(false), 3000);
+      const timer = setTimeout(() => setReconnectToast(false), 3000);
+      return () => clearTimeout(timer);
     }
-  }, [connectionState, disconnectToast]);
+  }, [connectionState]);
 
   const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
   const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];


### PR DESCRIPTION
## Summary
- SessionPage: `slashCommands` を useEffect + setState → `useMemo` 派生状態に変更
- SessionPage: toast の useEffect から不要な deps (`disconnectToast`) を削除、setTimeout の cleanup 追加
- CreateSession: provider 変更時のモデル初期化を無条件リセットに修正（stale closure 回避）

## Test plan
- [ ] `npm run build` が通ること（確認済み）
- [ ] セッション画面でスラッシュコマンドが正常に表示されること
- [ ] WebSocket 切断→再接続時の toast 表示が正常に動作すること
- [ ] プロバイダ切り替え時にデフォルトモデルが正しく選択されること

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)