### PR TITLE
feat: Running Taskモーダルにツール呼び出し履歴を表示

### DIFF
--- a/frontend/src/components/session/StreamOutputView.tsx
+++ b/frontend/src/components/session/StreamOutputView.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import type { StreamEntry } from "../../models/stream";
 import { mergeStreamEntries } from "../../models/stream";
-import type { ActiveTask } from "../../models/stream";
+import type { ActiveTask, ToolCallHistoryEntry } from "../../models/stream";
 import { useAutoScroll } from "../../hooks/useAutoScroll";
 import { StreamDisplayItemView } from "./StreamDisplayItemView";
 import { toolIcon, toolDescription } from "../../models/tool";
@@ -92,6 +92,33 @@ export function StreamOutputView({ lines, partialText, className, onAnswer, sess
   );
 }
 
+function ToolCallHistoryItem({ entry, index, isLatest }: { entry: ToolCallHistoryEntry; index: number; isLatest: boolean }) {
+  const [expanded, setExpanded] = useState(isLatest);
+  const Icon = toolIcon(entry.toolName);
+  const desc = entry.input ? toolDescription(entry.toolName, entry.input) : null;
+
+  return (
+    <div className={`border rounded ${isLatest ? "border-amber-300 bg-amber-50/50" : "border-gray-200 bg-gray-50"}`}>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full text-left px-2 py-1 flex items-center gap-1.5 hover:bg-gray-100/50 transition-colors"
+      >
+        <span className="text-gray-400 text-[10px] font-mono w-4 text-right shrink-0">{index + 1}</span>
+        <Icon className="w-3 h-3 text-gray-500 shrink-0" />
+        <span className="text-xs font-medium text-gray-700">{entry.toolName}</span>
+        {desc && <span className="text-xs text-gray-500 truncate min-w-0">{desc}</span>}
+        {isLatest && <span className="text-[10px] text-amber-600 ml-auto shrink-0">current</span>}
+        <svg className={`w-3 h-3 text-gray-400 shrink-0 transition-transform ${expanded ? "rotate-90" : ""}`} viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M4 2l4 4-4 4" /></svg>
+      </button>
+      {expanded && entry.input != null && (
+        <div className="px-2 pb-1.5 pt-0.5 border-t border-gray-200">
+          <ToolInputView input={entry.input} />
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ActiveTaskItem({ task, onDismiss }: { task: ActiveTask; onDismiss?: (taskId: string) => void }) {
   const [open, setOpen] = useState(false);
   const taskTypeLabel = task.taskType === "local_agent" ? "Agent" : task.taskType === "local_bash" ? "Bash" : task.taskType;
@@ -166,7 +193,17 @@ function ActiveTaskItem({ task, onDismiss }: { task: ActiveTask; onDismiss?: (ta
               <div className="text-gray-700 text-xs mt-0.5">{task.description}</div>
             </div>
           )}
-          {task.lastToolInput != null && (
+          {task.toolCallHistory.length > 0 && (
+            <div>
+              <span className="text-gray-400 text-[10px] uppercase tracking-wide">Tool Call History ({task.toolCallHistory.length})</span>
+              <div className="mt-1 space-y-1">
+                {task.toolCallHistory.map((entry, i) => (
+                  <ToolCallHistoryItem key={i} entry={entry} index={i} isLatest={i === task.toolCallHistory.length - 1} />
+                ))}
+              </div>
+            </div>
+          )}
+          {task.toolCallHistory.length === 0 && task.lastToolInput != null && (
             <div>
               <span className="text-gray-400 text-[10px] uppercase tracking-wide">Input</span>
               <div className="mt-0.5">

--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -55,6 +55,13 @@ export type StreamDisplayItem =
   | { kind: "thinking"; text: string }
   | { kind: "system_event"; eventType: string; label: string; detail?: string };
 
+// Tool call history entry for tracking sub-agent activity
+export interface ToolCallHistoryEntry {
+  toolName: string;
+  input: unknown;
+  timestamp?: string;
+}
+
 // Active task tracking for sub-agents and background tasks
 export interface ActiveTask {
   taskId: string;
@@ -65,6 +72,7 @@ export interface ActiveTask {
   lastToolInput?: unknown;
   output?: string;
   usage?: { inputTokens?: number; outputTokens?: number };
+  toolCallHistory: ToolCallHistoryEntry[];
 }
 
 export function extractActiveTasks(entries: StreamEntry[]): ActiveTask[] {
@@ -101,7 +109,7 @@ export function extractActiveTasks(entries: StreamEntry[]): ActiveTask[] {
       const taskType = raw.task_type as string;
       const toolUseId = raw.tool_use_id as string | undefined;
       if (taskId) {
-        const task: ActiveTask = { taskId, taskType: taskType || "unknown" };
+        const task: ActiveTask = { taskId, taskType: taskType || "unknown", toolCallHistory: [] };
         if (raw.agent_id) task.agentId = raw.agent_id as string;
         if (raw.description) task.description = raw.description as string;
         // Resolve tool input from the corresponding tool_use block
@@ -117,7 +125,20 @@ export function extractActiveTasks(entries: StreamEntry[]): ActiveTask[] {
       if (taskId && tasks.has(taskId)) {
         const task = tasks.get(taskId)!;
         if (raw.description) task.description = raw.description as string;
-        if (raw.last_tool_name) task.lastToolName = raw.last_tool_name as string;
+        // Track tool call history: append when last_tool_name changes
+        if (raw.last_tool_name) {
+          const newToolName = raw.last_tool_name as string;
+          const newToolInput = raw.last_tool_input;
+          const lastEntry = task.toolCallHistory[task.toolCallHistory.length - 1];
+          if (!lastEntry || lastEntry.toolName !== newToolName || JSON.stringify(lastEntry.input) !== JSON.stringify(newToolInput)) {
+            task.toolCallHistory.push({
+              toolName: newToolName,
+              input: newToolInput,
+              timestamp: raw.timestamp as string | undefined,
+            });
+          }
+          task.lastToolName = newToolName;
+        }
         if (raw.last_tool_input !== undefined) task.lastToolInput = raw.last_tool_input;
         if (raw.output) task.output = raw.output as string;
         if (raw.usage) {

--- a/frontend/src/pages/PreviewPage.tsx
+++ b/frontend/src/pages/PreviewPage.tsx
@@ -573,6 +573,11 @@ function ActiveTasksPanelPreview() {
       lastToolName: "Grep",
       lastToolInput: { pattern: "export function", path: "src/" },
       usage: { inputTokens: 12500, outputTokens: 3200 },
+      toolCallHistory: [
+        { toolName: "Read", input: { file_path: "/src/index.ts" } },
+        { toolName: "Glob", input: { pattern: "**/*.ts" } },
+        { toolName: "Grep", input: { pattern: "export function", path: "src/" } },
+      ],
     },
     {
       taskId: "task-ghi-789",
@@ -582,6 +587,9 @@ function ActiveTasksPanelPreview() {
       lastToolInput: { command: "npm test --watch" },
       output: "Tests: 42 passed, 1 failed",
       usage: { inputTokens: 800, outputTokens: 1500 },
+      toolCallHistory: [
+        { toolName: "Bash", input: { command: "npm test --watch" } },
+      ],
     },
   ];
 


### PR DESCRIPTION
## Summary
- `ActiveTask`インターフェースに`toolCallHistory`フィールドを追加
- `extractActiveTasks()`で`task_progress`イベント走査時に`last_tool_name`/`last_tool_input`の変化を検出し履歴に蓄積
- `ActiveTaskItem`モーダルにツール呼び出し履歴を展開可能なリスト形式で表示（現在実行中のツールには`current`ラベル付与）

Closes #365

## Test plan
- [ ] Running Taskのモーダルを開き、ツール呼び出し履歴がリスト表示されることを確認
- [ ] 各履歴アイテムをクリックして入力内容が展開表示されることを確認
- [ ] プレビューページでモックデータの履歴表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)