### PR TITLE
feat: セッション詳細画面にサブエージェント・タスクの実行状況を表示

### DIFF
--- a/frontend/src/components/session/StreamOutputView.tsx
+++ b/frontend/src/components/session/StreamOutputView.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { StreamEntry } from "../../models/stream";
-import { mergeStreamEntries } from "../../models/stream";
+import { mergeStreamEntries, extractActiveTasks } from "../../models/stream";
+import type { ActiveTask } from "../../models/stream";
 import { useAutoScroll } from "../../hooks/useAutoScroll";
 import { StreamDisplayItemView } from "./StreamDisplayItemView";
 
@@ -31,6 +32,7 @@ export function StreamOutputView({ lines, partialText, className, onAnswer, sess
     .filter((e) => e.type === "user" || e.type === "assistant" || e.type === "system");
 
   const groups = mergeStreamEntries(entries, partialText || undefined, provider);
+  const activeTasks = useMemo(() => extractActiveTasks(entries), [entries]);
 
   return (
     <div className={`flex flex-col ${className || ""}`}>
@@ -83,7 +85,48 @@ export function StreamOutputView({ lines, partialText, className, onAnswer, sess
             );
           })
         )}
+        {activeTasks.length > 0 && (
+          <ActiveTasksPanel tasks={activeTasks} />
+        )}
       </div>
+    </div>
+  );
+}
+
+function ActiveTasksPanel({ tasks }: { tasks: ActiveTask[] }) {
+  return (
+    <div className="border border-amber-200 bg-amber-50 rounded-lg p-3 space-y-2">
+      <div className="flex items-center gap-1.5 text-xs font-semibold text-amber-700">
+        <span className="inline-block w-2 h-2 rounded-full bg-amber-500 animate-pulse" />
+        Running Tasks ({tasks.length})
+      </div>
+      {tasks.map((task) => (
+        <div key={task.taskId} className="bg-white rounded border border-amber-100 px-3 py-2 text-xs space-y-1">
+          <div className="flex items-center gap-2">
+            <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
+              task.taskType === "local_agent"
+                ? "bg-purple-100 text-purple-700"
+                : "bg-gray-100 text-gray-600"
+            }`}>
+              {task.taskType === "local_agent" ? "Agent" : task.taskType === "local_bash" ? "Bash" : task.taskType}
+            </span>
+            {task.lastToolName && (
+              <span className="text-gray-500">
+                <span className="text-gray-400">tool:</span> {task.lastToolName}
+              </span>
+            )}
+            {task.usage && (
+              <span className="text-gray-400 ml-auto">
+                {task.usage.inputTokens != null && `${Math.round(task.usage.inputTokens / 1000)}k in`}
+                {task.usage.outputTokens != null && ` / ${Math.round(task.usage.outputTokens / 1000)}k out`}
+              </span>
+            )}
+          </div>
+          {task.description && (
+            <div className="text-gray-600 truncate">{task.description}</div>
+          )}
+        </div>
+      ))}
     </div>
   );
 }

--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -55,6 +55,51 @@ export type StreamDisplayItem =
   | { kind: "thinking"; text: string }
   | { kind: "system_event"; eventType: string; label: string; detail?: string };
 
+// Active task tracking for sub-agents and background tasks
+export interface ActiveTask {
+  taskId: string;
+  taskType: string; // "local_agent" | "local_bash"
+  description?: string;
+  lastToolName?: string;
+  usage?: { inputTokens?: number; outputTokens?: number };
+}
+
+export function extractActiveTasks(entries: StreamEntry[]): ActiveTask[] {
+  const tasks = new Map<string, ActiveTask>();
+  for (const entry of entries) {
+    const raw = entry as unknown as Record<string, unknown>;
+    if (entry.type !== "system") continue;
+    const subtype = raw.subtype as string | undefined;
+    if (subtype === "task_started") {
+      const taskId = raw.task_id as string;
+      const taskType = raw.task_type as string;
+      if (taskId) {
+        tasks.set(taskId, { taskId, taskType: taskType || "unknown" });
+      }
+    } else if (subtype === "task_progress") {
+      const taskId = raw.task_id as string;
+      if (taskId && tasks.has(taskId)) {
+        const task = tasks.get(taskId)!;
+        if (raw.description) task.description = raw.description as string;
+        if (raw.last_tool_name) task.lastToolName = raw.last_tool_name as string;
+        if (raw.usage) {
+          const usage = raw.usage as Record<string, unknown>;
+          task.usage = {
+            inputTokens: usage.input_tokens as number | undefined,
+            outputTokens: usage.output_tokens as number | undefined,
+          };
+        }
+      }
+    } else if (subtype === "task_notification") {
+      const taskId = raw.task_id as string;
+      if (taskId) {
+        tasks.delete(taskId);
+      }
+    }
+  }
+  return Array.from(tasks.values());
+}
+
 export function parseStreamContentBlocks(entry: StreamEntry): StreamContentBlock[] {
   // Check both entry.message.content and top-level entry.content (some entries
   // have content at the top level without a message wrapper)


### PR DESCRIPTION
## Summary
- セッション詳細画面のメッセージ一覧の下部に、実行中のサブエージェント・タスクの一覧を表示
- `task_started` で一覧に追加、`task_progress` で進捗更新（description, last_tool_name, usage）、`task_notification` で一覧から削除
- タスクタイプ（Agent / Bash）をバッジで表示し、現在使用中のツール名やトークン使用量も表示

## Test plan
- [ ] サブエージェント実行中のセッションで、画面下部にタスク一覧が表示されることを確認
- [ ] タスク完了後に一覧から消えることを確認
- [ ] `make build` 成功
- [ ] `make test` 成功

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)