### PR TITLE
SessionCardコンポーネント切り出し

### DIFF
--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -2,10 +2,10 @@ import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { TerminalSquare } from "lucide-react";
 import type { Session } from "../types/session";
-import { StatusDot } from "./StatusBadge";
 import { GroupSectionHeader } from "./ui/GroupSectionHeader";
 import { SecondaryButton } from "./ui/SecondaryButton";
 import { ExternalProcessRow } from "./ui/ExternalProcessRow";
+import { SessionCard } from "./ui/SessionCard";
 
 function timeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -87,54 +87,26 @@ export function SessionList({ sessions, onRestartController }: Props) {
                   timeAgo={timeAgo(s.createdAt)}
                 />
               ) : (
-                <div
+                <SessionCard
                   key={s.id}
+                  name={s.name}
+                  status={s.status}
+                  type={s.type}
+                  provider={s.provider}
+                  currentTask={s.currentTask}
+                  projectPath={s.projectPath}
+                  timeAgo={timeAgo(s.createdAt)}
                   onClick={() => navigate(`/sessions/${s.id}`)}
-                  className="border border-gray-200 rounded-lg p-3 transition-shadow bg-white hover:shadow-sm cursor-pointer"
-                >
-                  <div className="flex items-center gap-2 mb-1">
-                    <StatusDot status={s.status} />
-                    <span className="font-medium text-sm truncate">{s.name}</span>
-                    {s.type === "controller" && (
-                      <span className="px-1.5 py-0.5 text-[10px] font-medium bg-purple-100 text-purple-700 rounded">
-                        Controller
-                      </span>
-                    )}
-                    {s.provider && s.provider !== "claude" && (
-                      <span className={`px-1.5 py-0.5 text-[10px] font-medium rounded ${
-                        s.provider === "codex"
-                          ? "bg-green-100 text-green-700"
-                          : "bg-gray-100 text-gray-600"
-                      }`}>
-                        {s.provider.charAt(0).toUpperCase() + s.provider.slice(1)}
-                      </span>
-                    )}
-
-                    <span className="text-xs text-gray-400 ml-auto shrink-0">
-                      {s.status}
-                    </span>
-                  </div>
-                  {s.currentTask && (
-                    <p className="text-xs text-indigo-600 truncate mb-0.5">{s.currentTask}</p>
-                  )}
-                  <p className="text-xs text-gray-500 truncate mb-1">
-                    {s.projectPath}
-                  </p>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-gray-400">
-                      {timeAgo(s.createdAt)}
-                    </span>
-                    <div className="flex gap-1.5">
-                      {s.type === "controller" && s.status === "stopped" && (
-                        <SecondaryButton
-                          onClick={(e) => { e.stopPropagation(); onRestartController(); }}
-                        >
-                          Restart
-                        </SecondaryButton>
-                      )}
-                    </div>
-                  </div>
-                </div>
+                  actions={
+                    s.type === "controller" && s.status === "stopped" ? (
+                      <SecondaryButton
+                        onClick={(e) => { e.stopPropagation(); onRestartController(); }}
+                      >
+                        Restart
+                      </SecondaryButton>
+                    ) : undefined
+                  }
+                />
               )
             )}
           </div>

