### PR TITLE
fix: refetch full stream data on WebSocket reconnection

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -128,16 +128,14 @@ export function SessionPage() {
   // On WebSocket reconnection, do a full sync to catch up on missed messages
   useEffect(() => {
     if (prevConnectionState.current === "disconnected" && connectionState === "connected" && sessionId) {
-      const cursor = streamCursorRef.current;
-      if (cursor !== null) {
-        api.getStreamOutputDelta(sessionId, cursor).then((resp) => {
-          if (resp.lines.length > 0) {
-            setStreamLines((prev) => [...prev, ...resp.lines]);
-          }
-          streamCursorRef.current = resp.total;
-        }).catch(() => {});
-      }
+      // Re-fetch full stream data to ensure no gaps from disconnection
+      api.getStreamOutput(sessionId).then((resp) => {
+        setStreamLines(resp.lines);
+        setPartialText("");
+        streamCursorRef.current = resp.total;
+      }).catch(() => {});
       api.getSession(sessionId).then(setSession).catch(() => {});
+      api.getDiff(sessionId).then((r) => setDiffFiles(r.files)).catch(() => {});
     }
     prevConnectionState.current = connectionState;
   }, [connectionState, sessionId]);


### PR DESCRIPTION
## Summary
- WebSocket再接続時に、デルタ取得ではなくストリームデータの**全件再取得**を行うように変更
- 切断中に失われたイベントデータを確実に補完し、UIの整合性を保つ
- 再接続時にpartialTextのクリア、diffファイルの再取得も実施

## Changes
- `api.getStreamOutputDelta()` (差分取得) → `api.getStreamOutput()` (全件取得) に変更
- `setPartialText("")` で中途半端なストリーミングテキストをリセット
- `api.getDiff()` で差分ファイル情報も再取得

Closes #283

## Test plan
- [ ] WebSocket接続が切断された後、再接続時にストリームデータが最新状態に更新されることを確認
- [ ] 再接続後にpartialTextがクリアされ、表示が正常であることを確認
- [ ] `make build` / `make test` がパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)