### PR TITLE
feat: Running Tasksモーダルにタスク開始時刻を表示

### DIFF
--- a/frontend/src/components/session/StreamOutputView.tsx
+++ b/frontend/src/components/session/StreamOutputView.tsx
@@ -145,6 +145,9 @@ function ActiveTaskItem({ task, onDismiss }: { task: ActiveTask; onDismiss?: (ta
             {desc && (
               <span className="text-xs text-gray-500 truncate min-w-0">{desc}</span>
             )}
+            {task.startedAt && (
+              <span className="text-[10px] text-gray-400 shrink-0">{new Date(task.startedAt).toLocaleTimeString()}</span>
+            )}
             {task.usage && (
               <span className="text-[10px] text-gray-400 ml-auto shrink-0">
                 {task.usage.inputTokens != null && `${Math.round(task.usage.inputTokens / 1000)}k in`}
@@ -181,6 +184,12 @@ function ActiveTaskItem({ task, onDismiss }: { task: ActiveTask; onDismiss?: (ta
             <span className="text-gray-400 text-[10px] uppercase tracking-wide">Task ID</span>
             <div className="text-gray-700 text-xs mt-0.5 font-mono">{task.taskId}</div>
           </div>
+          {task.startedAt && (
+            <div>
+              <span className="text-gray-400 text-[10px] uppercase tracking-wide">Started At</span>
+              <div className="text-gray-700 text-xs mt-0.5">{new Date(task.startedAt).toLocaleString()}</div>
+            </div>
+          )}
           {task.agentId && (
             <div>
               <span className="text-gray-400 text-[10px] uppercase tracking-wide">Agent ID</span>

--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -69,6 +69,7 @@ export interface ActiveTask {
   taskType: string; // "local_agent" | "local_bash"
   agentId?: string;
   description?: string;
+  startedAt?: string;
   lastToolName?: string;
   lastToolInput?: unknown;
   output?: string;
@@ -113,6 +114,7 @@ export function extractActiveTasks(entries: StreamEntry[]): ActiveTask[] {
         const task: ActiveTask = { taskId, taskType: taskType || "unknown", toolCallHistory: [] };
         if (raw.agent_id) task.agentId = raw.agent_id as string;
         if (raw.description) task.description = raw.description as string;
+        if (raw.timestamp) task.startedAt = raw.timestamp as string;
         // Resolve tool input from the corresponding tool_use block
         if (toolUseId && toolUseInputs.has(toolUseId)) {
           const tu = toolUseInputs.get(toolUseId)!;


### PR DESCRIPTION
## Summary
- Running Tasksモーダルの実行中タスクに開始時刻を表示
- タスク一覧の各行に `toLocaleTimeString()` で時刻を表示
- モーダル詳細内に「Started At」セクションとして `toLocaleString()` で日時を表示

Closes #376

## Test plan
- [ ] Running Tasksモーダルを開き、実行中タスクの行に開始時刻が表示されていることを確認
- [ ] タスクをクリックしてモーダル詳細に「Started At」が表示されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)