### PR TITLE
fix: MCPサーバーにEnterPlanMode/ExitPlanModeハンドラを追加

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -167,6 +167,22 @@ func (s *Server) handleMethod(method string, params json.RawMessage) (interface{
 						"required": []string{"message"},
 					},
 				},
+				map[string]interface{}{
+					"name":        "EnterPlanMode",
+					"description": "Plan modeに入ります。",
+					"inputSchema": map[string]interface{}{
+						"type":       "object",
+						"properties": map[string]interface{}{},
+					},
+				},
+				map[string]interface{}{
+					"name":        "ExitPlanMode",
+					"description": "Plan modeから抜けます。",
+					"inputSchema": map[string]interface{}{
+						"type":       "object",
+						"properties": map[string]interface{}{},
+					},
+				},
 			},
 		}, nil
 
@@ -219,6 +235,10 @@ func (s *Server) callTool(name string, args json.RawMessage) (interface{}, *json
 		return s.handleSendNotification(args)
 	case "escalate":
 		return s.handleEscalate(args)
+	case "EnterPlanMode":
+		return toolResult("Plan mode entered", false), nil
+	case "ExitPlanMode":
+		return toolResult("Plan mode exited", false), nil
 	default:
 		return nil, &jsonRPCError{Code: -32602, Message: "unknown tool: " + name}
 	}


### PR DESCRIPTION
## Summary
- MCPサーバーの `callTool()` に `EnterPlanMode` / `ExitPlanMode` のno-opハンドラを追加
- `tools/list` にも両ツールを登録し、MCPクライアントに正しくアドバタイズされるようにした
- プランモードに入った後exitできない問題を解決

Closes #401

## Test plan
- [x] `make test` パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)