### PR TITLE
fix: 送信フォーム上部の不要なボーダーを削除

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -292,7 +292,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
   };
 
   const sendForm = session ? (
-    <form onSubmit={handleSend} className="shrink-0 sticky bottom-0 bg-white pt-2 pb-4 px-4 sm:px-8 -mx-4 sm:-mx-8 border-t border-gray-100">
+    <form onSubmit={handleSend} className="shrink-0 sticky bottom-0 bg-white pt-2 pb-4 px-4 sm:px-8 -mx-4 sm:-mx-8">
       {pendingImages.length > 0 && (
         <div className="flex gap-2 mb-2 flex-wrap">
           {pendingImages.map((img, i) => (
@@ -806,7 +806,7 @@ export function PermissionPromptBanner({ permission, sessionId, onResponded }: {
   };
 
   return (
-    <div className="shrink-0 sticky bottom-0 bg-white pt-2 pb-4 px-4 sm:px-8 -mx-4 sm:-mx-8 border-t border-gray-100">
+    <div className="shrink-0 sticky bottom-0 bg-white pt-2 pb-4 px-4 sm:px-8 -mx-4 sm:-mx-8">
       <div className="border border-amber-300 rounded-lg bg-amber-50 p-3 space-y-2">
         <div className="flex items-center gap-2">
           <AlertTriangle className="w-4 h-4 text-amber-500 shrink-0" />


### PR DESCRIPTION
## Summary
- SessionPageの送信フォーム（sendForm）とPermissionPromptBanner上部の `border-t border-gray-100` を削除

## Test plan
- [ ] セッション画面で送信フォーム上部に薄いボーダーが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)