### PR TITLE
fix: task_progressでRunning Tasksに追加されないケースを修正

### DIFF
--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -114,7 +114,13 @@ export function extractActiveTasks(entries: StreamEntry[]): ActiveTask[] {
       }
     } else if (subtype === "task_progress") {
       const taskId = raw.task_id as string;
-      if (taskId && tasks.has(taskId)) {
+      if (taskId) {
+        if (!tasks.has(taskId)) {
+          const taskType = (raw.task_type as string) || "unknown";
+          const task: ActiveTask = { taskId, taskType };
+          if (raw.agent_id) task.agentId = raw.agent_id as string;
+          tasks.set(taskId, task);
+        }
         const task = tasks.get(taskId)!;
         if (raw.description) task.description = raw.description as string;
         if (raw.last_tool_name) task.lastToolName = raw.last_tool_name as string;


### PR DESCRIPTION
## Summary
- `extractActiveTasks()`で`task_progress`イベント受信時、`task_started`が先行していない場合にタスクがスキップされる問題を修正
- 未登録のタスクは`task_id`と`task_type`（なければ`"unknown"`）で新規作成してから更新処理を適用

Closes #364

## Test plan
- [ ] `task_started`なしで`task_progress`のみ来るケースでRunning Tasksに表示されることを確認
- [ ] 通常の`task_started` → `task_progress`フローが従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)