### PR TITLE
feat: CLAUDE.md表示画面でグローバルCLAUDE.mdも表示

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1151,6 +1151,8 @@ func (s *Server) getClaudeMD(w http.ResponseWriter, r *http.Request) {
 
 	var files []claudeMDFile
 
+	homeDir, _ := os.UserHomeDir()
+
 	// Candidate paths for CLAUDE.md files (project-local)
 	type candidateEntry struct {
 		path        string
@@ -1163,7 +1165,7 @@ func (s *Server) getClaudeMD(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Add global ~/.claude/CLAUDE.md
-	if homeDir, err := os.UserHomeDir(); err == nil {
+	if homeDir != "" {
 		globalPath := filepath.Join(homeDir, ".claude", "CLAUDE.md")
 		candidates = append(candidates, candidateEntry{
 			path:        globalPath,
@@ -1203,11 +1205,9 @@ func (s *Server) getClaudeMD(w http.ResponseWriter, r *http.Request) {
 			}
 			// For refs from global CLAUDE.md, use ~/... display path
 			var refDisplayPath string
-			if candidate.displayPath != "" {
-				if homeDir, err := os.UserHomeDir(); err == nil {
-					if rel, err := filepath.Rel(homeDir, ref); err == nil {
-						refDisplayPath = "~/" + rel
-					}
+			if candidate.displayPath != "" && homeDir != "" && strings.HasPrefix(ref, homeDir+string(filepath.Separator)) {
+				if rel, err := filepath.Rel(homeDir, ref); err == nil {
+					refDisplayPath = "~/" + rel
 				}
 			}
 			if refDisplayPath == "" {


### PR DESCRIPTION
## Summary
- CLAUDE.md表示画面で `~/.claude/CLAUDE.md`（グローバル設定）の内容も閲覧できるようにした
- `@参照`で読み込まれるファイルも `~/...` 形式のパスで表示される
- ファイルが存在しない場合は自動的にスキップされる（エラーにならない）

## 変更内容
- `internal/server/server.go`: `getClaudeMD` ハンドラーの候補パスに `~/.claude/CLAUDE.md` を追加。表示パスの計算ロジックを `candidateEntry` 構造体で整理

## Test plan
- [x] `make test` パス
- [x] `make build` パス
- [ ] `~/.claude/CLAUDE.md` が存在する環境でCLAUDE.md表示画面にグローバルファイルが表示されることを確認
- [ ] `~/.claude/CLAUDE.md` が存在しない環境でエラーにならないことを確認

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)