### PR TITLE
feat: セッション起動時にシステムプロンプトを設定可能にする

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -27,6 +27,7 @@ export const api = {
     provider?: string;
     model?: string;
     autoApprove?: boolean;
+    systemPrompt?: string;
   }) =>
     request<Session>("/sessions", {
       method: "POST",

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -10,6 +10,7 @@ interface Props {
     provider?: string;
     model?: string;
     autoApprove?: boolean;
+    systemPrompt?: string;
   }) => void;
 }
 
@@ -23,6 +24,7 @@ export function CreateSession({ onClose, onCreate }: Props) {
   const [name, setName] = useState("");
   const [projectPath, setProjectPath] = useState("");
   const [prompt, setPrompt] = useState("");
+  const [systemPrompt, setSystemPrompt] = useState("");
   const [provider, setProvider] = useState("claude");
   const [model, setModel] = useState("");
   const [codexModels, setCodexModels] = useState<CodexModel[]>([]);
@@ -63,6 +65,7 @@ export function CreateSession({ onClose, onCreate }: Props) {
       provider,
       model: (provider === "codex" || provider === "claude") && model ? model : undefined,
       autoApprove: provider === "codex" && autoApprove ? true : undefined,
+      systemPrompt: systemPrompt || undefined,
     });
   };
 
@@ -107,6 +110,18 @@ export function CreateSession({ onClose, onCreate }: Props) {
               rows={3}
               className="w-full border border-gray-300 rounded px-3 py-2 text-sm"
               placeholder="Fix the bug in..."
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              System Prompt (optional)
+            </label>
+            <textarea
+              value={systemPrompt}
+              onChange={(e) => setSystemPrompt(e.target.value)}
+              rows={3}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm"
+              placeholder="You are a specialist in..."
             />
           </div>
           <div>

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -157,6 +157,12 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: add system_prompt column if missing (for per-session system prompt)
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN system_prompt TEXT`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	// Migration: remove UNIQUE constraint from tmux_session (no longer used)
 	// SQLite doesn't support DROP CONSTRAINT, so we recreate the table
 	{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -170,13 +170,14 @@ func (s *Server) NewHTTPServer(addr string) *http.Server {
 // API handlers
 
 type createSessionRequest struct {
-	Name        string `json:"name"`
-	ProjectPath string `json:"projectPath"`
-	Prompt      string `json:"prompt,omitempty"`
-	Worktree    bool   `json:"worktree,omitempty"`
-	Provider    string `json:"provider,omitempty"`
-	Model       string `json:"model,omitempty"`
-	AutoApprove bool   `json:"autoApprove,omitempty"`
+	Name         string `json:"name"`
+	ProjectPath  string `json:"projectPath"`
+	Prompt       string `json:"prompt,omitempty"`
+	Worktree     bool   `json:"worktree,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	Model        string `json:"model,omitempty"`
+	AutoApprove  bool   `json:"autoApprove,omitempty"`
+	SystemPrompt string `json:"systemPrompt,omitempty"`
 }
 
 type sendImageData struct {
@@ -223,7 +224,7 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "name and projectPath are required")
 		return
 	}
-	sess, err := s.sessions.Create(req.Name, req.ProjectPath, req.Prompt, req.Worktree, session.CreateOpts{Provider: session.ProviderName(req.Provider), Model: req.Model, FullAuto: req.AutoApprove})
+	sess, err := s.sessions.Create(req.Name, req.ProjectPath, req.Prompt, req.Worktree, session.CreateOpts{Provider: session.ProviderName(req.Provider), Model: req.Model, FullAuto: req.AutoApprove, SystemPrompt: req.SystemPrompt})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -83,12 +83,21 @@ func (m *Manager) SystemPrompt() string {
 	return m.systemPrompt
 }
 
