### PR TITLE
fix: 通知一覧のInvalid Date表示を修正

### DIFF
--- a/frontend/src/components/NotificationPanel.tsx
+++ b/frontend/src/components/NotificationPanel.tsx
@@ -53,7 +53,7 @@ export function NotificationPanel() {
               {notifications.map((n) => (
                 <tr key={n.id} className="align-top hover:bg-gray-800">
                   <td className="text-gray-500 pr-2 whitespace-nowrap py-0.5">
-                    {new Date(n.createdAt + "Z").toLocaleTimeString()}
+                    {new Date(n.createdAt).toLocaleTimeString()}
                   </td>
                   <td className={`pr-2 whitespace-nowrap py-0.5 ${kindColor(n.kind)}`}>
                     {kindLabel(n.kind)}


### PR DESCRIPTION
## Summary
- APIが既にZ付きISO文字列(`2026-03-27T02:57:44Z`)を返しているのに、フロントで`+ "Z"`を追加して`ZZ`になりInvalid Dateになっていた

## Test plan
- [ ] 通知一覧ページで日時が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)