### PR TITLE
fix: Toastコンポーネントのモバイルレイアウトを修正

### DIFF
--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -9,9 +9,11 @@ export function Toast({ message, variant = "success" }: { message: string; varia
   const Icon = variant === "success" ? CheckCircle2 : AlertTriangle;
 
   return (
-    <div className={`fixed top-4 left-4 right-4 sm:left-auto z-50 ${styles} text-white px-4 py-2 rounded shadow-lg text-sm flex items-center gap-2 animate-fade-in box-border`}>
-      <Icon className="w-4 h-4" />
-      {message}
+    <div className="fixed top-4 left-4 right-4 sm:left-auto sm:right-4 z-50 flex justify-end">
+      <div className={`${styles} text-white px-4 py-2 rounded shadow-lg text-sm flex items-center gap-2 animate-fade-in w-fit max-w-full`}>
+        <Icon className="w-4 h-4 shrink-0" />
+        {message}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Toastを外側コンテナ+内側divの2層構造に変更し、モバイルで左端の余白が欠落する問題を修正
- `w-fit` でコンテンツ幅に収め、`max-w-full` で溢れを防止
- `shrink-0` でアイコンの潰れを防止

Closes #300と関連

🤖 Generated with [Claude Code](https://claude.com/claude-code)