### PR TITLE
feat: サブエージェント表示を入力ボックス上に固定表示する

### DIFF
--- a/frontend/src/components/session/StreamOutputView.tsx
+++ b/frontend/src/components/session/StreamOutputView.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import type { StreamEntry } from "../../models/stream";
-import { mergeStreamEntries, extractActiveTasks } from "../../models/stream";
+import { mergeStreamEntries } from "../../models/stream";
 import type { ActiveTask } from "../../models/stream";
 import { useAutoScroll } from "../../hooks/useAutoScroll";
 import { StreamDisplayItemView } from "./StreamDisplayItemView";
@@ -32,7 +32,6 @@ export function StreamOutputView({ lines, partialText, className, onAnswer, sess
     .filter((e) => e.type === "user" || e.type === "assistant" || e.type === "system");
 
   const groups = mergeStreamEntries(entries, partialText || undefined, provider);
-  const activeTasks = useMemo(() => extractActiveTasks(entries), [entries]);
 
   return (
     <div className={`flex flex-col ${className || ""}`}>
@@ -85,15 +84,12 @@ export function StreamOutputView({ lines, partialText, className, onAnswer, sess
             );
           })
         )}
-        {activeTasks.length > 0 && (
-          <ActiveTasksPanel tasks={activeTasks} />
-        )}
       </div>
     </div>
   );
 }
 
-function ActiveTasksPanel({ tasks }: { tasks: ActiveTask[] }) {
+export function ActiveTasksPanel({ tasks }: { tasks: ActiveTask[] }) {
   return (
     <div className="border border-amber-200 bg-amber-50 rounded-lg p-3 space-y-2">
       <div className="flex items-center gap-1.5 text-xs font-semibold text-amber-700">

--- a/frontend/src/components/session/index.ts
+++ b/frontend/src/components/session/index.ts
@@ -1,5 +1,5 @@
 export { ToolInputView } from "./ToolInputView";
 export { ToolCallView } from "./ToolCallView";
 export { StreamDisplayItemView } from "./StreamDisplayItemView";
-export { StreamOutputView } from "./StreamOutputView";
+export { StreamOutputView, ActiveTasksPanel } from "./StreamOutputView";
 export { DiffDropdown } from "./DiffDropdown";

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -16,8 +16,10 @@ import { api, type DiffFile } from "../api/client";
 import { StatusDot } from "../components/StatusBadge";
 import { setActiveSessionName } from "../activeSession";
 import { useWebSocket } from "../hooks/useWebSocket";
-import { StreamOutputView } from "../components/session/StreamOutputView";
+import { StreamOutputView, ActiveTasksPanel } from "../components/session/StreamOutputView";
 import { DiffDropdown } from "../components/session/DiffDropdown";
+import type { StreamEntry } from "../models/stream";
+import { extractActiveTasks } from "../models/stream";
 
 type DeferredData = {
   streamOutput: { lines: unknown[]; total: number };
@@ -96,6 +98,14 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
 
   const providerVersion = deferred.providerVersion;
   const streamCursorRef = useRef<number | null>(null);
+
+  // Compute active tasks for fixed display above input
+  const activeTasks = useMemo(() => {
+    const entries = streamLines
+      .map((line) => line as StreamEntry)
+      .filter((e: StreamEntry) => e.type === "user" || e.type === "assistant" || e.type === "system");
+    return extractActiveTasks(entries);
+  }, [streamLines]);
 
   // Extract slash_commands from system init messages
   const slashCommands = useMemo(() => {
@@ -721,6 +731,11 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
             if (!sessionId) return;
             await api.sendToSession(sessionId, text);
           }} />
+          {activeTasks.length > 0 && (
+            <div className="shrink-0 pt-2 px-4 sm:px-8 -mx-4 sm:-mx-8">
+              <ActiveTasksPanel tasks={activeTasks} />
+            </div>
+          )}
           {sendForm}
         </div>
       )}


### PR DESCRIPTION
## Summary
- ActiveTasksPanel（実行中サブエージェント・タスク一覧）をメッセージスクロール領域の内側から外側に移動
- 入力ボックスの直上に固定表示されるように変更し、メッセージをスクロールしても常に見える状態に
- タスクがない場合は非表示のまま

Closes #327

## Test plan
- [ ] サブエージェントが実行中のセッションで、Running Tasksパネルが入力ボックスの上に表示されることを確認
- [ ] メッセージをスクロールしてもRunning Tasksパネルが固定表示されることを確認
- [ ] タスクがない場合にRunning Tasksパネルが非表示であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)