### PR TITLE
feat: 直近のプロジェクト履歴からセッション作成

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { Tabs } from "./components/ui/Tabs";
 import { useWebSocket } from "./hooks/useWebSocket";
 import { getActiveSessionName } from "./activeSession";
 import { IconButton } from "./components/ui/IconButton";
+import { CreateSession } from "./components/CreateSession";
 
 // Register service worker for mobile notifications
 if ("serviceWorker" in navigator) {
@@ -89,6 +90,7 @@ function useGlobalNotifications() {
 function Dashboard() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [showCreateModal, setShowCreateModal] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const mobileTab: MobileTab = searchParams.get("tab") === "logs" ? "logs" : "sessions";
   const navigate = useNavigate();
@@ -126,6 +128,15 @@ function Dashboard() {
       <header className="bg-white border-b border-gray-200 px-4 md:px-8 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-lg md:text-xl font-bold text-gray-900">agmux</h1>
         <div className="flex items-center gap-2">
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="p-1.5 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100"
+            title="New Session"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
+            </svg>
+          </button>
           <IconButton shape="rounded" to="/preview" title="UI Preview">
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
@@ -217,6 +228,20 @@ function Dashboard() {
         </div>
       </div>
 
+      {showCreateModal && (
+        <CreateSession
+          onClose={() => setShowCreateModal(false)}
+          onCreate={async (data) => {
+            try {
+              const created = await api.createSession(data);
+              setShowCreateModal(false);
+              navigate(`/sessions/${created.id}`);
+            } catch (e: unknown) {
+              setError(e instanceof Error ? e.message : "Failed to create session");
+            }
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,6 +20,9 @@ async function request<T>(
 export const api = {
   listSessions: () => request<Session[]>("/sessions"),
 
+  getRecentProjects: () =>
+    request<RecentProject[]>("/projects/recent"),
+
   createSession: (data: {
     name: string;
     projectPath: string;
@@ -133,6 +136,12 @@ export const api = {
     return request<MetricEvent[]>(`/metrics/events?${qs}`);
   },
 };
+
+export interface RecentProject {
+  projectPath: string;
+  lastUsedAt: string;
+  sessionCount: number;
+}
 
 export interface CodexModel {
   id: string;

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { api, type CodexModel } from "../api/client";
+import { api, type CodexModel, type RecentProject } from "../api/client";
 
 interface Props {
   onClose: () => void;
@@ -29,6 +29,13 @@ export function CreateSession({ onClose, onCreate }: Props) {
   const [claudeModels, setClaudeModels] = useState<ModelOption[]>([]);
   const [autoApprove, setAutoApprove] = useState(true);
   const [loadingModels, setLoadingModels] = useState(false);
+  const [recentProjects, setRecentProjects] = useState<RecentProject[]>([]);
+
+  useEffect(() => {
+    api.getRecentProjects()
+      .then(setRecentProjects)
+      .catch(() => setRecentProjects([]));
+  }, []);
 
   useEffect(() => {
     if (provider === "codex") {
@@ -96,6 +103,29 @@ export function CreateSession({ onClose, onCreate }: Props) {
               className="w-full border border-gray-300 rounded px-3 py-2 text-sm"
               placeholder="/path/to/project"
             />
+            {recentProjects.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mt-1.5">
+                {recentProjects.map((p) => {
+                  const dirName = p.projectPath.split("/").pop() || p.projectPath;
+                  return (
+                    <button
+                      key={p.projectPath}
+                      type="button"
+                      onClick={() => {
+                        setProjectPath(p.projectPath);
+                        if (!name) {
+                          setName(dirName);
+                        }
+                      }}
+                      className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-gray-100 text-gray-700 hover:bg-blue-100 hover:text-blue-700 transition-colors"
+                      title={p.projectPath}
+                    >
+                      {dirName}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -126,6 +126,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/escalate/respond", s.respondEscalation)
 		r.Post("/sessions/{id}/notify", s.sendNotification)
 		r.Post("/sessions/controller/restart", s.restartController)
+		r.Get("/projects/recent", s.getRecentProjects)
 		r.Get("/claude/models", s.getClaudeModels)
 		r.Get("/claude/version", s.getClaudeVersion)
 		r.Get("/logs", s.getLogs)
@@ -192,6 +193,18 @@ type sendRequest struct {
 type updateContextRequest struct {
 	CurrentTask string `json:"currentTask"`
 	Goal        string `json:"goal"`
+}
+
+func (s *Server) getRecentProjects(w http.ResponseWriter, r *http.Request) {
+	projects, err := s.sessions.ListRecentProjects(10)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if projects == nil {
+		projects = []session.RecentProject{}
+	}
+	writeJSON(w, http.StatusOK, projects)
 }
 
 func (s *Server) listSessions(w http.ResponseWriter, r *http.Request) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -879,6 +879,35 @@ func (m *Manager) CompleteGoal(id string) (*CompleteGoalResult, error) {
 	return result, nil
 }
 
+// ListRecentProjects returns recently used project paths, ordered by last usage.
+func (m *Manager) ListRecentProjects(limit int) ([]RecentProject, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := m.db.Query(
+		`SELECT project_path, MAX(updated_at) AS last_used_at, COUNT(*) AS session_count
+		 FROM sessions
+		 WHERE type != 'controller'
+		 GROUP BY project_path
+		 ORDER BY last_used_at DESC
+		 LIMIT ?`, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query recent projects: %w", err)
+	}
+	defer rows.Close()
+
+	var projects []RecentProject
+	for rows.Next() {
+		var p RecentProject
+		if err := rows.Scan(&p.ProjectPath, &p.LastUsedAt, &p.SessionCount); err != nil {
+			return nil, fmt.Errorf("scan recent project: %w", err)
+		}
+		projects = append(projects, p)
+	}
+	return projects, rows.Err()
+}
+
 // Reconnect restarts the CLI process for an existing session,
 // preserving the CLI session ID (--resume) and injecting a fresh MCP config.
 func (m *Manager) Reconnect(id string) error {

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -5,6 +5,13 @@ import (
 	"time"
 )
 
+// RecentProject represents a recently used project path.
+type RecentProject struct {
+	ProjectPath  string    `json:"projectPath"`
+	LastUsedAt   time.Time `json:"lastUsedAt"`
+	SessionCount int       `json:"sessionCount"`
+}
+
 type Status string
 
 const (

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -60,6 +60,9 @@ type SessionService interface {
 	StopAllStreamProcesses()
 	// SetCodexCommand sets the codex command for the manager.
 	SetCodexCommand(cmd string)
+
+	// ListRecentProjects returns recently used project paths.
+	ListRecentProjects(limit int) ([]RecentProject, error)
 }
 
 // Verify Manager implements SessionService at compile time.


### PR DESCRIPTION
## Summary

- `GET /api/projects/recent` エンドポイントを追加し、`sessions` テーブルから `project_path` を `GROUP BY` で集計して直近10件の使用プロジェクトを返す
- `CreateSession` モーダルの Project Path 入力欄の下に、最近使ったプロジェクトをチップ（小さなボタン）として表示。クリックで `projectPath` と `name` を自動入力
- ダッシュボードのヘッダーに「+」ボタンを追加し、Web UIからセッションを作成可能に

## 変更ファイル

- `internal/session/model.go` - `RecentProject` 型を追加
- `internal/session/service.go` - `ListRecentProjects` をインターフェースに追加
- `internal/session/manager.go` - `ListRecentProjects` メソッドを実装
- `internal/server/server.go` - `GET /api/projects/recent` ルートとハンドラを追加
- `frontend/src/api/client.ts` - `getRecentProjects()` API メソッドを追加
- `frontend/src/components/CreateSession.tsx` - 最近のプロジェクト選択UIを追加
- `frontend/src/App.tsx` - 「+」ボタンと `CreateSession` モーダルを統合

## Test plan

- [x] `make test` 通過
- [x] `make build` 通過
- [ ] ブラウザでダッシュボードの「+」ボタンをクリックしてモーダルが表示されることを確認
- [ ] モーダル内の最近のプロジェクトチップをクリックして、Project Path と Name が自動入力されることを確認
- [ ] セッション作成が正常に動作することを確認

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)