### PR TITLE
feat: フロントエンドをファイルシステムから配信するモードを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 PORT ?= 4321
 
-.PHONY: build build-frontend dev clean test install restart preview preview-stop
+.PHONY: build build-frontend reload-frontend dev clean test install restart preview preview-stop
 
 build: build-frontend
 	go build -o agmux ./cmd/agmux
 
 build-frontend:
 	cd frontend && npm ci && npm run build
+
+reload-frontend:
+	cd frontend && npm run build
 
 dev:
 	cd frontend && npm run dev &

--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"log/slog"
 	"net"
@@ -65,6 +66,7 @@ func initManager(cfg *config.Config, port int, logger *slog.Logger) (*session.Ma
 func serveCmd() *cobra.Command {
 	var port int
 	var devMode bool
+	var frontendDir string
 
 	cmd := &cobra.Command{
 		Use:   "serve",
@@ -162,11 +164,27 @@ func serveCmd() *cobra.Command {
 			// SetOnNewLines callback is already registered on the manager.
 			mgr.RecoverStreamProcesses()
 
-
 			if !devMode {
-				frontendFS, err := agmux.FrontendFS()
-				if err != nil {
-					return fmt.Errorf("load frontend: %w", err)
+				// Resolve frontend directory: CLI flag > config > embedded
+				if frontendDir == "" {
+					frontendDir = cfg.Server.FrontendDir
+				}
+
+				var frontendFS fs.FS
+				if frontendDir != "" {
+					if info, err := os.Stat(frontendDir); err == nil && info.IsDir() {
+						frontendFS = os.DirFS(frontendDir)
+						slog.Info("serving frontend from filesystem", "dir", frontendDir)
+					} else {
+						slog.Warn("frontend-dir not found, falling back to embedded", "dir", frontendDir)
+						frontendFS, _ = agmux.FrontendFS()
+					}
+				} else {
+					var err error
+					frontendFS, err = agmux.FrontendFS()
+					if err != nil {
+						return fmt.Errorf("load frontend: %w", err)
+					}
 				}
 				srv.MountFrontend(frontendFS)
 			}
@@ -219,6 +237,7 @@ func serveCmd() *cobra.Command {
 
 	cmd.Flags().IntVarP(&port, "port", "p", 0, "Server port (default: from config or 4321)")
 	cmd.Flags().BoolVar(&devMode, "dev", false, "Enable dev mode (CORS for Vite)")
+	cmd.Flags().StringVar(&frontendDir, "frontend-dir", "", "Serve frontend from this directory instead of embedded files")
 
 	return cmd
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,8 @@ type Config struct {
 }
 
 type ServerConfig struct {
-	Port int `toml:"port"`
+	Port        int    `toml:"port"`
+	FrontendDir string `toml:"frontend_dir"`
 }
 
 type DaemonConfig struct {


### PR DESCRIPTION
## Summary
- `--frontend-dir` フラグと `config.toml` の `[server] frontend_dir` 設定を追加し、埋め込みではなくファイルシステムからフロントエンドを配信可能にした
- ディレクトリが存在しない場合は埋め込みにフォールバック
- `make reload-frontend` ターゲットを追加（`npm ci` をスキップして高速ビルド）

## Test plan
- [x] `go test ./...` 全テスト通過
- [x] `go build ./cmd/agmux` ビルド成功
- [ ] `--frontend-dir` フラグ指定でファイルシステムから配信されることを確認
- [ ] フラグ未指定時は従来通り埋め込みから配信されることを確認
- [ ] 存在しないディレクトリ指定時にフォールバックされることを確認

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)