### PR TITLE
fix: Codexセッションのsandboxモードが--full-autoで上書きされる問題を修正

### DIFF
--- a/internal/session/provider_codex.go
+++ b/internal/session/provider_codex.go
@@ -36,20 +36,15 @@ func (p *CodexProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
 		args = append(args, "exec", "resume",
 			"--json",
 		)
-		if opts.FullAuto {
-			args = append(args, "--full-auto")
-		}
 		args = append(args, opts.CLISessionID)
 	} else {
 		// Start a new session
+		// Note: Do NOT use --full-auto here as it forces --sandbox workspace-write,
+		// overriding danger-full-access. In exec mode there is no approval prompt anyway.
 		args = append(args, "exec",
 			"--json",
+			"--sandbox", "danger-full-access",
 		)
-		if opts.FullAuto {
-			args = append(args, "--full-auto", "--sandbox", "danger-full-access")
-		} else {
-			args = append(args, "--sandbox", "danger-full-access")
-		}
 	}
 
 	// Codex CLI does not support --mcp-config or --instructions flags.
@@ -107,13 +102,13 @@ func (p *CodexProvider) BuildTerminalCommand(opts TerminalOpts) string {
 	if opts.Resume {
 		cmd = otelPrefix + p.command + " resume " + opts.SessionID
 		if opts.FullAuto {
-			cmd += " --full-auto"
+			cmd += " -a never"
 		}
 		cmd += " --sandbox danger-full-access"
 	} else {
 		cmd = otelPrefix + p.command
 		if opts.FullAuto {
-			cmd += " --full-auto"
+			cmd += " -a never"
 		}
 		cmd += " --sandbox danger-full-access"
 	}

--- a/internal/session/provider_codex_test.go
+++ b/internal/session/provider_codex_test.go
@@ -80,12 +80,12 @@ func TestCodexProvider_BuildStreamCommand_FullAuto(t *testing.T) {
 	})
 
 	args := cmd.Args
-	// Should contain both --full-auto and --sandbox danger-full-access
-	if !containsArg(args, "--full-auto") {
-		t.Errorf("expected args to contain '--full-auto', got: %v", args)
-	}
+	// exec mode always uses --sandbox danger-full-access (no --full-auto which forces workspace-write)
 	if !containsArg(args, "--sandbox") {
 		t.Errorf("expected args to contain '--sandbox', got: %v", args)
+	}
+	if containsArg(args, "--full-auto") {
+		t.Errorf("should not contain '--full-auto' (it forces workspace-write sandbox), got: %v", args)
 	}
 }
 
@@ -100,12 +100,12 @@ func TestCodexProvider_BuildStreamCommand_FullAuto_Resume(t *testing.T) {
 	})
 
 	args := cmd.Args
-	// Should contain --full-auto and resume
-	if !containsArg(args, "--full-auto") {
-		t.Errorf("expected args to contain '--full-auto', got: %v", args)
-	}
+	// exec resume mode: no approval flags needed (non-interactive)
 	if !containsArg(args, "resume") {
 		t.Errorf("expected args to contain 'resume', got: %v", args)
+	}
+	if containsArg(args, "--full-auto") {
+		t.Errorf("should not contain '--full-auto', got: %v", args)
 	}
 }
 
@@ -409,8 +409,11 @@ func TestCodexBuildTerminalCommand_FullAuto(t *testing.T) {
 		FullAuto:  true,
 	})
 
-	if !strings.Contains(cmd, "--full-auto") {
-		t.Errorf("expected --full-auto flag, got %s", cmd)
+	if !strings.Contains(cmd, "-a never") {
+		t.Errorf("expected '-a never' flag, got %s", cmd)
+	}
+	if strings.Contains(cmd, "--full-auto") {
+		t.Errorf("should not contain --full-auto (forces workspace-write), got %s", cmd)
 	}
 	if !strings.Contains(cmd, "--sandbox danger-full-access") {
 		t.Errorf("expected --sandbox danger-full-access with full-auto, got %s", cmd)
@@ -425,8 +428,11 @@ func TestCodexBuildTerminalCommand_FullAuto_Resume(t *testing.T) {
 		FullAuto:  true,
 	})
 
-	if !strings.Contains(cmd, "--full-auto") {
-		t.Errorf("expected --full-auto flag, got %s", cmd)
+	if !strings.Contains(cmd, "-a never") {
+		t.Errorf("expected '-a never' flag, got %s", cmd)
+	}
+	if strings.Contains(cmd, "--full-auto") {
+		t.Errorf("should not contain --full-auto, got %s", cmd)
 	}
 	if !strings.Contains(cmd, "resume") {
 		t.Errorf("expected resume, got %s", cmd)


### PR DESCRIPTION
## Summary
- `--full-auto`フラグが内部的に`--sandbox workspace-write`を強制設定するため、明示的に指定した`--sandbox danger-full-access`が無効化されていた
- exec mode: `--full-auto`を削除し`--sandbox danger-full-access`のみ指定（非インタラクティブなので承認制御は不要）
- terminal mode: `--full-auto`の代わりに`-a never --sandbox danger-full-access`を個別指定

## Test plan
- [x] `go test ./internal/session/ -run TestCodex` 全38テストパス
- [x] Codexセッションを作成し、ファイル書き込みが成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)