+// buildEffectiveSystemPrompt returns the effective system prompt by combining
+// the global default system prompt with a per-session custom system prompt.
+func (m *Manager) buildEffectiveSystemPrompt(customSystemPrompt string) string {
+	if customSystemPrompt == "" {
+		return m.systemPrompt
+	}
+	return m.systemPrompt + "\n\n" + customSystemPrompt
+}
+
 // RecoverStreamProcesses restarts stream processes for all working sessions.
 // This should be called at server startup to recover sessions that were running
 // before the server was restarted.
 func (m *Manager) RecoverStreamProcesses() {
 	rows, err := m.db.Query(
-		`SELECT id, project_path, provider, cli_session_id, model FROM sessions WHERE status = ? AND type != 'controller'`,
+		`SELECT id, project_path, provider, cli_session_id, model, system_prompt FROM sessions WHERE status = ? AND type != 'controller'`,
 		string(StatusWorking),
 	)
 	if err != nil {
@@ -99,7 +108,8 @@ func (m *Manager) RecoverStreamProcesses() {
 
 	for rows.Next() {
 		var id, projectPath, providerStr, dbCliSessionID, dbModel string
-		if err := rows.Scan(&id, &projectPath, &providerStr, &dbCliSessionID, &dbModel); err != nil {
+		var dbSystemPrompt sql.NullString
+		if err := rows.Scan(&id, &projectPath, &providerStr, &dbCliSessionID, &dbModel, &dbSystemPrompt); err != nil {
 			m.logger.Error("recover stream processes: scan failed", "error", err)
 			continue
 		}
@@ -121,11 +131,15 @@ func (m *Manager) RecoverStreamProcesses() {
 				_ = m.UpdateModel(id, model)
 			}
 		}
+		customPrompt := ""
+		if dbSystemPrompt.Valid {
+			customPrompt = dbSystemPrompt.String
+		}
 		sp, err := StartStreamProcessWithOpts(StreamOpts{
 			SessionID:     id,
 			ProjectPath:   projectPath,
 			MCPConfigPath: mcpPath,
-			SystemPrompt:  m.systemPrompt,
+			SystemPrompt:  m.buildEffectiveSystemPrompt(customPrompt),
 			Resume:        true,
 			CLISessionID:  cliSessionID,
 			Model:         dbModel,
@@ -145,21 +159,24 @@ func (m *Manager) RecoverStreamProcesses() {
 
 // CreateOpts contains optional parameters for creating a session.
 type CreateOpts struct {
-	Provider  ProviderName
-	Model     string
-	FullAuto  bool   // enable full-auto mode (bypasses permission prompts for Codex)
+	Provider     ProviderName
+	Model        string
+	FullAuto     bool   // enable full-auto mode (bypasses permission prompts for Codex)
+	SystemPrompt string // per-session custom system prompt (appended to defaultSystemPrompt)
 }
 
 func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts ...CreateOpts) (*Session, error) {
 	pn := ProviderClaude
 	model := ""
 	fullAuto := false
+	customSystemPrompt := ""
 	if len(opts) > 0 {
 		if opts[0].Provider != "" {
 			pn = opts[0].Provider
 		}
 		model = opts[0].Model
 		fullAuto = opts[0].FullAuto
+		customSystemPrompt = opts[0].SystemPrompt
 	}
 
 	// For Codex, resolve default model from config if not explicitly specified
@@ -180,12 +197,14 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		return nil, fmt.Errorf("write mcp config: %w", err)
 	}
 
+	effectiveSystemPrompt := m.buildEffectiveSystemPrompt(customSystemPrompt)
+
 	// Start stream process
 	streamOpts := StreamOpts{
 		SessionID:     id,
 		ProjectPath:   projectPath,
 		MCPConfigPath: mcpConfigPath,
-		SystemPrompt:  m.systemPrompt,
+		SystemPrompt:  effectiveSystemPrompt,
 		Resume:        false,
 		Worktree:      worktree,
 		Model:         model,
@@ -227,6 +246,7 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		Name:          name,
 		ProjectPath:   projectPath,
 		InitialPrompt: prompt,
+		SystemPrompt:  customSystemPrompt,
 		Status:        StatusWorking,
 		Type:          TypeWorker,
 		Provider:      pn,
@@ -236,9 +256,9 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	}
 
 	if _, err := m.db.Exec(
-		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.CreatedAt, s.UpdatedAt,
+		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, system_prompt, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.CreatedAt, s.UpdatedAt,
 	); err != nil {
 		return nil, fmt.Errorf("insert session: %w", err)
 	}
@@ -248,7 +268,7 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 
 func (m *Manager) List() ([]Session, error) {
 	rows, err := m.db.Query(
-		`SELECT id, name, project_path, initial_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, last_error, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, last_error, created_at, updated_at
 		 FROM sessions ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -262,8 +282,8 @@ func (m *Manager) List() ([]Session, error) {
 		var status string
 		var sessionType string
 		var providerStr string
-		var prompt, currentTask, goal, goalsJSON, lastError sql.NullString
-		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &lastError, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		var prompt, systemPrompt, currentTask, goal, goalsJSON, lastError sql.NullString
+		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &lastError, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		s.Status = Status(status)
@@ -274,6 +294,9 @@ func (m *Manager) List() ([]Session, error) {
 		}
 		if prompt.Valid {
 			s.InitialPrompt = prompt.String
+		}
+		if systemPrompt.Valid {
+			s.SystemPrompt = systemPrompt.String
 		}
 		if currentTask.Valid {
 			s.CurrentTask = currentTask.String
@@ -299,11 +322,11 @@ func (m *Manager) Get(id string) (*Session, error) {
 	var status string
 	var sessionType string
 	var providerStr string
-	var prompt, currentTask, goal, goalsJSON, lastError sql.NullString
+	var prompt, systemPrompt, currentTask, goal, goalsJSON, lastError sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, last_error, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, last_error, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id,
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &lastError, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &lastError, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
@@ -318,6 +341,9 @@ func (m *Manager) Get(id string) (*Session, error) {
 	}
 	if prompt.Valid {
 		s.InitialPrompt = prompt.String
+	}
+	if systemPrompt.Valid {
+		s.SystemPrompt = systemPrompt.String
 	}
 	if currentTask.Valid {
 		s.CurrentTask = currentTask.String
@@ -345,8 +371,9 @@ func (m *Manager) Duplicate(id string) (*Session, error) {
 
 	newName := src.Name + " (copy)"
 	return m.Create(newName, src.ProjectPath, "", false, CreateOpts{
-		Provider: src.Provider,
-		Model:    src.Model,
+		Provider:     src.Provider,
+		Model:        src.Model,
+		SystemPrompt: src.SystemPrompt,
 	})
 }
 
@@ -496,7 +523,7 @@ func (m *Manager) Clear(id string) error {
 		SessionID:     id,
 		ProjectPath:   s.ProjectPath,
 		MCPConfigPath: mcpConfigPath,
-		SystemPrompt:  m.systemPrompt,
+		SystemPrompt:  m.buildEffectiveSystemPrompt(s.SystemPrompt),
 		Model:         s.Model,
 		APIPort:       m.apiPort,
 	}, provider)
@@ -537,6 +564,7 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			cliSessionID = ReadCLISessionID(s.ID, provider)
 		}
 
+		effectiveSP := m.buildEffectiveSystemPrompt(s.SystemPrompt)
 		var err error
 		if s.Provider == ProviderCodex && cliSessionID != "" {
 			// For Codex, start resume directly with the prompt as a positional arg.
@@ -545,7 +573,7 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 				SessionID:     s.ID,
 				ProjectPath:   s.ProjectPath,
 				MCPConfigPath: mcpPath,
-				SystemPrompt:  m.systemPrompt,
+				SystemPrompt:  effectiveSP,
 				InitialPrompt: text,
 				Resume:        true,
 				CLISessionID:  cliSessionID,
@@ -567,7 +595,7 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			SessionID:     s.ID,
 			ProjectPath:   s.ProjectPath,
 			MCPConfigPath: mcpPath,
-			SystemPrompt:  m.systemPrompt,
+			SystemPrompt:  effectiveSP,
 			Resume:        true,
 			CLISessionID:  cliSessionID,
 			Model:         s.Model,
@@ -686,11 +714,11 @@ func (m *Manager) GetController() (*Session, error) {
 	var status string
 	var sessionType string
 	var providerStr string
-	var prompt, currentTask, goal, goalsJSON, lastError sql.NullString
+	var prompt, systemPrompt, currentTask, goal, goalsJSON, lastError sql.NullString
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, last_error, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, current_task, goal, goals, last_error, created_at, updated_at
 		 FROM sessions WHERE type = ? LIMIT 1`, string(TypeController),
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &lastError, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &currentTask, &goal, &goalsJSON, &lastError, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -705,6 +733,9 @@ func (m *Manager) GetController() (*Session, error) {
 	}
 	if prompt.Valid {
 		s.InitialPrompt = prompt.String
+	}
+	if systemPrompt.Valid {
+		s.SystemPrompt = systemPrompt.String
 	}
 	if currentTask.Valid {
 		s.CurrentTask = currentTask.String
@@ -908,7 +939,7 @@ func (m *Manager) Reconnect(id string) error {
 		SessionID:     id,
 		ProjectPath:   s.ProjectPath,
 		MCPConfigPath: mcpConfigPath,
-		SystemPrompt:  m.systemPrompt,
+		SystemPrompt:  m.buildEffectiveSystemPrompt(s.SystemPrompt),
 		Resume:        true,
 		CLISessionID:  cliSessionID,
 		Model:         s.Model,

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -29,6 +29,7 @@ type Session struct {
 	Name          string       `json:"name"`
 	ProjectPath   string       `json:"projectPath"`
 	InitialPrompt string       `json:"initialPrompt,omitempty"`
+	SystemPrompt  string       `json:"systemPrompt,omitempty"`
 	Status        Status       `json:"status"`
 	Type          SessionType  `json:"type"`
 	Provider      ProviderName `json:"provider"`


### PR DESCRIPTION
## 概要

セッション作成時にカスタムシステムプロンプトを設定できるようにする。

- セッション作成フォームに「System Prompt」テキストエリアを追加
- 入力されたカスタムプロンプトはagmux組み込みの`defaultSystemPrompt`に連結して`--append-system-prompt`で渡される
- DBに`system_prompt`カラムを追加し、セッション復旧・再接続・クリア時にも同じプロンプトが再適用される

## 変更内容

- **DB**: `sessions`テーブルに`system_prompt TEXT`カラムを追加（マイグレーション）
- **モデル**: `Session`構造体に`SystemPrompt`フィールドを追加
- **バックエンド**: `CreateOpts.SystemPrompt`を追加。`Manager.buildEffectiveSystemPrompt()`で`defaultSystemPrompt + カスタムプロンプト`を連結
- **API**: `POST /api/sessions`に`systemPrompt`フィールドを追加
- **フロントエンド**: `CreateSession.tsx`にSystem Promptテキストエリアを追加

## テスト計画

- [x] `make test` パス
- [x] `make build` パス
- [ ] システムプロンプト未入力でセッション作成 → 従来通り動作
- [ ] システムプロンプト入力してセッション作成 → カスタムプロンプトが反映される
- [ ] セッション復旧（サーバー再起動後）でカスタムプロンプトが保持される

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)