### PR TITLE
feat: 通知履歴を記録し一覧表示できるようにする

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Outlet, useNavigate, useSearchParams } from "react-router-dom";
 import { api } from "./api/client";
 import type { Session } from "./types/session";
 import { LogPanel } from "./components/LogPanel";
+import { NotificationPanel } from "./components/NotificationPanel";
 import { SessionList } from "./components/SessionList";
 import { Tabs } from "./components/ui/Tabs";
 import { useWebSocket } from "./hooks/useWebSocket";
@@ -39,7 +40,8 @@ async function sendNotification(title: string, body: string, sessionId?: string)
   }
 }
 
-type MobileTab = "sessions" | "logs";
+type MobileTab = "sessions" | "logs" | "notifications";
+type SidebarTab = "logs" | "notifications";
 
 // Global notification hook — runs regardless of which page is active
 function useGlobalNotifications() {
@@ -93,8 +95,9 @@ function Dashboard() {
   const [error, setError] = useState<string | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [broadcastOpen, setBroadcastOpen] = useState(false);
+  const [sidebarTab, setSidebarTab] = useState<SidebarTab>("logs");
   const [searchParams, setSearchParams] = useSearchParams();
-  const mobileTab: MobileTab = searchParams.get("tab") === "logs" ? "logs" : "sessions";
+  const mobileTab: MobileTab = (searchParams.get("tab") as MobileTab) || "sessions";
   const navigate = useNavigate();
   const loadSessions = () => {
     api.listSessions().then((data) => {
@@ -205,13 +208,14 @@ function Dashboard() {
           items={[
             { key: "sessions", label: `Sessions (${sessions.length})` },
             { key: "logs", label: "Logs" },
+            { key: "notifications", label: "Notifications" },
           ]}
           activeKey={mobileTab}
           onChange={(key) => {
-            if (key === "logs") {
-              setSearchParams({ tab: "logs" });
-            } else {
+            if (key === "sessions") {
               setSearchParams({});
+            } else {
+              setSearchParams({ tab: key });
             }
           }}
         />
@@ -234,13 +238,32 @@ function Dashboard() {
           />
         </div>
 
-        {/* Log panel - desktop: always visible (sidebar), mobile: only when tab active */}
+        {/* Sidebar - desktop: always visible, mobile: only when tab active */}
         <div
           className={`md:w-[480px] md:border-l border-gray-200 bg-white min-h-0 p-3 md:p-4 ${
-            mobileTab === "logs" ? "flex-1 flex flex-col" : "hidden md:flex md:flex-col"
+            mobileTab === "logs" || mobileTab === "notifications" ? "flex-1 flex flex-col" : "hidden md:flex md:flex-col"
           }`}
         >
-          <LogPanel />
+          {/* Desktop sidebar tab switcher */}
+          <div className="hidden md:block mb-2">
+            <Tabs
+              items={[
+                { key: "logs", label: "Logs" },
+                { key: "notifications", label: "Notifications" },
+              ]}
+              activeKey={sidebarTab}
+              onChange={(key) => setSidebarTab(key as SidebarTab)}
+            />
+          </div>
+          {/* Mobile: show based on mobileTab, Desktop: show based on sidebarTab */}
+          <div className="flex-1 min-h-0 flex flex-col md:hidden">
+            {mobileTab === "logs" && <LogPanel />}
+            {mobileTab === "notifications" && <NotificationPanel />}
+          </div>
+          <div className="flex-1 min-h-0 hidden md:flex md:flex-col">
+            {sidebarTab === "logs" && <LogPanel />}
+            {sidebarTab === "notifications" && <NotificationPanel />}
+          </div>
         </div>
       </div>
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -147,6 +147,9 @@ export const api = {
     if (params?.since) qs.set("since", params.since);
     return request<MetricEvent[]>(`/metrics/events?${qs}`);
   },
+
+  getNotifications: (limit = 50) =>
+    request<NotificationEntry[]>(`/notifications?limit=${limit}`),
 };
 
 export interface RecentProject {
@@ -206,6 +209,15 @@ export interface MetricsSummary {
   codeEditDecisions: number;
   costBySession: { sessionId: string; cost: number }[];
   tokensBySession: { sessionId: string; input: number; output: number }[];
+}
+
+export interface NotificationEntry {
+  id: number;
+  sessionId: string;
+  sessionName: string;
+  kind: string;
+  message: string;
+  createdAt: string;
 }
 
 export interface MetricEvent {

--- a/frontend/src/components/NotificationPanel.tsx
+++ b/frontend/src/components/NotificationPanel.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { api } from "../api/client";
+import type { NotificationEntry } from "../api/client";
+import { useWebSocket } from "../hooks/useWebSocket";
+
+export function NotificationPanel() {
+  const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
+  const navigate = useNavigate();
+
+  const load = useCallback(() => {
+    api.getNotifications(100).then(setNotifications).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Reload on new notification via WebSocket
+  const handleWsMessage = useCallback(
+    (msg: { type: string }) => {
+      if (msg.type === "agent_notification" || msg.type === "escalation") {
+        load();
+      }
+    },
+    [load]
+  );
+
+  useWebSocket(handleWsMessage);
+
+  const kindLabel = (kind: string) => {
+    if (kind === "escalation") return "Escalation";
+    return "Notification";
+  };
+
+  const kindColor = (kind: string) => {
+    if (kind === "escalation") return "text-orange-400";
+    return "text-blue-400";
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-gray-700 bg-gray-800 rounded-t-lg">
+        <h2 className="text-sm font-semibold text-gray-200">Notifications</h2>
+        <span className="text-xs text-gray-400">{notifications.length}</span>
+      </div>
+      <div className="bg-gray-900 rounded-b-lg p-3 font-mono text-xs overflow-auto flex-1 min-h-0">
+        {notifications.length === 0 ? (
+          <p className="text-gray-500">No notifications yet</p>
+        ) : (
+          <table className="w-full">
+            <tbody>
+              {notifications.map((n) => (
+                <tr key={n.id} className="align-top hover:bg-gray-800">
+                  <td className="text-gray-500 pr-2 whitespace-nowrap py-0.5">
+                    {new Date(n.createdAt + "Z").toLocaleTimeString()}
+                  </td>
+                  <td className={`pr-2 whitespace-nowrap py-0.5 ${kindColor(n.kind)}`}>
+                    {kindLabel(n.kind)}
+                  </td>
+                  <td className="text-gray-300 pr-2 whitespace-nowrap py-0.5">
+                    {n.sessionId ? (
+                      <button
+                        onClick={() => navigate(`/sessions/${n.sessionId}`)}
+                        className="text-cyan-400 underline hover:text-cyan-300 cursor-pointer"
+                      >
+                        {n.sessionName || n.sessionId.slice(0, 8)}
+                      </button>
+                    ) : null}
+                  </td>
+                  <td className="text-gray-100 py-0.5 break-all">
+                    {n.message}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -263,6 +263,22 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: create notifications table
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS notifications (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			kind TEXT NOT NULL,
+			message TEXT NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		return err
+	}
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_notifications_session ON notifications(session_id)`)
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_notifications_created ON notifications(created_at)`)
+
 	return nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -131,6 +131,7 @@ func (s *Server) setupRoutes() {
 		r.Get("/projects/recent", s.getRecentProjects)
 		r.Get("/claude/models", s.getClaudeModels)
 		r.Get("/claude/version", s.getClaudeVersion)
+		r.Get("/notifications", s.listNotifications)
 		r.Get("/logs", s.getLogs)
 		r.Get("/config", s.getConfig)
 		r.Put("/config", s.updateConfig)
@@ -540,6 +541,7 @@ func (s *Server) createEscalation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.recordSessionAction(sessionID, "escalation", req.Message)
+	s.saveNotification(sessionID, "escalation", req.Message)
 
 	// Determine timeout duration
 	timeoutSeconds := 300 // default 5 minutes
@@ -617,6 +619,7 @@ func (s *Server) sendNotification(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.recordSessionAction(sessionID, "agent_notification", req.Message)
+	s.saveNotification(sessionID, "notification", req.Message)
 
 	// Broadcast WebSocket notification to all connected clients
 	s.hub.Broadcast(Message{
@@ -730,6 +733,68 @@ func (s *Server) getSessionStream(w http.ResponseWriter, r *http.Request) {
 		"lines": result,
 		"total": total,
 	})
+}
+
+func (s *Server) saveNotification(sessionID, kind, message string) {
+	_, err := s.sqlDB.Exec(
+		`INSERT INTO notifications (session_id, kind, message) VALUES (?, ?, ?)`,
+		sessionID, kind, message,
+	)
+	if err != nil {
+		s.logger.Error("failed to save notification", "error", err)
+	}
+}
+
+type notificationRow struct {
+	ID          int64  `json:"id"`
+	SessionID   string `json:"sessionId"`
+	SessionName string `json:"sessionName"`
+	Kind        string `json:"kind"`
+	Message     string `json:"message"`
+	CreatedAt   string `json:"createdAt"`
+}
+
+func (s *Server) listNotifications(w http.ResponseWriter, r *http.Request) {
+	limit := 50
+	if q := r.URL.Query().Get("limit"); q != "" {
+		if n, err := strconv.Atoi(q); err == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	query := `
+		SELECT n.id, n.session_id, COALESCE(s.name, ''), n.kind, n.message, n.created_at
+		FROM notifications n
+		LEFT JOIN sessions s ON n.session_id = s.id
+	`
+	args := []interface{}{}
+
+	if since := r.URL.Query().Get("since"); since != "" {
+		query += ` WHERE n.created_at >= ?`
+		args = append(args, since)
+	}
+
+	query += ` ORDER BY n.created_at DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := s.sqlDB.Query(query, args...)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer rows.Close()
+
+	notifications := []notificationRow{}
+	for rows.Next() {
+		var n notificationRow
+		if err := rows.Scan(&n.ID, &n.SessionID, &n.SessionName, &n.Kind, &n.Message, &n.CreatedAt); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		notifications = append(notifications, n)
+	}
+
+	writeJSON(w, http.StatusOK, notifications)
 }
 
 func (s *Server) getLogs(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## 概要

`send_notification` MCPツールや `escalate` で送信された通知をDBに記録し、通知一覧として閲覧できるようにする。

## 変更内容

- **DB**: `notifications` テーブルを追加（id, session_id, kind, message, created_at）
- **バックエンド**: `sendNotification` / `createEscalation` ハンドラでDB書き込みを追加
- **API**: `GET /api/notifications?limit=50&since=...` エンドポイントを追加
- **フロントエンド**: `NotificationPanel` コンポーネントを追加し、ダッシュボードのサイドバーにLogs/Notificationsタブ切り替えを追加
- **WebSocket連携**: `agent_notification` / `escalation` イベント受信時に通知一覧をリアルタイム更新

## テスト計画

- [ ] `make test` パス確認
- [ ] `make build` ビルド確認
- [ ] 通知送信後にNotificationsタブで通知が表示されることを確認
- [ ] セッション名クリックでセッションページに遷移することを確認
- [ ] モバイルタブでNotificationsが表示されることを確認

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)