### PR TITLE
fix: Codexセッションでツール実行結果(output)を表示する

### DIFF
--- a/frontend/src/components/session/StreamOutputView.tsx
+++ b/frontend/src/components/session/StreamOutputView.tsx
@@ -11,7 +11,7 @@ const roleStyles: Record<string, { bg: string; label: string; text: string }> = 
 
 type StreamViewMode = "markdown" | "json";
 
-export function StreamOutputView({ lines, partialText, className, onAnswer, sessionId, escalationId, escalationTimedOut, escalationTimeoutSeconds, onEscalationResponded }: {
+export function StreamOutputView({ lines, partialText, className, onAnswer, sessionId, escalationId, escalationTimedOut, escalationTimeoutSeconds, onEscalationResponded, provider }: {
   lines: unknown[];
   partialText?: string;
   className?: string;
@@ -21,6 +21,7 @@ export function StreamOutputView({ lines, partialText, className, onAnswer, sess
   escalationTimedOut?: boolean;
   escalationTimeoutSeconds?: number;
   onEscalationResponded?: () => void;
+  provider?: string;
 }) {
   const { ref, onScroll } = useAutoScroll(lines);
   const [viewMode, setViewMode] = useState<StreamViewMode>("markdown");
@@ -29,7 +30,7 @@ export function StreamOutputView({ lines, partialText, className, onAnswer, sess
     .map((line) => line as StreamEntry)
     .filter((e) => e.type === "user" || e.type === "assistant" || e.type === "system");
 
-  const groups = mergeStreamEntries(entries, partialText || undefined);
+  const groups = mergeStreamEntries(entries, partialText || undefined, provider);
 
   return (
     <div className={`flex flex-col ${className || ""}`}>

--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -125,7 +125,7 @@ export type DisplayGroup =
 
 // Merge assistant/user entries into display items, pairing tool_use with tool_result by id
 // partialText: incremental text from stream_event deltas (shown as "typing" in the last assistant group)
-export function mergeStreamEntries(entries: StreamEntry[], partialText?: string): DisplayGroup[] {
+export function mergeStreamEntries(entries: StreamEntry[], partialText?: string, provider?: string): DisplayGroup[] {
   // First pass: collect all tool_results keyed by tool_use_id, and track Skill tool IDs
   const resultMap = new Map<string, string>();
   const resultImageMap = new Map<string, Array<{ mediaType: string; data: string }>>();
@@ -265,20 +265,24 @@ export function mergeStreamEntries(entries: StreamEntry[], partialText?: string)
             continue;
           }
 
-          // For Claude: look up result by tool_use_id from user entries
-          let result = b.id ? resultMap.get(b.id) : undefined;
-          let resultImages = b.id ? resultImageMap.get(b.id) : undefined;
+          let result: string | undefined;
+          let resultImages: Array<{ mediaType: string; data: string }> | undefined;
 
-          // For Codex: tool_result is in the same assistant content array (no id/tool_use_id pairing)
-          // Check if the next block is a tool_result and use its content directly
-          if (result === undefined && bi + 1 < blocks.length && blocks[bi + 1].type === "tool_result") {
-            const nextBlock = blocks[bi + 1];
-            if (typeof nextBlock.content === "string") {
-              result = nextBlock.content;
-            } else if (nextBlock.content != null) {
-              result = JSON.stringify(nextBlock.content);
+          if (provider === "codex") {
+            // Codex: tool_result is in the same assistant content array, directly after tool_use
+            if (bi + 1 < blocks.length && blocks[bi + 1].type === "tool_result") {
+              const nextBlock = blocks[bi + 1];
+              if (typeof nextBlock.content === "string") {
+                result = nextBlock.content;
+              } else if (nextBlock.content != null) {
+                result = JSON.stringify(nextBlock.content);
+              }
+              bi++; // skip the tool_result block since we consumed it
             }
-            bi++; // skip the tool_result block since we consumed it
+          } else {
+            // Claude: look up result by tool_use_id from user entries
+            result = b.id ? resultMap.get(b.id) : undefined;
+            resultImages = b.id ? resultImageMap.get(b.id) : undefined;
           }
 
           // For Skill calls, fold the next user text (skill content) into the result

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -717,7 +717,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
         </div>
       ) : (
         <div className="flex flex-col flex-1 min-h-0">
-          <StreamOutputView lines={streamLines} partialText={partialText} className="flex-1 min-h-0" sessionId={sessionId} escalationId={pendingEscalationId ?? undefined} escalationTimedOut={escalationTimedOut} escalationTimeoutSeconds={escalationTimeoutSeconds} onEscalationResponded={() => { setPendingEscalationId(null); setEscalationTimedOut(false); }} onAnswer={async (text) => {
+          <StreamOutputView lines={streamLines} partialText={partialText} className="flex-1 min-h-0" sessionId={sessionId} escalationId={pendingEscalationId ?? undefined} escalationTimedOut={escalationTimedOut} escalationTimeoutSeconds={escalationTimeoutSeconds} onEscalationResponded={() => { setPendingEscalationId(null); setEscalationTimedOut(false); }} provider={session?.provider ?? undefined} onAnswer={async (text) => {
             if (!sessionId) return;
             await api.sendToSession(sessionId, text);
           }} />


### PR DESCRIPTION
## Summary
- Codexセッションでツール実行結果（stdout/stderr等）が表示されない問題を修正
- Codexプロバイダーは`tool_use`と`tool_result`を同一assistant content配列内に配置するが、フロントエンドはClaude形式（別エントリでID紐付け）のみ対応していた
- assistant content配列内で`tool_use`の直後に`tool_result`がある場合、そのcontentを直接resultとして使用するよう`mergeStreamEntries`を修正

## Test plan
- [x] `make build` ビルド成功
- [x] `make test` テスト通過

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)