### PR TITLE
feat: resultイベントとタスク追跡によるidle/working自動判定

### DIFF
--- a/internal/monitor/checker.go
+++ b/internal/monitor/checker.go
@@ -98,8 +98,10 @@ func (sc *StatusChecker) check() {
 		}
 
 		// Status detection via stream JSONL
+		// Note: idle/working transitions are handled by StreamProcess (result event + task tracking),
+		// so the monitor only detects question_waiting, alignment_needed, and paused.
 		result := sc.monitor.CheckStatus(s)
-		if result.Status != s.Status {
+		if result.Status != "" && result.Status != s.Status {
 			sc.logger.Info(fmt.Sprintf("%s (%s): %s -> %s (%s)",
 				s.Name, shortID,
 				s.Status, result.Status, result.Reason),

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -86,11 +86,10 @@ const StatusPrompt = `以下はClaude Codeセッションのstream-json出力の
 1行目にステータス、2行目に日本語で短い要約（何をしている/何を聞いている/何を待っているか）を出力してください。
 
 ステータス（1行目に以下のいずれか1つだけ）:
-- working: AIが作業中（ツール実行中、コード生成中、思考中など）
 - question_waiting: ユーザーに質問や確認をしている状態
 - alignment_needed: タスクの方針決定や仕様の確認など、ユーザーとのアラインメントが必要な状態
 - paused: ゴール未達成だが作業が中断している状態（次にやることはわかっている）
-- idle: ゴールを達成し、ユーザーの次の指示を待っている状態（明確にタスク完了した場合のみ）
+- none: 上記に該当しない（判定不要）
 
 例:
 question_waiting
@@ -133,10 +132,9 @@ func classifyWithLLM(lastLine string) CheckStatusResult {
 		return CheckStatusResult{session.StatusQuestionWaiting, reason, summary}
 	case strings.Contains(statusLine, "paused"):
 		return CheckStatusResult{session.StatusPaused, reason, summary}
-	case strings.Contains(statusLine, "idle"):
-		return CheckStatusResult{session.StatusIdle, reason, summary}
-	case strings.Contains(statusLine, "working"):
-		return CheckStatusResult{session.StatusWorking, reason, summary}
+	case strings.Contains(statusLine, "none"):
+		// LLM says none of the special statuses apply; keep current status
+		return CheckStatusResult{Status: "", Reason: "llm: none"}
 	}
 
 	return CheckStatusResult{Reason: fmt.Sprintf("llm unrecognized: %s", truncate(response, 60))}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -543,6 +543,13 @@ func (m *Manager) wireSessionIDCallback(sessionID string, sp *StreamProcess) {
 	} else {
 		m.logger.Warn("onNewLines callback is nil, WebSocket updates will not work", "sessionId", sessionID)
 	}
+	sp.SetOnStatusChange(func(sid string, status Status) {
+		if err := m.UpdateStatus(sid, status); err != nil {
+			m.logger.Error("failed to update status from stream event", "sessionId", sid, "status", status, "error", err)
+		} else {
+			m.logger.Info("status updated from stream event", "sessionId", sid, "status", status)
+		}
+	})
 	sp.SetOnProcessExit(func(sid string, exitErr error) {
 		// For Codex provider, exit code 0 is normal (exec finishes after each prompt).
 		// Keep the session running and the stream process in the map so that

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -50,6 +50,14 @@ type StreamProcess struct {
 	// onProcessExit is called when the CLI process exits unexpectedly.
 	// The callback receives the agmux session ID and the exit error (nil if exited cleanly).
 	onProcessExit func(sessionID string, exitErr error)
+
+	// onStatusChange is called when the stream detects a status transition
+	// (e.g. result event received → idle, user message sent → working).
+	onStatusChange func(sessionID string, status Status)
+
+	// runningTasks tracks the number of background Agent tasks currently in progress.
+	// Incremented on task_started, decremented on task_notification.
+	runningTasks int
 }
 
 // ReadCLISessionID reads the CLI-assigned session ID from a stream JSONL file.
@@ -275,12 +283,18 @@ func (sp *StreamProcess) readLoop(stdout io.Reader) {
 		// stream_event lines are only delivered via WebSocket (real-time),
 		// not persisted to .jsonl or included in the lines slice.
 		isStreamEvent := false
+		var peekType, peekSubtype string
 		if len(normalized) > 0 && normalized[0] == '{' {
 			var peek struct {
-				Type string `json:"type"`
+				Type    string `json:"type"`
+				Subtype string `json:"subtype"`
 			}
-			if json.Unmarshal(normalized, &peek) == nil && peek.Type == "stream_event" {
-				isStreamEvent = true
+			if json.Unmarshal(normalized, &peek) == nil {
+				peekType = peek.Type
+				peekSubtype = peek.Subtype
+				if peekType == "stream_event" {
+					isStreamEvent = true
+				}
 			}
 		}
 
@@ -292,7 +306,29 @@ func (sp *StreamProcess) readLoop(stdout io.Reader) {
 		}
 		total := len(sp.lines)
 		cb := sp.onNewLines
+
+		// Track running tasks and detect status transitions
+		var statusChange *Status
+		switch {
+		case peekType == "result":
+			if sp.runningTasks <= 0 {
+				idle := StatusIdle
+				statusChange = &idle
+			}
+		case peekSubtype == "task_started":
+			sp.runningTasks++
+		case peekSubtype == "task_notification":
+			sp.runningTasks--
+			if sp.runningTasks < 0 {
+				sp.runningTasks = 0
+			}
+		}
+		statusCb := sp.onStatusChange
 		sp.mu.Unlock()
+
+		if statusChange != nil && statusCb != nil {
+			statusCb(sp.streamOpts.SessionID, *statusChange)
+		}
 
 		if cb != nil {
 			cb(sp.streamOpts.SessionID, []string{normalizedStr}, total)
@@ -370,6 +406,12 @@ func (sp *StreamProcess) SetOnProcessExit(fn func(sessionID string, exitErr erro
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 	sp.onProcessExit = fn
+}
+
+func (sp *StreamProcess) SetOnStatusChange(fn func(sessionID string, status Status)) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.onStatusChange = fn
 }
 
 // ImageData represents a base64-encoded image to be sent with a message.
@@ -472,7 +514,13 @@ func (sp *StreamProcess) sendClaude(message string, images []ImageData) error {
 	sp.file.WriteString(line + "\n")
 	sp.file.Sync()
 	cb := sp.onNewLines
+	statusCb := sp.onStatusChange
 	sp.mu.Unlock()
+
+	// User message sent → working
+	if statusCb != nil {
+		statusCb(sp.streamOpts.SessionID, StatusWorking)
+	}
 
 	if cb != nil {
 		cb(sp.streamOpts.SessionID, []string{line}, total)


### PR DESCRIPTION
## Summary
- ストリームの `result` イベント + running tasks カウントで idle/working を自動判定
- LLMベースの status checker から idle/working 判定を除外（question_waiting, alignment_needed, paused のみ）
- ユーザーメッセージ送信時に自動で working に遷移

## 背景
従来はLLM（claude -p）で最終イベントを分析してステータスを判定していたが、idle/working についてはストリームイベントから確実に判定できることが判明。`type: "result"` イベントがターン完了シグナルとして機能し、`task_started`/`task_notification` でバックグラウンドタスク数を追跡可能。

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/session/... ./internal/monitor/...` passes (78 tests)
- [ ] セッション実行中にステータスが working → idle に正しく遷移することを確認
- [ ] バックグラウンドタスク実行中は result 受信後も idle にならないことを確認
- [ ] ユーザーメッセージ送信時に idle → working に遷移することを確認

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)