### PR TITLE
feat: Running Tasksモーダルにタスク/エージェントIDを表示する

### DIFF
--- a/frontend/src/components/session/StreamOutputView.tsx
+++ b/frontend/src/components/session/StreamOutputView.tsx
@@ -134,6 +134,16 @@ function ActiveTaskItem({ task }: { task: ActiveTask }) {
       >
         <div className="space-y-3">
           <div>
+            <span className="text-gray-400 text-[10px] uppercase tracking-wide">Task ID</span>
+            <div className="text-gray-700 text-xs mt-0.5 font-mono">{task.taskId}</div>
+          </div>
+          {task.agentId && (
+            <div>
+              <span className="text-gray-400 text-[10px] uppercase tracking-wide">Agent ID</span>
+              <div className="text-gray-700 text-xs mt-0.5 font-mono">{task.agentId}</div>
+            </div>
+          )}
+          <div>
             <span className="text-gray-400 text-[10px] uppercase tracking-wide">Task Type</span>
             <div className="text-gray-700 text-xs mt-0.5 font-mono">{taskTypeLabel}</div>
           </div>

--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -59,6 +59,7 @@ export type StreamDisplayItem =
 export interface ActiveTask {
   taskId: string;
   taskType: string; // "local_agent" | "local_bash"
+  agentId?: string;
   description?: string;
   lastToolName?: string;
   lastToolInput?: unknown;
@@ -93,6 +94,7 @@ export function extractActiveTasks(entries: StreamEntry[]): ActiveTask[] {
       const toolUseId = raw.tool_use_id as string | undefined;
       if (taskId) {
         const task: ActiveTask = { taskId, taskType: taskType || "unknown" };
+        if (raw.agent_id) task.agentId = raw.agent_id as string;
         if (raw.description) task.description = raw.description as string;
         // Resolve tool input from the corresponding tool_use block
         if (toolUseId && toolUseInputs.has(toolUseId)) {


### PR DESCRIPTION
## Summary
- Running Tasksの詳細モーダルにTask IDを常時表示
- Agentタスクの場合はAgent IDも条件付きで表示（`agent_id`フィールドが存在する場合）
- `ActiveTask`インターフェースに`agentId`オプショナルフィールドを追加し、`task_started`イベントから抽出

Closes #344

## Test plan
- [ ] Running Tasksモーダルを開いてTask IDが表示されることを確認
- [ ] Agentタスクの場合、Agent IDが表示されることを確認
- [ ] `make build` / `make test` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)