--- a/frontend/src/components/ui/SessionCard.tsx
+++ b/frontend/src/components/ui/SessionCard.tsx
@@ -1,0 +1,66 @@
+import type { Session } from "../../types/session";
+import { StatusDot } from "../StatusBadge";
+import { Chip } from "./Chip";
+
+interface SessionCardProps {
+  name: string;
+  status: Session["status"];
+  type?: string;
+  provider?: string;
+  currentTask?: string;
+  projectPath: string;
+  timeAgo: string;
+  onClick?: () => void;
+  actions?: React.ReactNode;
+}
+
+export function SessionCard({
+  name,
+  status,
+  type,
+  provider,
+  currentTask,
+  projectPath,
+  timeAgo,
+  onClick,
+  actions,
+}: SessionCardProps) {
+  return (
+    <div
+      onClick={onClick}
+      className="border border-gray-200 rounded-lg p-3 transition-shadow bg-white hover:shadow-sm cursor-pointer"
+    >
+      <div className="flex items-center gap-2 mb-1">
+        <StatusDot status={status} />
+        <span className="font-medium text-sm truncate">{name}</span>
+        {type === "controller" && (
+          <Chip color="purple">Controller</Chip>
+        )}
+        {provider && provider !== "claude" && (
+          <Chip color={provider === "codex" ? "green" : "gray"}>
+            {provider.charAt(0).toUpperCase() + provider.slice(1)}
+          </Chip>
+        )}
+        <span className="text-xs text-gray-400 ml-auto shrink-0">
+          {status}
+        </span>
+      </div>
+      {currentTask && (
+        <p className="text-xs text-indigo-600 truncate mb-0.5">{currentTask}</p>
+      )}
+      <p className="text-xs text-gray-500 truncate mb-1">
+        {projectPath}
+      </p>
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-gray-400">
+          {timeAgo}
+        </span>
+        {actions && (
+          <div className="flex gap-1.5">
+            {actions}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/PreviewPage.tsx
+++ b/frontend/src/pages/PreviewPage.tsx
@@ -25,6 +25,7 @@ import type { DiffFile } from "../api/client";
 import { GoalPanel } from "../components/ui/GoalPanel";
 import { ActiveTasksPanel } from "../components/session/StreamOutputView";
 import { SessionList } from "../components/SessionList";
+import { SessionCard } from "../components/ui/SessionCard";
 import { AlertBanner } from "../components/ui/AlertBanner";
 import { ConnectionStatusIndicator } from "../components/ui/ConnectionStatus";
 import { PermissionStatus } from "../components/ui/PermissionStatus";
@@ -608,6 +609,53 @@ function ActiveTasksPanelPreview() {
   );
 }
 
+function SessionCardPreview() {
+  return (
+    <PreviewSection title="SessionCard">
+      <div className="space-y-2 max-w-md">
+        <p className="text-xs text-gray-500 font-medium">Working (with currentTask)</p>
+        <SessionCard
+          name="implement-auth-feature"
+          status="working"
+          type="worker"
+          provider="claude"
+          currentTask="Adding JWT token validation middleware"
+          projectPath="/Users/dev/projects/my-app"
+          timeAgo="3m ago"
+          onClick={() => {}}
+        />
+
+        <p className="text-xs text-gray-500 font-medium mt-4">Idle (no currentTask)</p>
+        <SessionCard
+          name="refactor-database"
+          status="idle"
+          type="worker"
+          provider="codex"
+          projectPath="/Users/dev/projects/my-app"
+          timeAgo="1h ago"
+          onClick={() => {}}
+        />
+
+        <p className="text-xs text-gray-500 font-medium mt-4">Controller (stopped, with Restart action)</p>
+        <SessionCard
+          name="project-orchestrator"
+          status="stopped"
+          type="controller"
+          provider="claude"
+          projectPath="/Users/dev/projects/my-app"
+          timeAgo="2h ago"
+          onClick={() => {}}
+          actions={
+            <SecondaryButton onClick={(e) => e.stopPropagation()}>
+              Restart
+            </SecondaryButton>
+          }
+        />
+      </div>
+    </PreviewSection>
+  );
+}
+
 function SessionListPreview() {
   const now = new Date().toISOString();
   const oneHourAgo = new Date(Date.now() - 3600000).toISOString();
@@ -989,6 +1037,7 @@ const categories = [
       { id: "diffdropdown", label: "DiffDropdown", el: <DiffDropdownPreview /> },
       { id: "goalpanel", label: "GoalPanel", el: <GoalPanelPreview /> },
       { id: "activetaskspanel", label: "ActiveTasksPanel", el: <ActiveTasksPanelPreview /> },
+      { id: "sessioncard", label: "SessionCard", el: <SessionCardPreview /> },
       { id: "sessionlist", label: "SessionList", el: <SessionListPreview /> },
     ],
   },


### PR DESCRIPTION
## Summary

- SessionList内のインラインセッションカードJSXを `SessionCard` コンポーネントとして `ui/` に切り出し
- プレビューページのDomainカテゴリに3バリエーション追加（working/idle/controller）
- SessionListを新コンポーネントでリファクタ

## Test plan
- [ ] `make build` 通ること
- [ ] `/preview` でSessionCardが表示されること
- [ ] トップのセッション一覧の表示が変わっていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)