### PR TITLE
fix: 警告アラートがスマホで画面をはみ出す問題を修正

### DIFF
--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -9,7 +9,7 @@ export function Toast({ message, variant = "success" }: { message: string; varia
   const Icon = variant === "success" ? CheckCircle2 : AlertTriangle;
 
   return (
-    <div className={`fixed top-4 right-4 z-50 ${styles} text-white px-4 py-2 rounded shadow-lg text-sm flex items-center gap-2 animate-fade-in`}>
+    <div className={`fixed top-4 left-4 right-4 sm:left-auto z-50 ${styles} text-white px-4 py-2 rounded shadow-lg text-sm flex items-center gap-2 animate-fade-in box-border`}>
       <Icon className="w-4 h-4" />
       {message}
     </div>


### PR DESCRIPTION
## Summary
- Toastコンポーネントにモバイル向けの幅制約を追加
- `left-4 right-4` でスマホ画面幅内に収まるようにし、`sm:left-auto` でデスクトップでは従来通り右寄せ表示を維持

## Test plan
- [ ] スマホ幅(375px程度)でWebSocket切断トーストが画面内に収まることを確認
- [ ] デスクトップ幅では従来通り右上に表示されることを確認

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)