### PR TITLE
fix: circle型IconButtonのvariant='primary'抜け修正

### DIFF
--- a/frontend/src/pages/PreviewPage.tsx
+++ b/frontend/src/pages/PreviewPage.tsx
@@ -489,7 +489,7 @@ function IconButtonPreview() {
         <div>
           <p className="text-xs text-gray-500 mb-1">shape=&quot;circle&quot; + variant=&quot;primary&quot; / &quot;secondary&quot;</p>
           <div className="flex items-center gap-2">
-            <IconButton shape="circle" title="Send">
+            <IconButton shape="circle" variant="primary" title="Send">
               <SendHorizonal className="w-4 h-4" />
             </IconButton>
             <IconButton shape="circle" variant="secondary" title="Actions">
@@ -500,7 +500,7 @@ function IconButtonPreview() {
         <div>
           <p className="text-xs text-gray-500 mb-1">Disabled</p>
           <div className="flex items-center gap-2">
-            <IconButton shape="circle" disabled title="Disabled primary">
+            <IconButton shape="circle" variant="primary" disabled title="Disabled primary">
               <SendHorizonal className="w-4 h-4" />
             </IconButton>
             <IconButton shape="circle" variant="secondary" disabled title="Disabled secondary">

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -523,7 +523,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
           />
         </div>
         {/* Send button */}
-        <IconButton shape="circle" type="submit">
+        <IconButton shape="circle" variant="primary" type="submit">
           <SendHorizonal className="w-4 h-4" />
         </IconButton>
       </div>


### PR DESCRIPTION
## Summary
- 送信ボタン(SessionPage)とプレビューのprimary circle buttonに`variant="primary"`が指定されていなかった
- デフォルトがghostのため青色が出ずグレー表示になっていた

🤖 Generated with [Claude Code](https://claude.com/claude-code)