### PR TITLE
feat: 複数セッションへのメッセージ一斉送信機能

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -253,6 +253,7 @@ func sessionCmd() *cobra.Command {
 	cmd.AddCommand(sessionStopCmd())
 	cmd.AddCommand(sessionDeleteCmd())
 	cmd.AddCommand(sessionSendCmd())
+	cmd.AddCommand(sessionBroadcastCmd())
 
 	return cmd
 }
@@ -455,6 +456,85 @@ func sendSessionViaAPI(id, text string, port int) error {
 	}
 
 	fmt.Println("Text sent.")
+	return nil
+}
+
+func sessionBroadcastCmd() *cobra.Command {
+	var all bool
+	var filter string
+
+	cmd := &cobra.Command{
+		Use:   "broadcast <text>",
+		Short: "Broadcast a message to multiple sessions",
+		Long:  "Send the same message to all active sessions or specify a filter.\nExamples:\n  agmux session broadcast \"Report your progress\"\n  agmux session broadcast --filter all \"Stop work\"",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, _ := config.Load()
+			port := cfg.Server.Port
+			text := args[0]
+
+			if all {
+				filter = "all"
+			}
+			if filter == "" {
+				filter = "active"
+			}
+
+			return broadcastViaAPI(text, nil, filter, port)
+		},
+	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Send to all sessions including stopped/paused (shortcut for --filter all)")
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter target sessions: \"active\" (default) or \"all\"")
+
+	return cmd
+}
+
+func broadcastViaAPI(text string, sessionIDs []string, filter string, port int) error {
+	payload := map[string]interface{}{
+		"text":   text,
+		"filter": filter,
+	}
+	if len(sessionIDs) > 0 {
+		payload["sessionIds"] = sessionIDs
+	}
+	body, _ := json.Marshal(payload)
+
+	url := fmt.Sprintf("http://localhost:%d/api/sessions/broadcast", port)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to connect to agmux server on port %d (is it running?): %w", port, err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Results []struct {
+			SessionID string `json:"sessionId"`
+			Status    string `json:"status"`
+			Error     string `json:"error,omitempty"`
+		} `json:"results"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decode server response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server error: %s", result.Error)
+	}
+
+	if len(result.Results) == 0 {
+		fmt.Println("No target sessions found.")
+		return nil
+	}
+
+	for _, r := range result.Results {
+		if r.Status == "sent" {
+			fmt.Printf("  %s: sent\n", r.SessionID)
+		} else {
+			fmt.Printf("  %s: error - %s\n", r.SessionID, r.Error)
+		}
+	}
+	fmt.Printf("Broadcast complete: %d session(s)\n", len(result.Results))
 	return nil
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { useWebSocket } from "./hooks/useWebSocket";
 import { getActiveSessionName } from "./activeSession";
 import { IconButton } from "./components/ui/IconButton";
 import { CreateSession } from "./components/CreateSession";
+import { BroadcastModal } from "./components/BroadcastModal";
 
 // Register service worker for mobile notifications
 if ("serviceWorker" in navigator) {
@@ -91,6 +92,7 @@ function Dashboard() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [broadcastOpen, setBroadcastOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const mobileTab: MobileTab = searchParams.get("tab") === "logs" ? "logs" : "sessions";
   const navigate = useNavigate();
@@ -153,6 +155,19 @@ function Dashboard() {
             </svg>
           </IconButton>
           <button
+            onClick={() => setBroadcastOpen(true)}
+            className="p-1.5 text-gray-500 hover:text-gray-700 rounded-lg hover:bg-gray-100"
+            title="Broadcast"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9" />
+              <path d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.4" />
+              <circle cx="12" cy="12" r="2" />
+              <path d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.4" />
+              <path d="M19.1 4.9C23 8.8 23 15.1 19.1 19" />
+            </svg>
+          </button>
+          <button
             onClick={() => {
               const controller = sessions.find((s) => s.type === "controller");
               if (controller) {
@@ -169,6 +184,7 @@ function Dashboard() {
           </button>
         </div>
       </header>
+      <BroadcastModal open={broadcastOpen} onClose={() => setBroadcastOpen(false)} sessions={sessions} />
 
       {/* Error banner */}
       {error && (

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -87,6 +87,17 @@ export const api = {
   clearSession: (id: string) =>
     request<{ status: string }>(`/sessions/${id}/clear`, { method: "POST" }),
 
+  broadcastToSessions: (
+    text: string,
+    opts?: { sessionIds?: string[]; filter?: "active" | "all" }
+  ) =>
+    request<{
+      results: { sessionId: string; status: string; error?: string }[];
+    }>("/sessions/broadcast", {
+      method: "POST",
+      body: JSON.stringify({ text, ...opts }),
+    }),
+
   restartController: () =>
     request<Session>("/sessions/controller/restart", { method: "POST" }),
 

--- a/frontend/src/components/BroadcastModal.tsx
+++ b/frontend/src/components/BroadcastModal.tsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import { Modal } from "./ui/Modal";
+import { api } from "../api/client";
+import type { Session } from "../types/session";
+
+const ACTIVE_STATUSES = new Set(["working", "idle", "question_waiting", "alignment_needed"]);
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  sessions: Session[];
+}
+
+export function BroadcastModal({ open, onClose, sessions }: Props) {
+  const [text, setText] = useState("");
+  const [mode, setMode] = useState<"active" | "select">("active");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [sending, setSending] = useState(false);
+  const [result, setResult] = useState<{
+    results: { sessionId: string; status: string; error?: string }[];
+  } | null>(null);
+
+  const broadcastTargets = sessions.filter(
+    (s) => s.type !== "external" && ACTIVE_STATUSES.has(s.status)
+  );
+
+  const toggleSession = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleSend = async () => {
+    if (!text.trim()) return;
+    setSending(true);
+    setResult(null);
+    try {
+      const opts =
+        mode === "select"
+          ? { sessionIds: Array.from(selectedIds) }
+          : { filter: "active" as const };
+      const res = await api.broadcastToSessions(text.trim(), opts);
+      setResult(res);
+    } catch {
+      setResult({ results: [{ sessionId: "", status: "error", error: "Failed to send" }] });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleClose = () => {
+    setText("");
+    setMode("active");
+    setSelectedIds(new Set());
+    setResult(null);
+    onClose();
+  };
+
+  const canSend =
+    text.trim() !== "" &&
+    !sending &&
+    (mode === "active" ? broadcastTargets.length > 0 : selectedIds.size > 0);
+
+  return (
+    <Modal open={open} onClose={handleClose} title="Broadcast Message">
+      <div className="flex flex-col gap-4">
+        {/* Target mode selector */}
+        <div>
+          <label className="text-xs font-medium text-gray-600 mb-1 block">Target</label>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setMode("active")}
+              className={`px-3 py-1.5 text-xs rounded-md border ${
+                mode === "active"
+                  ? "bg-blue-50 border-blue-300 text-blue-700"
+                  : "bg-white border-gray-200 text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              All Active ({broadcastTargets.length})
+            </button>
+            <button
+              onClick={() => setMode("select")}
+              className={`px-3 py-1.5 text-xs rounded-md border ${
+                mode === "select"
+                  ? "bg-blue-50 border-blue-300 text-blue-700"
+                  : "bg-white border-gray-200 text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              Select Sessions
+            </button>
+          </div>
+        </div>
+
+        {/* Session selection list */}
+        {mode === "select" && (
+          <div className="max-h-40 overflow-y-auto border border-gray-200 rounded-md divide-y divide-gray-100">
+            {sessions
+              .filter((s) => s.type !== "external")
+              .map((s) => (
+                <label
+                  key={s.id}
+                  className="flex items-center gap-2 px-3 py-2 hover:bg-gray-50 cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.has(s.id)}
+                    onChange={() => toggleSession(s.id)}
+                    className="rounded border-gray-300"
+                  />
+                  <span className="text-sm text-gray-800 truncate">{s.name}</span>
+                  <span
+                    className={`ml-auto text-xs px-1.5 py-0.5 rounded ${
+                      ACTIVE_STATUSES.has(s.status)
+                        ? "bg-green-50 text-green-700"
+                        : "bg-gray-100 text-gray-500"
+                    }`}
+                  >
+                    {s.status}
+                  </span>
+                </label>
+              ))}
+          </div>
+        )}
+
+        {/* Message input */}
+        <div>
+          <label className="text-xs font-medium text-gray-600 mb-1 block">Message</label>
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Enter message to broadcast..."
+            rows={3}
+            className="w-full px-3 py-2 border border-gray-200 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-300 resize-none"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && canSend) {
+                handleSend();
+              }
+            }}
+          />
+        </div>
+
+        {/* Result display */}
+        {result && (
+          <div className="text-xs space-y-1">
+            {result.results.map((r, i) => (
+              <div
+                key={i}
+                className={`px-2 py-1 rounded ${
+                  r.status === "sent"
+                    ? "bg-green-50 text-green-700"
+                    : "bg-red-50 text-red-700"
+                }`}
+              >
+                {r.sessionId ? `${r.sessionId.slice(0, 8)}: ${r.status}` : r.error}
+                {r.error && r.sessionId ? ` - ${r.error}` : ""}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={handleClose}
+            className="px-3 py-1.5 text-xs text-gray-600 border border-gray-200 rounded-md hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSend}
+            disabled={!canSend}
+            className="px-3 py-1.5 text-xs text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {sending ? "Sending..." : "Broadcast"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -125,6 +126,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/escalate", s.createEscalation)
 		r.Post("/sessions/{id}/escalate/respond", s.respondEscalation)
 		r.Post("/sessions/{id}/notify", s.sendNotification)
+		r.Post("/sessions/broadcast", s.broadcastToSessions)
 		r.Post("/sessions/controller/restart", s.restartController)
 		r.Get("/projects/recent", s.getRecentProjects)
 		r.Get("/claude/models", s.getClaudeModels)
@@ -346,6 +348,77 @@ func (s *Server) sendToSession(w http.ResponseWriter, r *http.Request) {
 	_ = s.sessions.UpdateStatus(id, session.StatusWorking)
 	s.recordSessionAction(id, "session_send_keys", req.Text)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "sent"})
+}
+
+type broadcastRequest struct {
+	Text       string   `json:"text"`
+	SessionIDs []string `json:"sessionIds,omitempty"`
+	Filter     string   `json:"filter,omitempty"` // "active" (default) | "all"
+}
+
+type broadcastResult struct {
+	SessionID string `json:"sessionId"`
+	Status    string `json:"status"`
+	Error     string `json:"error,omitempty"`
+}
+
+func (s *Server) broadcastToSessions(w http.ResponseWriter, r *http.Request) {
+	var req broadcastRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Text == "" {
+		writeError(w, http.StatusBadRequest, "text is required")
+		return
+	}
+
+	// Determine target sessions
+	var targetIDs []string
+	if len(req.SessionIDs) > 0 {
+		targetIDs = req.SessionIDs
+	} else {
+		sessions, err := s.sessions.List()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		activeStatuses := map[session.Status]bool{
+			session.StatusWorking:         true,
+			session.StatusIdle:            true,
+			session.StatusQuestionWaiting: true,
+			session.StatusAlignmentNeeded: true,
+		}
+		for _, sess := range sessions {
+			// Skip external sessions
+			if sess.Type == session.TypeExternal {
+				continue
+			}
+			if req.Filter == "all" || activeStatuses[sess.Status] {
+				targetIDs = append(targetIDs, sess.ID)
+			}
+		}
+	}
+
+	// Send to all targets in parallel
+	results := make([]broadcastResult, len(targetIDs))
+	var wg sync.WaitGroup
+	for i, id := range targetIDs {
+		wg.Add(1)
+		go func(idx int, sessionID string) {
+			defer wg.Done()
+			if err := s.sessions.SendKeysWithImages(sessionID, req.Text, nil); err != nil {
+				results[idx] = broadcastResult{SessionID: sessionID, Status: "error", Error: err.Error()}
+				return
+			}
+			_ = s.sessions.UpdateStatus(sessionID, session.StatusWorking)
+			s.recordSessionAction(sessionID, "session_send_keys", req.Text)
+			results[idx] = broadcastResult{SessionID: sessionID, Status: "sent"}
+		}(i, id)
+	}
+	wg.Wait()
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"results": results})
 }
 
 func (s *Server) updateSessionContext(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- 複数セッションに同じメッセージを一斉送信できるbroadcast機能を追加
- API、CLI、フロントエンドの3層で実装
- デフォルトではアクティブなセッション(working/idle/question_waiting/alignment_needed)に並列送信

## 変更内容

### API
- `POST /api/sessions/broadcast` エンドポイントを追加
- `text` (必須)、`sessionIds` (任意)、`filter` (`active`/`all`) をリクエストパラメータとして受け付け
- 対象セッションに `sync.WaitGroup` で並列送信、各セッションの成功/失敗を個別に返却

### CLI
- `agmux session broadcast <text>` コマンドを追加
- `--all` フラグで停止/一時停止中セッションも含めて送信
- `--filter` フラグでフィルタ指定可能

### フロントエンド
- ダッシュボードヘッダーにBroadcastボタン（電波アイコン）を追加
- モーダルで「全アクティブセッション」または「セッション個別選択」を切り替え可能
- 送信結果を各セッションごとに表示
- Cmd+Enter / Ctrl+Enter で送信可能

## Test plan
- [x] `make test` パス
- [x] `make build` パス
- [ ] Broadcastモーダルの表示確認
- [ ] アクティブセッションへの一斉送信動作確認
- [ ] セッション個別選択での送信動作確認
- [ ] CLIからの `agmux session broadcast` 動作確認

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)