### PR TITLE
feat: agmux外で起動されたCodexプロセスも検出・表示する

### DIFF
--- a/internal/session/external.go
+++ b/internal/session/external.go
@@ -11,10 +11,11 @@ import (
 	"time"
 )
 
-// ExternalProcess represents a Claude process running outside of agmux.
+// ExternalProcess represents a Claude or Codex process running outside of agmux.
 type ExternalProcess struct {
-	PID int
-	CWD string
+	PID      int
+	CWD      string
+	Provider ProviderName
 }
 
 // ExternalDetector detects Claude processes running outside of agmux.
@@ -72,9 +73,9 @@ func (d *ExternalDetector) Sessions() []Session {
 	return result
 }
 
-// detect finds external Claude processes and updates the sessions list.
+// detect finds external Claude and Codex processes and updates the sessions list.
 func (d *ExternalDetector) detect() {
-	processes, err := findExternalClaudeProcesses()
+	processes, err := findExternalProcesses()
 	if err != nil {
 		d.logger.Error("failed to detect external processes", "error", err)
 		return
@@ -97,11 +98,11 @@ func (d *ExternalDetector) detect() {
 		projectName := projectNameFromPath(p.CWD)
 		s := Session{
 			ID:          id,
-			Name:        fmt.Sprintf("claude (pid:%d)", p.PID),
+			Name:        fmt.Sprintf("%s (pid:%d)", p.Provider, p.PID),
 			ProjectPath: p.CWD,
 			Status:      StatusWorking,
 			Type:        TypeExternal,
-			Provider:    ProviderClaude,
+			Provider:    p.Provider,
 			CreatedAt:   createdAt,
 			UpdatedAt:   now,
 		}
@@ -123,11 +124,11 @@ func (d *ExternalDetector) detect() {
 	d.mu.Unlock()
 }
 
-// findExternalClaudeProcesses finds Claude processes not managed by this agmux instance.
-func findExternalClaudeProcesses() ([]ExternalProcess, error) {
+// findExternalProcesses finds Claude and Codex processes not managed by this agmux instance.
+func findExternalProcesses() ([]ExternalProcess, error) {
 	myPID := os.Getpid()
 
-	// Get all Claude processes: ps -eo pid,ppid,comm
+	// Get all processes: ps -eo pid,ppid,comm
 	out, err := exec.Command("ps", "-eo", "pid,ppid,comm").Output()
 	if err != nil {
 		return nil, fmt.Errorf("ps command failed: %w", err)
@@ -136,7 +137,11 @@ func findExternalClaudeProcesses() ([]ExternalProcess, error) {
 	// Collect all PIDs in the agmux process tree
 	agmuxPIDs := collectProcessTree(myPID, string(out))
 
-	var claudePIDs []int
+	type pidWithProvider struct {
+		PID      int
+		Provider ProviderName
+	}
+	var externalPIDs []pidWithProvider
 	for _, line := range strings.Split(string(out), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 3 {
@@ -147,28 +152,29 @@ func findExternalClaudeProcesses() ([]ExternalProcess, error) {
 			continue
 		}
 		comm := fields[2]
-		// Match claude process (the binary name)
-		if !isClaudeProcess(comm) {
+		provider := detectProvider(comm)
+		if provider == "" {
 			continue
 		}
 		// Skip if this process is in the agmux tree
 		if agmuxPIDs[pid] {
 			continue
 		}
-		claudePIDs = append(claudePIDs, pid)
+		externalPIDs = append(externalPIDs, pidWithProvider{PID: pid, Provider: provider})
 	}
 
-	if len(claudePIDs) == 0 {
+	if len(externalPIDs) == 0 {
 		return nil, nil
 	}
 
-	// Get CWD for each external Claude process via lsof
+	// Get CWD for each external process via lsof
 	var results []ExternalProcess
-	for _, pid := range claudePIDs {
-		cwd := getCWD(pid)
+	for _, p := range externalPIDs {
+		cwd := getCWD(p.PID)
 		results = append(results, ExternalProcess{
-			PID: pid,
-			CWD: cwd,
+			PID:      p.PID,
+			CWD:      cwd,
+			Provider: p.Provider,
 		})
 	}
 
@@ -210,12 +216,29 @@ func collectProcessTree(rootPID int, psOutput string) map[int]bool {
 
 // isClaudeProcess checks if a process name corresponds to Claude CLI.
 func isClaudeProcess(comm string) bool {
-	// The binary might be "claude" or a full path ending in "/claude"
+	return detectProvider(comm) == ProviderClaude
+}
+
+// isCodexProcess checks if a process name corresponds to Codex CLI.
+func isCodexProcess(comm string) bool {
+	return detectProvider(comm) == ProviderCodex
+}
+
+// detectProvider returns the provider name for a given process command name.
+// Returns empty string if the process is not a recognized AI agent.
+func detectProvider(comm string) ProviderName {
 	base := comm
 	if idx := strings.LastIndex(comm, "/"); idx >= 0 {
 		base = comm[idx+1:]
 	}
-	return base == "claude"
+	switch base {
+	case "claude":
+		return ProviderClaude
+	case "codex":
+		return ProviderCodex
+	default:
+		return ""
+	}
 }
 
 // getCWD returns the current working directory of a process.

--- a/internal/session/external_test.go
+++ b/internal/session/external_test.go
@@ -13,7 +13,9 @@ func TestCollectProcessTree(t *testing.T) {
   300   100 bash
   400   300 claude
   500     1 claude
-  600    50 claude`
+  600    50 claude
+  700     1 codex
+  800   100 codex`
 
 	tree := collectProcessTree(100, psOutput)
 
@@ -30,6 +32,9 @@ func TestCollectProcessTree(t *testing.T) {
 	if !tree[400] {
 		t.Error("expected grandchild PID 400 to be in tree")
 	}
+	if !tree[800] {
+		t.Error("expected child PID 800 (codex) to be in tree")
+	}
 
 	// Should NOT include external processes
 	if tree[500] {
@@ -37,6 +42,9 @@ func TestCollectProcessTree(t *testing.T) {
 	}
 	if tree[600] {
 		t.Error("PID 600 should not be in agmux tree")
+	}
+	if tree[700] {
+		t.Error("PID 700 should not be in agmux tree")
 	}
 }
 
@@ -52,12 +60,57 @@ func TestIsClaudeProcess(t *testing.T) {
 		{"claudeX", false},
 		{"bash", false},
 		{"", false},
+		{"codex", false},
 	}
 
 	for _, tt := range tests {
 		got := isClaudeProcess(tt.comm)
 		if got != tt.want {
 			t.Errorf("isClaudeProcess(%q) = %v, want %v", tt.comm, got, tt.want)
+		}
+	}
+}
+
+func TestIsCodexProcess(t *testing.T) {
+	tests := []struct {
+		comm string
+		want bool
+	}{
+		{"codex", true},
+		{"/usr/local/bin/codex", true},
+		{"/opt/homebrew/bin/codex", true},
+		{"node", false},
+		{"codexX", false},
+		{"claude", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		got := isCodexProcess(tt.comm)
+		if got != tt.want {
+			t.Errorf("isCodexProcess(%q) = %v, want %v", tt.comm, got, tt.want)
+		}
+	}
+}
+
+func TestDetectProvider(t *testing.T) {
+	tests := []struct {
+		comm string
+		want ProviderName
+	}{
+		{"claude", ProviderClaude},
+		{"/usr/local/bin/claude", ProviderClaude},
+		{"codex", ProviderCodex},
+		{"/usr/local/bin/codex", ProviderCodex},
+		{"node", ""},
+		{"bash", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		got := detectProvider(tt.comm)
+		if got != tt.want {
+			t.Errorf("detectProvider(%q) = %q, want %q", tt.comm, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- #307 のClaude外部プロセス検出ロジックを拡張し、Codexプロセスも検出対象に追加
- `detectProvider` 関数を導入し、プロセス名から `ProviderClaude` / `ProviderCodex` を判定
- `ExternalProcess` に `Provider` フィールドを追加し、検出されたプロセスの種別を保持

## Test plan
- [x] `TestDetectProvider` で claude/codex/その他の判定を確認
- [x] `TestIsCodexProcess` で codex バイナリ名の判定を確認
- [x] `TestCollectProcessTree` に codex プロセスのケースを追加
- [x] `make build` でビルド成功を確認

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)