### PR TITLE
fix: Codexセッションが2ターン目以降ブロックする問題を修正

### DIFF
--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -518,7 +518,12 @@ func (sp *StreamProcess) sendCodex(message string) error {
 	sp.mu.Lock()
 	sp.stopped = true
 	doneCh := sp.done
+	stdinToClose := sp.stdin
 	sp.mu.Unlock()
+
+	// Close stdin to signal the Codex process to exit.
+	// Without this, the process may hang waiting for input even after turn.completed.
+	stdinToClose.Close()
 
 	// Check if the process has already finished (non-blocking).
 	// If it has, skip the wait and proceed directly to restart.
@@ -552,14 +557,12 @@ func (sp *StreamProcess) sendCodex(message string) error {
 
 // restartForCodex spawns a new codex exec resume process for a followup message.
 func (sp *StreamProcess) restartForCodex(message, cliSessionID string) error {
-	// Clean up the old process (already exited since done channel was closed).
 	// Wait for monitorExit to finish calling Wait() before proceeding.
+	// stdin is already closed by sendCodex() to trigger process exit.
 	sp.mu.RLock()
-	oldStdin := sp.stdin
 	exitedCh := sp.exited
 	sp.mu.RUnlock()
 
-	oldStdin.Close()
 	<-exitedCh // wait for monitorExit to call Wait() and close exited
 
 	opts := sp.streamOpts


### PR DESCRIPTION
## Summary
- `sendCodex()`で`doneCh`待機前に`sp.stdin.Close()`を呼び出し、Codexプロセスにstdin EOFを通知するように修正
- `restartForCodex()`の重複する`oldStdin.Close()`を削除

## 原因
Codex `exec`プロセスはターン完了後もstdinが開いている限り終了しない場合がある。`sendCodex()`はプロセス終了（stdout EOF → `done`チャネル）を待つが、stdinを閉じていなかったためプロセスが終了せず、10分後にタイムアウトしていた。

## Test plan
- [x] `go build ./internal/session/` 成功
- [x] `go test ./internal/session/` 全テスト通過
- [ ] Codexセッションで2ターン以上の会話が正常に動作することを確認

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)