### PR TITLE
feat: SessionServiceインターフェースを定義しCLI/Serverで共通化

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 }
 
-func initManager(cfg *config.Config, port int, logger *slog.Logger) (*session.Manager, *sql.DB, error) {
+func initManager(cfg *config.Config, port int, logger *slog.Logger) (session.SessionService, *sql.DB, error) {
 	dbPath, err := db.DBPathForPort(port)
 	if err != nil {
 		return nil, nil, err

--- a/internal/monitor/checker.go
+++ b/internal/monitor/checker.go
@@ -16,14 +16,14 @@ type Broadcaster interface {
 
 type StatusChecker struct {
 	monitor  *Monitor
-	sessions *session.Manager
+	sessions session.SessionService
 	logger   *slog.Logger
 	onUpdate func(sessions []session.Session)
 	onNotify func(sessionId, sessionName, status, summary string)
 	interval time.Duration
 }
 
-func NewStatusChecker(monitor *Monitor, sessions *session.Manager, interval time.Duration, logger *slog.Logger) *StatusChecker {
+func NewStatusChecker(monitor *Monitor, sessions session.SessionService, interval time.Duration, logger *slog.Logger) *StatusChecker {
 	return &StatusChecker{
 		monitor:  monitor,
 		sessions: sessions,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,7 +29,7 @@ import (
 )
 
 type Server struct {
-	sessions         *session.Manager
+	sessions         session.SessionService
 	hub              *Hub
 	router           chi.Router
 	devMode          bool
@@ -41,7 +41,7 @@ type Server struct {
 	externalDetector *session.ExternalDetector
 }
 
-func New(sessions *session.Manager, hub *Hub, devMode bool, logPath string, logger *slog.Logger, sqlDB *sql.DB) *Server {
+func New(sessions session.SessionService, hub *Hub, devMode bool, logPath string, logger *slog.Logger, sqlDB *sql.DB) *Server {
 	extDetector := session.NewExternalDetector(logger, 10*time.Second)
 	go extDetector.Start()
 

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -1,0 +1,66 @@
+package session
+
+// SessionService defines the interface for session management operations.
+// Both the CLI and Server use this interface to interact with sessions,
+// ensuring consistent behavior regardless of the access path.
+type SessionService interface {
+	// List returns all sessions.
+	List() ([]Session, error)
+	// Get returns a session by ID.
+	Get(id string) (*Session, error)
+	// Create creates a new session.
+	Create(name, projectPath, prompt string, worktree bool, opts ...CreateOpts) (*Session, error)
+	// Duplicate creates a copy of an existing session.
+	Duplicate(id string) (*Session, error)
+	// Stop stops a running session.
+	Stop(id string) error
+	// Delete deletes a session.
+	Delete(id string) error
+
+	// SendKeys sends text to a session.
+	SendKeys(id string, text string) error
+	// SendKeysWithImages sends text and images to a session.
+	SendKeysWithImages(id string, text string, images []ImageData) error
+
+	// Reconnect restarts the CLI process for an existing session.
+	Reconnect(id string) error
+	// Clear resets the session context.
+	Clear(id string) error
+
+	// UpdateStatus updates the session status.
+	UpdateStatus(id string, status Status) error
+	// UpdateContext updates the session's current task and goal.
+	UpdateContext(id string, currentTask, goal string) error
+
+	// CreateGoal creates a new goal for a session.
+	CreateGoal(id string, currentTask, goal string, subgoal bool) error
+	// CompleteGoal completes the current goal and returns the result.
+	CompleteGoal(id string) (*CompleteGoalResult, error)
+
+	// GetStreamLines returns stream lines for a session.
+	GetStreamLines(id string, limit int) ([]string, int, error)
+	// GetStreamLinesAfter returns stream lines added after the given index.
+	GetStreamLinesAfter(id string, after int) ([]string, int, error)
+
+	// SystemPrompt returns the system prompt used for sessions.
+	SystemPrompt() string
+
+	// CreateController creates or returns the singleton controller session.
+	CreateController(projectPath string) (*Session, error)
+
+	// SetOnNewLines sets a callback for real-time stream updates.
+	SetOnNewLines(fn func(sessionID string, newLines []string, total int))
+
+	// IsStreamProcessAlive returns true if a stream process exists and has not exited.
+	IsStreamProcessAlive(id string) bool
+
+	// RecoverStreamProcesses restarts stream processes for all working sessions.
+	RecoverStreamProcesses()
+	// StopAllStreamProcesses gracefully stops all running stream processes.
+	StopAllStreamProcesses()
+	// SetCodexCommand sets the codex command for the manager.
+	SetCodexCommand(cmd string)
+}
+
+// Verify Manager implements SessionService at compile time.
+var _ SessionService = (*Manager)(nil)


### PR DESCRIPTION
## Summary
- `SessionService` インターフェースを `internal/session/service.go` に定義し、Manager の全操作メソッドを含める
- `Server` の `sessions` フィールドを `*session.Manager` から `session.SessionService` に変更
- `Monitor` の `StatusChecker` も同様にインターフェースを使用するよう変更
- CLI の `initManager()` の戻り値を `session.SessionService` に変更
- コンパイル時の型チェック (`var _ SessionService = (*Manager)(nil)`) を追加

## Test plan
- [x] `make build` が通ること
- [x] `make test` が通ること
- [ ] CLI の `list/stop/delete` がサーバー起動なしで動作すること(既存動作の維持)

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)