### PR TITLE
feat: セッションのエラーをユーザーにわかりやすく表示する

### DIFF
--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -94,6 +94,7 @@ export function SessionList({ sessions, onRestartController }: Props) {
                   type={s.type}
                   provider={s.provider}
                   currentTask={s.currentTask}
+                  lastError={s.lastError}
                   projectPath={s.projectPath}
                   timeAgo={timeAgo(s.createdAt)}
                   onClick={() => navigate(`/sessions/${s.id}`)}

--- a/frontend/src/components/ui/SessionCard.tsx
+++ b/frontend/src/components/ui/SessionCard.tsx
@@ -8,6 +8,7 @@ interface SessionCardProps {
   type?: string;
   provider?: string;
   currentTask?: string;
+  lastError?: string;
   projectPath: string;
   timeAgo: string;
   onClick?: () => void;
@@ -20,6 +21,7 @@ export function SessionCard({
   type,
   provider,
   currentTask,
+  lastError,
   projectPath,
   timeAgo,
   onClick,
@@ -47,6 +49,11 @@ export function SessionCard({
       </div>
       {currentTask && (
         <p className="text-xs text-indigo-600 truncate mb-0.5">{currentTask}</p>
+      )}
+      {status === "stopped" && lastError && (
+        <p className="text-xs text-red-600 truncate mb-0.5" title={lastError}>
+          Error: {lastError}
+        </p>
       )}
       <p className="text-xs text-gray-500 truncate mb-1">
         {projectPath}

--- a/frontend/src/pages/PreviewPage.tsx
+++ b/frontend/src/pages/PreviewPage.tsx
@@ -643,6 +643,18 @@ function SessionCardPreview() {
             </SecondaryButton>
           }
         />
+
+        <p className="text-xs text-gray-500 font-medium mt-4">Stopped with error</p>
+        <SessionCard
+          name="failing-worker"
+          status="stopped"
+          type="worker"
+          provider="claude"
+          lastError="exit status 1"
+          projectPath="/Users/dev/projects/my-app"
+          timeAgo="5m ago"
+          onClick={() => {}}
+        />
       </div>
     </PreviewSection>
   );

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -25,6 +25,7 @@ import { DiffDropdown } from "../components/session/DiffDropdown";
 import { GoalPanel } from "../components/ui/GoalPanel";
 import { ConnectionStatusIndicator } from "../components/ui/ConnectionStatus";
 import { PullRequestBadge } from "../components/ui/PullRequestBadge";
+import { AlertBanner } from "../components/ui/AlertBanner";
 import type { StreamEntry } from "../models/stream";
 import { extractActiveTasks } from "../models/stream";
 
@@ -642,6 +643,14 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
           goal={session.goal}
           goals={session.goals}
         />
+      )}
+
+      {session && session.status === "stopped" && session.lastError && (
+        <div className="mb-2 shrink-0">
+          <AlertBanner variant="error">
+            {session.lastError}
+          </AlertBanner>
+        </div>
       )}
 
       {session && connectionState !== "connected" && (

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -10,6 +10,7 @@ export interface Session {
   currentTask?: string;
   goal?: string;
   goals?: { currentTask: string; goal: string }[];
+  lastError?: string;
   createdAt: string;
   updatedAt: string;
   githubUrl?: string;

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -151,6 +151,12 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: add last_error column if missing (for error display)
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN last_error TEXT`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	// Migration: remove UNIQUE constraint from tmux_session (no longer used)
 	// SQLite doesn't support DROP CONSTRAINT, so we recreate the table
 	{

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -248,7 +248,7 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 
 func (m *Manager) List() ([]Session, error) {
 	rows, err := m.db.Query(
-		`SELECT id, name, project_path, initial_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, last_error, created_at, updated_at
 		 FROM sessions ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -262,8 +262,8 @@ func (m *Manager) List() ([]Session, error) {
 		var status string
 		var sessionType string
 		var providerStr string
-		var prompt, currentTask, goal, goalsJSON sql.NullString
-		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		var prompt, currentTask, goal, goalsJSON, lastError sql.NullString
+		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &lastError, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		s.Status = Status(status)
@@ -284,6 +284,9 @@ func (m *Manager) List() ([]Session, error) {
 		if goalsJSON.Valid {
 			s.Goals = ParseGoalStack(goalsJSON.String)
 		}
+		if lastError.Valid {
+			s.LastError = lastError.String
+		}
 
 		sessions = append(sessions, s)
 	}
@@ -296,11 +299,11 @@ func (m *Manager) Get(id string) (*Session, error) {
 	var status string
 	var sessionType string
 	var providerStr string
-	var prompt, currentTask, goal, goalsJSON sql.NullString
+	var prompt, currentTask, goal, goalsJSON, lastError sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, last_error, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id,
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &lastError, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
@@ -324,6 +327,9 @@ func (m *Manager) Get(id string) (*Session, error) {
 	}
 	if goalsJSON.Valid {
 		s.Goals = ParseGoalStack(goalsJSON.String)
+	}
+	if lastError.Valid {
+		s.LastError = lastError.String
 	}
 	return &s, nil
 }
@@ -410,7 +416,7 @@ func (m *Manager) wireSessionIDCallback(sessionID string, sp *StreamProcess) {
 			"sessionId", sid,
 			"exitError", errMsg,
 		)
-		if err := m.UpdateStatus(sid, StatusStopped); err != nil {
+		if err := m.UpdateStatusWithError(sid, StatusStopped, errMsg); err != nil {
 			m.logger.Error("failed to update status after process exit", "sessionId", sid, "error", err)
 		}
 		// Clean up the stream process from the map
@@ -507,7 +513,7 @@ func (m *Manager) Clear(id string) error {
 	m.streamMu.Unlock()
 
 	// Reset task/goal and set status to working (preserve cli_session_id with fresh value)
-	_, err = m.db.Exec("UPDATE sessions SET status = ?, current_task = NULL, goal = NULL, goals = '[]', cli_session_id = ?, updated_at = ? WHERE id = ?", string(StatusWorking), freshCLISessionID, time.Now(), id)
+	_, err = m.db.Exec("UPDATE sessions SET status = ?, last_error = NULL, current_task = NULL, goal = NULL, goals = '[]', cli_session_id = ?, updated_at = ? WHERE id = ?", string(StatusWorking), freshCLISessionID, time.Now(), id)
 	return err
 }
 
@@ -682,11 +688,11 @@ func (m *Manager) GetController() (*Session, error) {
 	var status string
 	var sessionType string
 	var providerStr string
-	var prompt, currentTask, goal, goalsJSON sql.NullString
+	var prompt, currentTask, goal, goalsJSON, lastError sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, last_error, created_at, updated_at
 		 FROM sessions WHERE type = ? LIMIT 1`, string(TypeController),
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &lastError, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -710,6 +716,9 @@ func (m *Manager) GetController() (*Session, error) {
 	}
 	if goalsJSON.Valid {
 		s.Goals = ParseGoalStack(goalsJSON.String)
+	}
+	if lastError.Valid {
+		s.LastError = lastError.String
 	}
 	return &s, nil
 }
@@ -786,6 +795,12 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 
 func (m *Manager) UpdateStatus(id string, status Status) error {
 	_, err := m.db.Exec("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", string(status), time.Now(), id)
+	return err
+}
+
+// UpdateStatusWithError updates the session status and records the last error message.
+func (m *Manager) UpdateStatusWithError(id string, status Status, lastError string) error {
+	_, err := m.db.Exec("UPDATE sessions SET status = ?, last_error = ?, updated_at = ? WHERE id = ?", string(status), lastError, time.Now(), id)
 	return err
 }
 
@@ -909,6 +924,6 @@ func (m *Manager) Reconnect(id string) error {
 	m.streamProcesses[id] = sp
 	m.streamMu.Unlock()
 
-	_, err = m.db.Exec("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", string(StatusWorking), time.Now(), id)
+	_, err = m.db.Exec("UPDATE sessions SET status = ?, last_error = NULL, updated_at = ? WHERE id = ?", string(StatusWorking), time.Now(), id)
 	return err
 }

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -37,6 +37,7 @@ type Session struct {
 	CurrentTask   string       `json:"currentTask,omitempty"`
 	Goal          string       `json:"goal,omitempty"`
 	Goals         GoalStack    `json:"goals,omitempty"`
+	LastError     string       `json:"lastError,omitempty"`
 	CreatedAt     time.Time    `json:"createdAt"`
 	UpdatedAt     time.Time    `json:"updatedAt"`
 }


### PR DESCRIPTION
## Summary
- `sessions` テーブルに `last_error TEXT` カラムを追加（NULL許容、既存データ影響なし）
- プロセス異常終了時に `last_error` をDBに記録し、セッション再開・クリア・再接続時にクリア
- SessionCard: stopped状態でエラーがある場合、赤字テキストとツールチップで表示
- SessionPage: エラー詳細をAlertBanner（error variant）で表示

## Test plan
- [x] `make build` 成功
- [x] `make test` 全テスト通過
- [ ] セッションが異常終了した際に last_error が記録されることを確認
- [ ] SessionCard にエラー内容が赤字で表示されることを確認
- [ ] SessionPage にエラーバナーが表示されることを確認
- [ ] セッション再開後に last_error がクリアされることを確認

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)