### PR TITLE
fix: restart_server MCPツールで再起動完了通知が届かない問題を修正

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -294,16 +294,27 @@ func (s *Server) launchctlKickstart() error {
 	return exec.Command("launchctl", "kickstart", "-k", serviceTarget).Run()
 }
 
-// waitForServerReady はサーバーのAPIにアクセスできるようになるまでポーリングする
+// waitForServerReady はサーバーのAPIにアクセスできるようになるまでポーリングする。
+// 旧プロセスの応答を誤認しないよう、まず旧プロセスの停止を確認（接続エラー）してから
+// 新プロセスの起動完了を待つ2フェーズ方式を採用している。
 func (s *Server) waitForServerReady(timeout, interval time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	client := &http.Client{Timeout: 2 * time.Second}
+	url := fmt.Sprintf("%s/api/sessions", s.apiURL)
 
-	// kickstart直後はまだ旧プロセスが応答する可能性があるので少し待つ
-	time.Sleep(1 * time.Second)
-
+	// Phase 1: 旧プロセスが停止するのを待つ（接続エラーになるまでポーリング）
 	for time.Now().Before(deadline) {
-		url := fmt.Sprintf("%s/api/sessions", s.apiURL)
+		resp, err := client.Get(url)
+		if err != nil {
+			// 接続エラー = 旧プロセスが停止した
+			break
+		}
+		resp.Body.Close()
+		time.Sleep(interval)
+	}
+
+	// Phase 2: 新プロセスが起動するのを待つ（200 OKが返るまでポーリング）
+	for time.Now().Before(deadline) {
 		resp, err := client.Get(url)
 		if err == nil {
 			resp.Body.Close()


### PR DESCRIPTION
## Summary
- `restart_server` MCPツールが `launchctl kickstart` 後に即座にレスポンスを返していたため、サーバーがまだ起動完了していない状態でエージェントが後続の操作を行い、再起動完了の通知が届かない問題を修正
- 再起動キック後にAPIエンドポイント (`/api/sessions`) をポーリングし、サーバーが応答可能になるまで待機してからレスポンスを返すように変更
- タイムアウト（30秒）を超えた場合はエラーとして報告

## Test plan
- [ ] `restart_server` MCPツールを実行し、レスポンスが「サーバーの再起動が完了しました。」になることを確認
- [ ] 再起動後に他のMCPツール（`get_goal` 等）が正常に動作することを確認

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)