### PR TITLE
feat: Per-session Holderプロセスでサーバー再起動時のプロセス停止を防ぐ

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -43,6 +43,7 @@ func main() {
 	rootCmd.AddCommand(mcpCmd())
 	rootCmd.AddCommand(logsCmd())
 	rootCmd.AddCommand(daemonCmd())
+	rootCmd.AddCommand(holderCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -716,6 +717,43 @@ func daemonCmd() *cobra.Command {
 			return daemon.Uninstall()
 		},
 	})
+
+	return cmd
+}
+
+func holderCmd() *cobra.Command {
+	var sessionID string
+	var projectPath string
+
+	cmd := &cobra.Command{
+		Use:    "holder",
+		Short:  "Run as a holder process for a session (internal use)",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if sessionID == "" {
+				return fmt.Errorf("--session-id is required")
+			}
+			if projectPath == "" {
+				return fmt.Errorf("--project-path is required")
+			}
+
+			// Everything after "--" is the CLI command to execute
+			cmdArgs := cmd.Flags().Args()
+			if len(cmdArgs) == 0 {
+				return fmt.Errorf("no command specified after --")
+			}
+
+			// Collect environment from current process
+			env := os.Environ()
+
+			return session.RunHolder(sessionID, cmdArgs, projectPath, env)
+		},
+	}
+
+	cmd.Flags().StringVar(&sessionID, "session-id", "", "Session ID")
+	cmd.Flags().StringVar(&projectPath, "project-path", "", "Project directory path")
+	// Allow passing arbitrary args after "--"
+	cmd.Flags().SetInterspersed(false)
 
 	return cmd
 }

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -169,6 +169,12 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: add holder_pid column if missing (for holder process tracking)
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN holder_pid INTEGER NOT NULL DEFAULT 0`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	// Migration: remove UNIQUE constraint from tmux_session (no longer used)
 	// SQLite doesn't support DROP CONSTRAINT, so we recreate the table
 	{

--- a/internal/session/holder.go
+++ b/internal/session/holder.go
@@ -1,0 +1,370 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/myuon/agmux/internal/db"
+)
+
+const (
+	// SocketDir is the directory for holder Unix sockets.
+	SocketDir = "/tmp/agmux/socks"
+)
+
+// SocketPath returns the Unix socket path for a session.
+func SocketPath(sessionID string) string {
+	return filepath.Join(SocketDir, sessionID+".sock")
+}
+
+// HolderControlMessage is a message sent over the socket for control purposes.
+type HolderControlMessage struct {
+	Type    string `json:"type"`
+	Action  string `json:"action,omitempty"`  // server → holder: "stop", "restart"
+	Event   string `json:"event,omitempty"`   // holder → server: "exited"
+	Code    int    `json:"code,omitempty"`     // exit code
+	Content string `json:"content,omitempty"` // message content
+}
+
+// RunHolder is the main entry point for the holder subprocess.
+// It starts the CLI process, listens on a Unix socket, and manages the lifecycle.
+func RunHolder(sessionID string, cmdArgs []string, projectPath string, env []string) error {
+	if err := os.MkdirAll(SocketDir, 0700); err != nil {
+		return fmt.Errorf("create socket dir: %w", err)
+	}
+
+	sockPath := SocketPath(sessionID)
+	// Clean up stale socket file if it exists
+	os.Remove(sockPath)
+
+	// Open JSONL stream file for writing
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		return fmt.Errorf("get streams dir: %w", err)
+	}
+	streamPath := filepath.Join(streamsDir, sessionID+".jsonl")
+	streamFile, err := os.OpenFile(streamPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open stream file: %w", err)
+	}
+	defer streamFile.Close()
+
+	// Start the CLI process
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd.Dir = projectPath
+	cmd.Env = env
+	cmd.Stderr = os.Stderr
+
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("stdin pipe: %w", err)
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start cli process: %w", err)
+	}
+
+	slog.Info("holder: CLI process started", "pid", cmd.Process.Pid, "sessionId", sessionID)
+
+	// Set up Unix socket listener
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		cmd.Process.Kill()
+		return fmt.Errorf("listen unix socket: %w", err)
+	}
+	defer func() {
+		listener.Close()
+		os.Remove(sockPath)
+	}()
+
+	slog.Info("holder: listening on socket", "path", sockPath)
+
+	h := &holder{
+		sessionID:  sessionID,
+		cmd:        cmd,
+		stdin:      stdinPipe,
+		streamFile: streamFile,
+		listener:   listener,
+		done:       make(chan struct{}),
+		clients:    make(map[net.Conn]struct{}),
+	}
+
+	// Read stdout in a goroutine
+	go h.readStdout(stdoutPipe)
+
+	// Accept socket connections in a goroutine
+	go h.acceptLoop()
+
+	// Handle signals
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+
+	// Wait for CLI process to exit or signal
+	select {
+	case <-h.done:
+		// CLI process exited naturally
+		exitCode := 0
+		if err := cmd.Wait(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				exitCode = exitErr.ExitCode()
+			}
+		}
+		slog.Info("holder: CLI process exited", "code", exitCode, "sessionId", sessionID)
+		h.broadcastControl(HolderControlMessage{
+			Type:  "control",
+			Event: "exited",
+			Code:  exitCode,
+		})
+	case sig := <-sigCh:
+		slog.Info("holder: received signal, stopping CLI process", "signal", sig, "sessionId", sessionID)
+		stdinPipe.Close()
+		select {
+		case <-h.done:
+			cmd.Wait()
+		case <-time.After(5 * time.Second):
+			cmd.Process.Kill()
+			cmd.Wait()
+		}
+	}
+
+	// Give clients a moment to receive the exit notification
+	time.Sleep(100 * time.Millisecond)
+
+	return nil
+}
+
+type holder struct {
+	sessionID  string
+	cmd        *exec.Cmd
+	stdin      io.WriteCloser
+	streamFile *os.File
+	listener   net.Listener
+	done       chan struct{} // closed when stdout EOF (CLI exited)
+
+	clientsMu sync.Mutex
+	clients   map[net.Conn]struct{}
+
+	// restartInfo holds info needed for Codex restart
+	restartMu   sync.Mutex
+	cmdArgs     []string
+	projectPath string
+	env         []string
+}
+
+// readStdout reads lines from the CLI process stdout, writes to JSONL file,
+// and broadcasts to all connected socket clients.
+func (h *holder) readStdout(stdout io.Reader) {
+	defer close(h.done)
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		// Write to JSONL file (permanent record)
+		h.streamFile.WriteString(line + "\n")
+		h.streamFile.Sync()
+
+		// Broadcast to all connected socket clients
+		h.broadcastLine(line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		slog.Error("holder: stdout reader error", "error", err, "sessionId", h.sessionID)
+	}
+}
+
+// broadcastLine sends a line to all connected socket clients.
+func (h *holder) broadcastLine(line string) {
+	h.clientsMu.Lock()
+	defer h.clientsMu.Unlock()
+
+	for conn := range h.clients {
+		// Write line + newline; ignore errors (client may have disconnected)
+		conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		if _, err := fmt.Fprintf(conn, "%s\n", line); err != nil {
+			slog.Debug("holder: failed to write to client, removing", "error", err)
+			conn.Close()
+			delete(h.clients, conn)
+		}
+	}
+}
+
+// broadcastControl sends a control message to all connected socket clients.
+func (h *holder) broadcastControl(msg HolderControlMessage) {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return
+	}
+	h.broadcastLine(string(data))
+}
+
+// acceptLoop accepts incoming Unix socket connections.
+func (h *holder) acceptLoop() {
+	for {
+		conn, err := h.listener.Accept()
+		if err != nil {
+			// Listener closed
+			return
+		}
+
+		h.clientsMu.Lock()
+		h.clients[conn] = struct{}{}
+		h.clientsMu.Unlock()
+
+		slog.Info("holder: client connected", "sessionId", h.sessionID)
+
+		// Handle incoming messages from this client
+		go h.handleClient(conn)
+	}
+}
+
+// handleClient reads messages from a socket client and processes them.
+func (h *holder) handleClient(conn net.Conn) {
+	defer func() {
+		h.clientsMu.Lock()
+		delete(h.clients, conn)
+		h.clientsMu.Unlock()
+		conn.Close()
+	}()
+
+	scanner := bufio.NewScanner(conn)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		// Check if this is a control message
+		var msg HolderControlMessage
+		if json.Unmarshal([]byte(line), &msg) == nil && msg.Type == "control" {
+			h.handleControl(msg)
+			continue
+		}
+
+		// Otherwise, forward to CLI stdin
+		if _, err := fmt.Fprintf(h.stdin, "%s\n", line); err != nil {
+			slog.Error("holder: failed to write to stdin", "error", err, "sessionId", h.sessionID)
+			return
+		}
+	}
+}
+
+// handleControl processes control messages from the server.
+func (h *holder) handleControl(msg HolderControlMessage) {
+	switch msg.Action {
+	case "stop":
+		slog.Info("holder: received stop command", "sessionId", h.sessionID)
+		h.stdin.Close()
+	case "restart":
+		slog.Info("holder: received restart command", "sessionId", h.sessionID)
+		// For Codex: close stdin to let the current process exit,
+		// then the holder will exit and the server should spawn a new holder.
+		h.stdin.Close()
+	default:
+		slog.Warn("holder: unknown control action", "action", msg.Action, "sessionId", h.sessionID)
+	}
+}
+
+// SpawnHolder starts a new holder process that is detached from the current process group.
+// It returns the PID of the holder process.
+func SpawnHolder(sessionID string, cmdArgs []string, projectPath string, env []string) (int, error) {
+	if err := os.MkdirAll(SocketDir, 0700); err != nil {
+		return 0, fmt.Errorf("create socket dir: %w", err)
+	}
+
+	// Find the agmux binary path
+	agmuxBin, err := os.Executable()
+	if err != nil {
+		return 0, fmt.Errorf("get executable path: %w", err)
+	}
+
+	// Build holder command arguments
+	holderArgs := []string{"holder", "--session-id", sessionID, "--project-path", projectPath, "--"}
+	holderArgs = append(holderArgs, cmdArgs...)
+
+	cmd := exec.Command(agmuxBin, holderArgs...)
+	cmd.Env = env
+	cmd.Dir = projectPath
+
+	// Detach from parent process group using SysProcAttr
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true,
+	}
+
+	// Redirect holder's stdout/stderr to a log file for debugging
+	holderLogDir := filepath.Join(SocketDir, "..", "logs")
+	os.MkdirAll(holderLogDir, 0700)
+	logPath := filepath.Join(holderLogDir, sessionID+".log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return 0, fmt.Errorf("open holder log: %w", err)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		return 0, fmt.Errorf("start holder: %w", err)
+	}
+
+	pid := cmd.Process.Pid
+	slog.Info("holder spawned", "pid", pid, "sessionId", sessionID)
+
+	// Release the process so it's truly detached
+	cmd.Process.Release()
+	logFile.Close()
+
+	return pid, nil
+}
+
+// ConnectToHolder connects to a holder's Unix socket and returns the connection.
+// It retries for a short period to allow the holder time to start listening.
+func ConnectToHolder(sessionID string) (net.Conn, error) {
+	sockPath := SocketPath(sessionID)
+
+	var conn net.Conn
+	var err error
+	for i := 0; i < 50; i++ {
+		conn, err = net.Dial("unix", sockPath)
+		if err == nil {
+			return conn, nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("connect to holder socket %s: %w", sockPath, err)
+}
+
+// IsHolderAlive checks if a holder process with the given PID is still running.
+func IsHolderAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// On Unix, FindProcess always succeeds; send signal 0 to check existence
+	err = process.Signal(syscall.Signal(0))
+	return err == nil
+}

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -1,0 +1,618 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/myuon/agmux/internal/db"
+)
+
+// HolderStreamProcess manages a CLI process through a holder subprocess.
+// Instead of directly holding pipes to the CLI process, it communicates
+// through a Unix socket to the holder.
+type HolderStreamProcess struct {
+	conn      net.Conn
+	lines     []string
+	mu        sync.RWMutex
+	done      chan struct{} // closed when the holder's CLI process has exited
+	sessionID string       // CLI session ID
+	provider  Provider
+	holderPID int
+
+	// Fields for Codex followup support
+	streamOpts StreamOpts
+
+	// stopped is true when Stop() was called explicitly
+	stopped bool
+
+	// modelCaptured is true once the model has been captured
+	modelCaptured bool
+
+	// Callbacks
+	onSessionID   func(cliSessionID string)
+	onModel       func(model string)
+	onNewLines    func(sessionID string, newLines []string, total int)
+	onProcessExit func(sessionID string, exitErr error)
+}
+
+// StartHolderStreamProcess starts a CLI process via a holder subprocess.
+func StartHolderStreamProcess(opts StreamOpts, provider Provider) (*HolderStreamProcess, error) {
+	// Build the command that the holder will execute
+	cmd := provider.BuildStreamCommand(opts)
+	cmd.Env = provider.AppendOTelEnv(cmd.Env, 0)
+
+	cmdArgs := append([]string{cmd.Path}, cmd.Args[1:]...)
+
+	// Spawn the holder process
+	pid, err := SpawnHolder(opts.SessionID, cmdArgs, opts.ProjectPath, cmd.Env)
+	if err != nil {
+		return nil, fmt.Errorf("spawn holder: %w", err)
+	}
+
+	// Connect to the holder's socket
+	conn, err := ConnectToHolder(opts.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("connect to holder: %w", err)
+	}
+
+	sp := &HolderStreamProcess{
+		conn:       conn,
+		done:       make(chan struct{}),
+		sessionID:  opts.CLISessionID,
+		provider:   provider,
+		holderPID:  pid,
+		streamOpts: opts,
+	}
+
+	// Load existing lines from JSONL file
+	sp.loadExistingLines(opts.SessionID)
+
+	// Start reading from the socket
+	go sp.readLoop()
+
+	return sp, nil
+}
+
+// ReconnectHolderStreamProcess reconnects to an existing holder process.
+func ReconnectHolderStreamProcess(opts StreamOpts, provider Provider, holderPID int) (*HolderStreamProcess, error) {
+	if !IsHolderAlive(holderPID) {
+		return nil, fmt.Errorf("holder process %d is not alive", holderPID)
+	}
+
+	conn, err := ConnectToHolder(opts.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("reconnect to holder: %w", err)
+	}
+
+	sp := &HolderStreamProcess{
+		conn:       conn,
+		done:       make(chan struct{}),
+		sessionID:  opts.CLISessionID,
+		provider:   provider,
+		holderPID:  holderPID,
+		streamOpts: opts,
+	}
+
+	// Load all existing lines from JSONL file
+	sp.loadExistingLines(opts.SessionID)
+
+	// Start reading from the socket
+	go sp.readLoop()
+
+	return sp, nil
+}
+
+func (sp *HolderStreamProcess) loadExistingLines(sessionID string) {
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		return
+	}
+	path := filepath.Join(streamsDir, sessionID+".jsonl")
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Normalize lines from JSONL (holder writes raw lines)
+		normalized := sp.provider.NormalizeStreamLine([]byte(line))
+		if normalized == nil {
+			continue
+		}
+		normalizedStr := string(normalized)
+
+		// Skip stream_events (transient, not for history)
+		if len(normalized) > 0 && normalized[0] == '{' {
+			var peek struct {
+				Type string `json:"type"`
+			}
+			if json.Unmarshal(normalized, &peek) == nil && peek.Type == "stream_event" {
+				continue
+			}
+		}
+
+		sp.lines = append(sp.lines, normalizedStr)
+	}
+}
+
+func (sp *HolderStreamProcess) readLoop() {
+	defer close(sp.done)
+
+	reader := bufio.NewReader(sp.conn)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err != io.EOF {
+				slog.Error("holder stream: read error", "error", err)
+			}
+			return
+		}
+		// Trim the trailing newline
+		if len(line) > 0 && line[len(line)-1] == '\n' {
+			line = line[:len(line)-1]
+		}
+		if line == "" {
+			continue
+		}
+
+		// Check if this is a control message from the holder
+		var ctrlMsg HolderControlMessage
+		if json.Unmarshal([]byte(line), &ctrlMsg) == nil && ctrlMsg.Type == "control" {
+			if ctrlMsg.Event == "exited" {
+				slog.Info("holder stream: CLI process exited", "code", ctrlMsg.Code, "sessionId", sp.streamOpts.SessionID)
+				sp.mu.RLock()
+				stopped := sp.stopped
+				cb := sp.onProcessExit
+				sp.mu.RUnlock()
+
+				if !stopped && cb != nil {
+					var exitErr error
+					if ctrlMsg.Code != 0 {
+						exitErr = fmt.Errorf("exit code %d", ctrlMsg.Code)
+					}
+					cb(sp.streamOpts.SessionID, exitErr)
+				}
+				return
+			}
+			continue
+		}
+
+		// Capture session_id via provider
+		if sid, ok := sp.provider.ParseSessionID([]byte(line)); ok {
+			sp.mu.Lock()
+			sp.sessionID = sid
+			cb := sp.onSessionID
+			sp.mu.Unlock()
+			if cb != nil {
+				cb(sid)
+			}
+		}
+
+		// Capture model name via provider (only once)
+		if !sp.modelCaptured {
+			if model, ok := sp.provider.ParseModel([]byte(line)); ok {
+				sp.mu.Lock()
+				sp.modelCaptured = true
+				cb := sp.onModel
+				sp.mu.Unlock()
+				if cb != nil {
+					cb(model)
+				}
+			}
+		}
+
+		// Normalize the line
+		normalized := sp.provider.NormalizeStreamLine([]byte(line))
+		if normalized == nil {
+			continue
+		}
+		normalizedStr := string(normalized)
+
+		// Check for stream_event (real-time only, not persisted)
+		isStreamEvent := false
+		if len(normalized) > 0 && normalized[0] == '{' {
+			var peek struct {
+				Type string `json:"type"`
+			}
+			if json.Unmarshal(normalized, &peek) == nil && peek.Type == "stream_event" {
+				isStreamEvent = true
+			}
+		}
+
+		sp.mu.Lock()
+		if !isStreamEvent {
+			sp.lines = append(sp.lines, normalizedStr)
+			// Note: holder already writes to JSONL file, so we don't write here
+		}
+		total := len(sp.lines)
+		cb := sp.onNewLines
+		sp.mu.Unlock()
+
+		if cb != nil {
+			cb(sp.streamOpts.SessionID, []string{normalizedStr}, total)
+		}
+	}
+}
+
+// SessionID returns the CLI session ID.
+func (sp *HolderStreamProcess) SessionID() string {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+	return sp.sessionID
+}
+
+// ProviderName returns the name of the provider used by this process.
+func (sp *HolderStreamProcess) ProviderName() ProviderName {
+	return sp.provider.Name()
+}
+
+// HolderPID returns the PID of the holder process.
+func (sp *HolderStreamProcess) HolderPID() int {
+	return sp.holderPID
+}
+
+// SetOnSessionID sets a callback for CLI session ID capture.
+func (sp *HolderStreamProcess) SetOnSessionID(fn func(cliSessionID string)) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.onSessionID = fn
+}
+
+// SetOnModel sets a callback for model name capture.
+func (sp *HolderStreamProcess) SetOnModel(fn func(model string)) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.onModel = fn
+}
+
+// SetOnNewLines sets a callback for new stream lines.
+func (sp *HolderStreamProcess) SetOnNewLines(fn func(sessionID string, newLines []string, total int)) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.onNewLines = fn
+}
+
+// SetOnProcessExit sets a callback for process exit.
+func (sp *HolderStreamProcess) SetOnProcessExit(fn func(sessionID string, exitErr error)) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.onProcessExit = fn
+}
+
+// Send writes a user message to the holder's socket.
+func (sp *HolderStreamProcess) Send(message string) error {
+	return sp.SendWithImages(message, nil)
+}
+
+// SendWithImages writes a user message with optional images via the socket.
+func (sp *HolderStreamProcess) SendWithImages(message string, images []ImageData) error {
+	// For Codex, check if the process has finished and handle restart
+	if sp.provider.Name() == ProviderCodex {
+		return sp.sendCodex(message)
+	}
+
+	return sp.sendClaude(message, images)
+}
+
+func (sp *HolderStreamProcess) sendClaude(message string, images []ImageData) error {
+	var data []byte
+	var err error
+
+	if len(images) > 0 {
+		type imageSource struct {
+			Type      string `json:"type"`
+			MediaType string `json:"media_type"`
+			Data      string `json:"data"`
+		}
+		type contentBlock struct {
+			Type   string       `json:"type"`
+			Text   string       `json:"text,omitempty"`
+			Source *imageSource `json:"source,omitempty"`
+		}
+
+		var content []contentBlock
+		if message != "" {
+			content = append(content, contentBlock{Type: "text", Text: message})
+		}
+		for _, img := range images {
+			content = append(content, contentBlock{
+				Type: "image",
+				Source: &imageSource{
+					Type:      "base64",
+					MediaType: img.MediaType,
+					Data:      img.Data,
+				},
+			})
+		}
+
+		msg := struct {
+			Type    string `json:"type"`
+			Message struct {
+				Role    string         `json:"role"`
+				Content []contentBlock `json:"content"`
+			} `json:"message"`
+		}{
+			Type: "user",
+		}
+		msg.Message.Role = "user"
+		msg.Message.Content = content
+
+		data, err = json.Marshal(msg)
+	} else {
+		msg := struct {
+			Type    string `json:"type"`
+			Message struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+		}{
+			Type: "user",
+		}
+		msg.Message.Role = "user"
+		msg.Message.Content = message
+
+		data, err = json.Marshal(msg)
+	}
+
+	if err != nil {
+		return fmt.Errorf("marshal message: %w", err)
+	}
+
+	// Record user message in memory (holder writes to JSONL file via stdin echo)
+	line := string(data)
+	sp.mu.Lock()
+	sp.lines = append(sp.lines, line)
+	total := len(sp.lines)
+
+	// Also write to JSONL file from server side for user messages
+	// (holder only writes stdout from CLI, not stdin messages)
+	sp.writeToStreamFile(line)
+
+	cb := sp.onNewLines
+	sp.mu.Unlock()
+
+	if cb != nil {
+		cb(sp.streamOpts.SessionID, []string{line}, total)
+	}
+
+	// Send to holder via socket
+	_, err = fmt.Fprintf(sp.conn, "%s\n", data)
+	return err
+}
+
+func (sp *HolderStreamProcess) writeToStreamFile(line string) {
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		return
+	}
+	path := filepath.Join(streamsDir, sp.streamOpts.SessionID+".jsonl")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	f.WriteString(line + "\n")
+	f.Sync()
+}
+
+// sendCodex handles message sending for Codex provider via holder.
+func (sp *HolderStreamProcess) sendCodex(message string) error {
+	// Record the user message
+	userMsg := struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+	}{Type: "user"}
+	userMsg.Message.Role = "user"
+	userMsg.Message.Content = message
+	data, err := json.Marshal(userMsg)
+	if err != nil {
+		return fmt.Errorf("marshal message: %w", err)
+	}
+	line := string(data)
+	sp.mu.Lock()
+	sp.lines = append(sp.lines, line)
+	total := len(sp.lines)
+	sp.writeToStreamFile(line)
+	cb := sp.onNewLines
+	sp.mu.Unlock()
+
+	if cb != nil {
+		cb(sp.streamOpts.SessionID, []string{line}, total)
+	}
+
+	// For Codex, send restart control to holder (which will close stdin,
+	// wait for process exit, then the holder exits).
+	// After holder exits, we need to spawn a new holder with resume args.
+	sp.mu.Lock()
+	sp.stopped = true
+	sp.mu.Unlock()
+
+	// Send stop to current holder
+	ctrlMsg, _ := json.Marshal(HolderControlMessage{
+		Type:   "control",
+		Action: "stop",
+	})
+	fmt.Fprintf(sp.conn, "%s\n", ctrlMsg)
+
+	// Wait for holder to exit
+	select {
+	case <-sp.done:
+	case <-time.After(10 * time.Minute):
+		return fmt.Errorf("timeout waiting for codex holder to exit")
+	}
+
+	// Get CLI session ID for resume
+	sp.mu.RLock()
+	cliSessionID := sp.sessionID
+	sp.mu.RUnlock()
+
+	if cliSessionID == "" {
+		return fmt.Errorf("no CLI session ID available for codex resume")
+	}
+
+	slog.Info("restarting codex via new holder", "cliSessionID", cliSessionID, "message", message)
+	return sp.restartForCodex(message, cliSessionID)
+}
+
+// restartForCodex spawns a new holder for a Codex followup message.
+func (sp *HolderStreamProcess) restartForCodex(message, cliSessionID string) error {
+	opts := sp.streamOpts
+	opts.Resume = true
+	opts.CLISessionID = cliSessionID
+	opts.InitialPrompt = message
+
+	cmd := sp.provider.BuildStreamCommand(opts)
+	cmd.Env = sp.provider.AppendOTelEnv(cmd.Env, 0)
+	cmdArgs := append([]string{cmd.Path}, cmd.Args[1:]...)
+
+	pid, err := SpawnHolder(opts.SessionID, cmdArgs, opts.ProjectPath, cmd.Env)
+	if err != nil {
+		return fmt.Errorf("spawn holder for codex resume: %w", err)
+	}
+
+	conn, err := ConnectToHolder(opts.SessionID)
+	if err != nil {
+		return fmt.Errorf("connect to holder for codex resume: %w", err)
+	}
+
+	sp.mu.Lock()
+	sp.conn = conn
+	sp.holderPID = pid
+	sp.done = make(chan struct{})
+	sp.stopped = false
+	sp.mu.Unlock()
+
+	go sp.readLoop()
+
+	return nil
+}
+
+// recordUserMessage records a user message without sending it to stdin.
+func (sp *HolderStreamProcess) recordUserMessage(message string) {
+	msg := struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+	}{Type: "user"}
+	msg.Message.Role = "user"
+	msg.Message.Content = message
+	data, _ := json.Marshal(msg)
+	line := string(data)
+
+	sp.mu.Lock()
+	sp.lines = append(sp.lines, line)
+	total := len(sp.lines)
+	sp.writeToStreamFile(line)
+	cb := sp.onNewLines
+	sp.mu.Unlock()
+
+	if cb != nil {
+		cb(sp.streamOpts.SessionID, []string{line}, total)
+	}
+}
+
+// GetLines returns the last N lines.
+func (sp *HolderStreamProcess) GetLines(limit int) []string {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+
+	if limit <= 0 || limit >= len(sp.lines) {
+		result := make([]string, len(sp.lines))
+		copy(result, sp.lines)
+		return result
+	}
+
+	start := len(sp.lines) - limit
+	result := make([]string, limit)
+	copy(result, sp.lines[start:])
+	return result
+}
+
+// GetLinesAfter returns lines added after the given index.
+func (sp *HolderStreamProcess) GetLinesAfter(after int) ([]string, int) {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+
+	total := len(sp.lines)
+	if after >= total {
+		return nil, total
+	}
+	if after < 0 {
+		after = 0
+	}
+	result := make([]string, total-after)
+	copy(result, sp.lines[after:])
+	return result, total
+}
+
+// TotalLines returns the total number of lines.
+func (sp *HolderStreamProcess) TotalLines() int {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+	return len(sp.lines)
+}
+
+// Stop sends a stop command to the holder.
+func (sp *HolderStreamProcess) Stop() {
+	sp.mu.Lock()
+	sp.stopped = true
+	sp.mu.Unlock()
+
+	// Send stop control message
+	ctrlMsg, _ := json.Marshal(HolderControlMessage{
+		Type:   "control",
+		Action: "stop",
+	})
+	fmt.Fprintf(sp.conn, "%s\n", ctrlMsg)
+
+	// Wait for holder to exit
+	select {
+	case <-sp.done:
+	case <-time.After(5 * time.Second):
+		// Force kill the holder process
+		slog.Warn("holder did not exit gracefully, killing", "pid", sp.holderPID)
+		if p, err := os.FindProcess(sp.holderPID); err == nil {
+			p.Kill()
+		}
+		<-sp.done
+	}
+
+	sp.conn.Close()
+}
+
+// Done returns a channel that is closed when the holder's CLI process exits.
+func (sp *HolderStreamProcess) Done() <-chan struct{} {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+	return sp.done
+}
+
+// IsExited returns true if the holder's CLI process has exited.
+func (sp *HolderStreamProcess) IsExited() bool {
+	sp.mu.RLock()
+	ch := sp.done
+	sp.mu.RUnlock()
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -22,7 +22,7 @@ type Manager struct {
 	permissionMode  string
 	apiPort         int
 	systemPrompt    string
-	streamProcesses map[string]*StreamProcess
+	streamProcesses map[string]StreamProcessInterface
 	streamMu        sync.Mutex
 	logger          *slog.Logger
 	onNewLines      func(sessionID string, newLines []string, total int)
@@ -51,7 +51,7 @@ func NewManager(db *sql.DB, claudeCommand string, permissionMode string, apiPort
 		permissionMode:  permissionMode,
 		apiPort:         apiPort,
 		systemPrompt:    systemPrompt,
-		streamProcesses: make(map[string]*StreamProcess),
+		streamProcesses: make(map[string]StreamProcessInterface),
 		logger:          logger.With("component", "session_manager"),
 	}
 }
@@ -92,12 +92,12 @@ func (m *Manager) buildEffectiveSystemPrompt(customSystemPrompt string) string {
 	return m.systemPrompt + "\n\n" + customSystemPrompt
 }
 
-// RecoverStreamProcesses restarts stream processes for all working sessions.
-// This should be called at server startup to recover sessions that were running
-// before the server was restarted.
+// RecoverStreamProcesses recovers stream processes for all working sessions.
+// If a holder process is still alive (survived server restart), reconnect to it.
+// Otherwise, start a new holder process with --resume.
 func (m *Manager) RecoverStreamProcesses() {
 	rows, err := m.db.Query(
-		`SELECT id, project_path, provider, cli_session_id, model, system_prompt FROM sessions WHERE status = ? AND type != 'controller'`,
+		`SELECT id, project_path, provider, cli_session_id, model, system_prompt, holder_pid FROM sessions WHERE status = ? AND type != 'controller'`,
 		string(StatusWorking),
 	)
 	if err != nil {
@@ -109,7 +109,8 @@ func (m *Manager) RecoverStreamProcesses() {
 	for rows.Next() {
 		var id, projectPath, providerStr, dbCliSessionID, dbModel string
 		var dbSystemPrompt sql.NullString
-		if err := rows.Scan(&id, &projectPath, &providerStr, &dbCliSessionID, &dbModel, &dbSystemPrompt); err != nil {
+		var holderPID int
+		if err := rows.Scan(&id, &projectPath, &providerStr, &dbCliSessionID, &dbModel, &dbSystemPrompt, &holderPID); err != nil {
 			m.logger.Error("recover stream processes: scan failed", "error", err)
 			continue
 		}
@@ -135,7 +136,8 @@ func (m *Manager) RecoverStreamProcesses() {
 		if dbSystemPrompt.Valid {
 			customPrompt = dbSystemPrompt.String
 		}
-		sp, err := StartStreamProcessWithOpts(StreamOpts{
+
+		opts := StreamOpts{
 			SessionID:     id,
 			ProjectPath:   projectPath,
 			MCPConfigPath: mcpPath,
@@ -144,16 +146,44 @@ func (m *Manager) RecoverStreamProcesses() {
 			CLISessionID:  cliSessionID,
 			Model:         dbModel,
 			APIPort:       m.apiPort,
-		}, provider)
+		}
+
+		// Try to reconnect to existing holder first
+		if holderPID > 0 && IsHolderAlive(holderPID) {
+			m.logger.Info("holder still alive, reconnecting", "sessionId", id, "holderPid", holderPID)
+			sp, err := ReconnectHolderStreamProcess(opts, provider, holderPID)
+			if err != nil {
+				m.logger.Warn("reconnect to holder failed, will start new holder", "sessionId", id, "error", err)
+			} else {
+				m.wireSessionIDCallback(id, sp)
+				m.streamMu.Lock()
+				m.streamProcesses[id] = sp
+				m.streamMu.Unlock()
+				m.logger.Info("reconnected to existing holder", "sessionId", id, "holderPid", holderPID)
+				continue
+			}
+		}
+
+		// Start new holder process
+		sp, err := StartHolderStreamProcess(opts, provider)
 		if err != nil {
-			m.logger.Error("recover stream processes: start failed", "sessionId", id, "error", err)
+			m.logger.Error("recover stream processes: start holder failed", "sessionId", id, "error", err)
 			continue
 		}
 		m.wireSessionIDCallback(id, sp)
 		m.streamMu.Lock()
 		m.streamProcesses[id] = sp
 		m.streamMu.Unlock()
-		m.logger.Info("recovered stream process", "sessionId", id)
+		// Persist new holder PID
+		m.updateHolderPID(id, sp.HolderPID())
+		m.logger.Info("recovered stream process via new holder", "sessionId", id, "holderPid", sp.HolderPID())
+	}
+}
+
+// updateHolderPID persists the holder PID to the database.
+func (m *Manager) updateHolderPID(id string, pid int) {
+	if _, err := m.db.Exec("UPDATE sessions SET holder_pid = ?, updated_at = ? WHERE id = ?", pid, time.Now(), id); err != nil {
+		m.logger.Error("failed to update holder_pid", "sessionId", id, "pid", pid, "error", err)
 	}
 }
 
@@ -211,34 +241,39 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		FullAuto:      fullAuto,
 	}
 	streamOpts.APIPort = m.apiPort
-	var sp *StreamProcess
+	var sp StreamProcessInterface
 	if pn == ProviderCodex && prompt != "" {
 		// Codex: pass initial prompt as command-line argument (not stdin)
 		streamOpts.InitialPrompt = prompt
-		var err error
-		sp, err = StartStreamProcessWithOpts(streamOpts, provider)
+		hsp, err := StartHolderStreamProcess(streamOpts, provider)
 		if err != nil {
 			return nil, fmt.Errorf("start stream process: %w", err)
 		}
 		// Record the user message in the stream for UI display
-		sp.recordUserMessage(prompt)
+		hsp.recordUserMessage(prompt)
+		sp = hsp
 	} else {
-		var err error
-		sp, err = StartStreamProcessWithOpts(streamOpts, provider)
+		hsp, err := StartHolderStreamProcess(streamOpts, provider)
 		if err != nil {
 			return nil, fmt.Errorf("start stream process: %w", err)
 		}
 		// Send initial prompt via stream process (stdin for Claude)
 		if prompt != "" {
-			if err := sp.Send(prompt); err != nil {
+			if err := hsp.Send(prompt); err != nil {
 				return nil, fmt.Errorf("send initial prompt: %w", err)
 			}
 		}
+		sp = hsp
 	}
 	m.wireSessionIDCallback(id, sp)
 	m.streamMu.Lock()
 	m.streamProcesses[id] = sp
 	m.streamMu.Unlock()
+
+	// Persist holder PID
+	if hsp, ok := sp.(*HolderStreamProcess); ok {
+		m.updateHolderPID(id, hsp.HolderPID())
+	}
 
 	now := time.Now()
 	s := &Session{
@@ -426,8 +461,8 @@ func (m *Manager) Fork(id string) (*Session, error) {
 
 	effectiveSystemPrompt := m.buildEffectiveSystemPrompt(src.SystemPrompt)
 
-	// Start new CLI process with --resume --fork-session
-	sp, err := StartStreamProcessWithOpts(StreamOpts{
+	// Start new CLI process with --resume --fork-session via holder
+	sp, err := StartHolderStreamProcess(StreamOpts{
 		SessionID:     newID,
 		ProjectPath:   src.ProjectPath,
 		MCPConfigPath: mcpConfigPath,
@@ -445,6 +480,7 @@ func (m *Manager) Fork(id string) (*Session, error) {
 	m.streamMu.Lock()
 	m.streamProcesses[newID] = sp
 	m.streamMu.Unlock()
+	m.updateHolderPID(newID, sp.HolderPID())
 
 	now := time.Now()
 	newName := src.Name + " (fork)"
@@ -505,7 +541,7 @@ func (m *Manager) Stop(id string) error {
 	// Stop stream process if exists
 	m.stopStreamProcess(id)
 
-	_, err = m.db.Exec("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", string(StatusStopped), time.Now(), id)
+	_, err = m.db.Exec("UPDATE sessions SET status = ?, holder_pid = 0, updated_at = ? WHERE id = ?", string(StatusStopped), time.Now(), id)
 	return err
 }
 
@@ -524,7 +560,7 @@ func (m *Manager) Delete(id string) error {
 
 // wireSessionIDCallback sets up the onSessionID callback on a stream process
 // so that when the CLI session ID is captured, it gets persisted to the DB.
-func (m *Manager) wireSessionIDCallback(sessionID string, sp *StreamProcess) {
+func (m *Manager) wireSessionIDCallback(sessionID string, sp StreamProcessInterface) {
 	sp.SetOnSessionID(func(cliSessionID string) {
 		if err := m.UpdateCliSessionID(sessionID, cliSessionID); err != nil {
 			m.logger.Error("failed to persist cli session id", "sessionId", sessionID, "cliSessionId", cliSessionID, "error", err)
@@ -547,7 +583,7 @@ func (m *Manager) wireSessionIDCallback(sessionID string, sp *StreamProcess) {
 		// For Codex provider, exit code 0 is normal (exec finishes after each prompt).
 		// Keep the session running and the stream process in the map so that
 		// sendCodex can restart it with "codex exec resume" on the next message.
-		if sp.provider.Name() == ProviderCodex && exitErr == nil {
+		if sp.ProviderName() == ProviderCodex && exitErr == nil {
 			m.logger.Info("codex process exited normally (exit code 0), keeping session running for resume",
 				"sessionId", sid,
 			)
@@ -595,18 +631,26 @@ func (m *Manager) stopStreamProcess(id string) {
 	}
 }
 
-// StopAllStreamProcesses gracefully stops all running stream processes.
-// This should be called during server shutdown to ensure output is flushed.
+// StopAllStreamProcesses disconnects from all holder processes on server shutdown.
+// Unlike the old behavior, holders are NOT killed -- they survive server restart.
+// Only the server's socket connections are closed.
 func (m *Manager) StopAllStreamProcesses() {
 	m.streamMu.Lock()
-	processes := make(map[string]*StreamProcess, len(m.streamProcesses))
+	processes := make(map[string]StreamProcessInterface, len(m.streamProcesses))
 	maps.Copy(processes, m.streamProcesses)
-	m.streamProcesses = make(map[string]*StreamProcess)
+	m.streamProcesses = make(map[string]StreamProcessInterface)
 	m.streamMu.Unlock()
 
 	for id, sp := range processes {
-		m.logger.Info("stopping stream process", "sessionId", id)
-		sp.Stop()
+		if hsp, ok := sp.(*HolderStreamProcess); ok {
+			// Just close the socket connection; don't kill the holder
+			m.logger.Info("disconnecting from holder (holder stays alive)", "sessionId", id, "holderPid", hsp.HolderPID())
+			hsp.conn.Close()
+		} else {
+			// Legacy StreamProcess: stop as before
+			m.logger.Info("stopping stream process", "sessionId", id)
+			sp.Stop()
+		}
 	}
 }
 
@@ -638,7 +682,7 @@ func (m *Manager) Clear(id string) error {
 
 	// Start fresh without CLISessionID — BuildStreamCommand will generate a
 	// new UUID for --session-id automatically.
-	sp, err := StartStreamProcessWithOpts(StreamOpts{
+	sp, err := StartHolderStreamProcess(StreamOpts{
 		SessionID:     id,
 		ProjectPath:   s.ProjectPath,
 		MCPConfigPath: mcpConfigPath,
@@ -653,6 +697,7 @@ func (m *Manager) Clear(id string) error {
 	m.streamMu.Lock()
 	m.streamProcesses[id] = sp
 	m.streamMu.Unlock()
+	m.updateHolderPID(id, sp.HolderPID())
 
 	// Reset task/goal and set status to working.
 	// Clear cli_session_id so that Reconnect does not reuse a stale/invalid ID;
@@ -674,7 +719,7 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 	sp, ok := m.streamProcesses[id]
 	m.streamMu.Unlock()
 	if !ok {
-		// Auto-recover: restart stream process after server restart
+		// Auto-recover: restart stream process via holder after server restart
 		provider := m.getProvider(s.Provider)
 		mcpPath, _ := provider.SetupMCP(s.ID, m.apiPort)
 		// Prefer DB-stored cli_session_id; fall back to JSONL file scan
@@ -684,11 +729,9 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 		}
 
 		effectiveSP := m.buildEffectiveSystemPrompt(s.SystemPrompt)
-		var err error
 		if s.Provider == ProviderCodex && cliSessionID != "" {
 			// For Codex, start resume directly with the prompt as a positional arg.
-			// Codex exec exits after processing, so we can't send via stdin later.
-			sp, err = StartStreamProcessWithOpts(StreamOpts{
+			hsp, err := StartHolderStreamProcess(StreamOpts{
 				SessionID:     s.ID,
 				ProjectPath:   s.ProjectPath,
 				MCPConfigPath: mcpPath,
@@ -702,15 +745,17 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			if err != nil {
 				return fmt.Errorf("restart stream process: %w", err)
 			}
-			sp.recordUserMessage(text)
+			hsp.recordUserMessage(text)
+			sp = hsp
 			m.wireSessionIDCallback(id, sp)
 			m.streamMu.Lock()
 			m.streamProcesses[id] = sp
 			m.streamMu.Unlock()
+			m.updateHolderPID(id, hsp.HolderPID())
 			return nil
 		}
 
-		sp, err = StartStreamProcessWithOpts(StreamOpts{
+		hsp, err := StartHolderStreamProcess(StreamOpts{
 			SessionID:     s.ID,
 			ProjectPath:   s.ProjectPath,
 			MCPConfigPath: mcpPath,
@@ -718,14 +763,17 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			Resume:        true,
 			CLISessionID:  cliSessionID,
 			Model:         s.Model,
+			APIPort:       m.apiPort,
 		}, provider)
 		if err != nil {
 			return fmt.Errorf("restart stream process: %w", err)
 		}
+		sp = hsp
 		m.wireSessionIDCallback(id, sp)
 		m.streamMu.Lock()
 		m.streamProcesses[id] = sp
 		m.streamMu.Unlock()
+		m.updateHolderPID(id, hsp.HolderPID())
 	}
 	return sp.SendWithImages(text, images)
 }
@@ -901,8 +949,8 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 		return nil, fmt.Errorf("write mcp config: %w", err)
 	}
 
-	// Start stream process
-	sp, err := StartStreamProcessWithOpts(StreamOpts{
+	// Start stream process via holder
+	sp, err := StartHolderStreamProcess(StreamOpts{
 		SessionID:     id,
 		ProjectPath:   projectPath,
 		MCPConfigPath: mcpConfigPath,
@@ -948,7 +996,7 @@ func (m *Manager) UpdateStatus(id string, status Status) error {
 
 // UpdateStatusWithError updates the session status and records the last error message.
 func (m *Manager) UpdateStatusWithError(id string, status Status, lastError string) error {
-	_, err := m.db.Exec("UPDATE sessions SET status = ?, last_error = ?, updated_at = ? WHERE id = ?", string(status), lastError, time.Now(), id)
+	_, err := m.db.Exec("UPDATE sessions SET status = ?, last_error = ?, holder_pid = 0, updated_at = ? WHERE id = ?", string(status), lastError, time.Now(), id)
 	return err
 }
 
@@ -1085,7 +1133,7 @@ func (m *Manager) Reconnect(id string) error {
 	if cliSessionID == "" {
 		cliSessionID = ReadCLISessionID(id, provider)
 	}
-	sp, err := StartStreamProcessWithOpts(StreamOpts{
+	sp, err := StartHolderStreamProcess(StreamOpts{
 		SessionID:     id,
 		ProjectPath:   s.ProjectPath,
 		MCPConfigPath: mcpConfigPath,
@@ -1102,6 +1150,7 @@ func (m *Manager) Reconnect(id string) error {
 	m.streamMu.Lock()
 	m.streamProcesses[id] = sp
 	m.streamMu.Unlock()
+	m.updateHolderPID(id, sp.HolderPID())
 
 	_, err = m.db.Exec("UPDATE sessions SET status = ?, last_error = NULL, updated_at = ? WHERE id = ?", string(StatusWorking), time.Now(), id)
 	return err

--- a/internal/session/stream_iface.go
+++ b/internal/session/stream_iface.go
@@ -1,0 +1,46 @@
+package session
+
+// StreamProcessInterface abstracts the common interface between
+// StreamProcess (direct pipe) and HolderStreamProcess (Unix socket).
+type StreamProcessInterface interface {
+	// SessionID returns the CLI session ID.
+	SessionID() string
+
+	// Send writes a user message.
+	Send(message string) error
+	// SendWithImages writes a user message with optional images.
+	SendWithImages(message string, images []ImageData) error
+
+	// SetOnSessionID sets a callback for CLI session ID capture.
+	SetOnSessionID(fn func(cliSessionID string))
+	// SetOnModel sets a callback for model name capture.
+	SetOnModel(fn func(model string))
+	// SetOnNewLines sets a callback for new stream lines.
+	SetOnNewLines(fn func(sessionID string, newLines []string, total int))
+	// SetOnProcessExit sets a callback for process exit.
+	SetOnProcessExit(fn func(sessionID string, exitErr error))
+
+	// GetLines returns the last N lines.
+	GetLines(limit int) []string
+	// GetLinesAfter returns lines after the given index.
+	GetLinesAfter(after int) ([]string, int)
+	// TotalLines returns the total line count.
+	TotalLines() int
+
+	// Stop stops the process.
+	Stop()
+	// Done returns a channel closed when the process exits.
+	Done() <-chan struct{}
+	// IsExited returns true if the process has exited.
+	IsExited() bool
+
+	// recordUserMessage records a user message without sending it to stdin.
+	recordUserMessage(message string)
+
+	// ProviderName returns the name of the provider used by this process.
+	ProviderName() ProviderName
+}
+
+// Verify both implementations satisfy the interface at compile time.
+var _ StreamProcessInterface = (*StreamProcess)(nil)
+var _ StreamProcessInterface = (*HolderStreamProcess)(nil)

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -698,6 +698,11 @@ func (sp *StreamProcess) Stop() {
 	sp.file.Close()
 }
 
+// ProviderName returns the name of the provider used by this process.
+func (sp *StreamProcess) ProviderName() ProviderName {
+	return sp.provider.Name()
+}
+
 // Done returns a channel that is closed when the process exits.
 func (sp *StreamProcess) Done() <-chan struct{} {
 	sp.mu.RLock()


### PR DESCRIPTION
## Summary
- 各セッションに独立したholderプロセス（setsidで分離）を導入し、サーバー再起動時にClaude/Codexプロセスが生き残れるように変更
- holderプロセスはUnix socket経由でサーバーと通信し、CLIプロセスのstdout→JSONL書き出し + socket配信、stdin←socket受信を担当
- サーバー再起動時はDB内のholder_pidで生存確認し、socketに再接続してシームレスにリカバリ

## Changes
- `internal/session/holder.go` - holderプロセス本体（`agmux holder`サブコマンド）
- `internal/session/holder_stream.go` - サーバー側socket thin client（HolderStreamProcess）
- `internal/session/stream_iface.go` - StreamProcess/HolderStreamProcessの共通インターフェース
- `internal/session/manager.go` - 全プロセス管理をholder経由に変更、RecoverStreamProcessesでholder reconnect対応
- `internal/db/sqlite.go` - `holder_pid`カラムをsessionsテーブルに追加
- `cmd/agmux/main.go` - `agmux holder`サブコマンド追加

## Test plan
- [x] `make test` — 全テスト通過（89件）
- [x] `make build` — ビルド成功
- [ ] 実際にセッションを作成してholderプロセスが起動することを確認
- [ ] サーバー再起動後にセッションが生き残ることを確認
- [ ] セッション停止でholderが正常終了することを確認

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)