### PR TITLE
FileCodeViewerを常に折りたたみ可能にしcollapsible propを削除

### DIFF
--- a/frontend/src/components/session/DiffDropdown.tsx
+++ b/frontend/src/components/session/DiffDropdown.tsx
@@ -36,7 +36,6 @@ export function DiffDropdown({ files }: { files: DiffFile[] }) {
       >
         <FileCodeViewer
           files={files.map((f) => ({ name: f.path, content: f.diff || "" }))}
-          collapsible
           fileHeaderExtra={(file) => {
             const status = statusMap.get(file.name) || "?";
             return (

--- a/frontend/src/components/ui/FileCodeViewer.tsx
+++ b/frontend/src/components/ui/FileCodeViewer.tsx
@@ -10,8 +10,8 @@ interface FileCodeViewerProps {
   lineClickable?: boolean;
   /** No content message */
   emptyMessage?: string;
-  /** Enable collapsible file list (expand/collapse per file) */
-  collapsible?: boolean;
+  /** Start with all files expanded (default: false = all collapsed) */
+  defaultExpanded?: boolean;
   /** Extra element rendered before the file name in the header (e.g. status badge) */
   fileHeaderExtra?: (file: { name: string; content: string }) => ReactNode;
   /** Custom line renderer for code display (e.g. diff coloring) */
@@ -80,13 +80,15 @@ export function FileCodeViewer({
   renderContent,
   lineClickable = false,
   emptyMessage = "No content",
-  collapsible = false,
+  defaultExpanded = false,
   fileHeaderExtra,
   renderLine,
 }: FileCodeViewerProps) {
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [selectedLine, setSelectedLine] = useState<number | null>(null);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [expanded, setExpanded] = useState<Set<string>>(() =>
+    defaultExpanded ? new Set(files.map((f) => f.name)) : new Set()
+  );
 
   if (files.length === 0) {
     return <div className="text-gray-400 text-sm">{emptyMessage}</div>;
@@ -110,25 +112,18 @@ export function FileCodeViewer({
     <div className="border border-gray-200 rounded-lg overflow-hidden">
       {files.map((file) => {
         const content = formatContent ? formatContent(file.content) : file.content;
-        const isExpanded = !collapsible || expanded.has(file.name);
+        const isExpanded = expanded.has(file.name);
 
         return (
           <div key={file.name} className="border-b border-gray-100 last:border-b-0">
-            {collapsible ? (
-              <button
-                onClick={() => toggle(file.name)}
-                className="w-full flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-gray-50 text-left min-w-0"
-              >
-                {fileHeaderExtra?.(file)}
-                <span className="font-mono text-gray-700 truncate min-w-0">{file.name}</span>
-                <span className="ml-auto text-gray-400 shrink-0">{isExpanded ? "\u25BC" : "\u25B6"}</span>
-              </button>
-            ) : (
-              <div className="flex items-center gap-2 px-3 py-1.5 text-xs min-w-0">
-                {fileHeaderExtra?.(file)}
-                <span className="font-mono text-gray-700 truncate min-w-0">{file.name}</span>
-              </div>
-            )}
+            <button
+              onClick={() => toggle(file.name)}
+              className="w-full flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-gray-50 text-left min-w-0"
+            >
+              {fileHeaderExtra?.(file)}
+              <span className="font-mono text-gray-700 truncate min-w-0">{file.name}</span>
+              <span className="ml-auto text-gray-400 shrink-0">{isExpanded ? "\u25BC" : "\u25B6"}</span>
+            </button>
             {isExpanded && (
               renderContent ? (
                 <div className="border-t border-gray-200 p-3">

--- a/frontend/src/pages/PreviewPage.tsx
+++ b/frontend/src/pages/PreviewPage.tsx
@@ -205,12 +205,12 @@ func add(a, b int) int {
     <PreviewSection title="FileCodeViewer">
       <div className="space-y-6">
         <div>
-          <p className="text-xs text-gray-500 mb-2">通常表示 (行クリック有効)</p>
-          <FileCodeViewer files={sampleFiles} lineClickable />
+          <p className="text-xs text-gray-500 mb-2">初期展開 (行クリック有効)</p>
+          <FileCodeViewer files={sampleFiles} defaultExpanded lineClickable />
         </div>
         <div>
-          <p className="text-xs text-gray-500 mb-2">折りたたみ表示</p>
-          <FileCodeViewer files={sampleFiles} collapsible />
+          <p className="text-xs text-gray-500 mb-2">初期折りたたみ (デフォルト)</p>
+          <FileCodeViewer files={sampleFiles} />
         </div>
         <div>
           <p className="text-xs text-gray-500 mb-2">カスタム行レンダリング (diff風)</p>
@@ -225,7 +225,6 @@ func add(a, b int) int {
                 <span className="flex-1">{line}</span>
               </div>
             )}
-            collapsible
           />
         </div>
         <div>

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -706,6 +706,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
         ) : claudeMDFiles && claudeMDFiles.length > 0 ? (
           <FileCodeViewer
             files={claudeMDFiles.map((f) => ({ name: f.path, content: f.content }))}
+            defaultExpanded
             lineClickable={claudeMDViewMode === "source"}
             renderContent={claudeMDViewMode === "preview" ? (content) => (
               <div className="prose prose-sm max-w-none">
@@ -734,7 +735,6 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
         ) : (
           <FileCodeViewer
             files={settingsJSONFiles}
-            collapsible
             formatContent={(content) => {
               try {
                 return JSON.stringify(JSON.parse(content), null, 2);


### PR DESCRIPTION
## Summary

- `collapsible` propを削除し、常に折りたたみ可能に統一
- `defaultExpanded` propを追加（`true`で初期展開）
- CLAUDE.md表示は`defaultExpanded`で初期展開に設定
- settings.json、DiffDropdownは初期折りたたみ（従来通り）

## Test plan
- [ ] `/preview` のFileCodeViewerで初期展開/折りたたみ両方確認
- [ ] セッション詳細のCLAUDE.mdが初期展開で表示されること
- [ ] settings.json、DiffDropdownが初期折りたたみで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)