### PR TITLE
fix: holderプロセスのorphan化を防止

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -92,16 +92,12 @@ func (m *Manager) buildEffectiveSystemPrompt(customSystemPrompt string) string {
 	return m.systemPrompt + "\n\n" + customSystemPrompt
 }
 
-// RecoverStreamProcesses recovers stream processes for all working sessions.
+// RecoverStreamProcesses recovers stream processes for all sessions with holder_pid > 0.
 // If a holder process is still alive (survived server restart), reconnect to it.
 // Otherwise, start a new holder process with --resume.
 func (m *Manager) RecoverStreamProcesses() {
-	// Recover working sessions AND stopped sessions that still have a live holder process.
-	// Stopped sessions with holder_pid > 0 need to be in the streamProcesses map
-	// so that future Delete() calls can reach and kill the holder.
 	rows, err := m.db.Query(
-		`SELECT id, project_path, provider, cli_session_id, model, system_prompt, holder_pid, status FROM sessions WHERE (status = ? AND type != 'controller') OR (status = ? AND holder_pid > 0)`,
-		string(StatusWorking), string(StatusStopped),
+		`SELECT id, project_path, provider, cli_session_id, model, system_prompt, holder_pid FROM sessions WHERE holder_pid > 0 AND type != 'controller'`,
 	)
 	if err != nil {
 		m.logger.Error("recover stream processes: query failed", "error", err)
@@ -110,14 +106,13 @@ func (m *Manager) RecoverStreamProcesses() {
 	defer rows.Close()
 
 	for rows.Next() {
-		var id, projectPath, providerStr, dbCliSessionID, dbModel, statusStr string
+		var id, projectPath, providerStr, dbCliSessionID, dbModel string
 		var dbSystemPrompt sql.NullString
 		var holderPID int
-		if err := rows.Scan(&id, &projectPath, &providerStr, &dbCliSessionID, &dbModel, &dbSystemPrompt, &holderPID, &statusStr); err != nil {
+		if err := rows.Scan(&id, &projectPath, &providerStr, &dbCliSessionID, &dbModel, &dbSystemPrompt, &holderPID); err != nil {
 			m.logger.Error("recover stream processes: scan failed", "error", err)
 			continue
 		}
-		isStopped := Status(statusStr) == StatusStopped
 
 		provider := m.getProvider(ProviderName(providerStr))
 		mcpPath, err := provider.SetupMCP(id, m.apiPort)
@@ -155,29 +150,21 @@ func (m *Manager) RecoverStreamProcesses() {
 
 		// Try to reconnect to existing holder first
 		if holderPID > 0 && IsHolderAlive(holderPID) {
-			m.logger.Info("holder still alive, reconnecting", "sessionId", id, "holderPid", holderPID, "status", statusStr)
+			m.logger.Info("holder still alive, reconnecting", "sessionId", id, "holderPid", holderPID)
 			sp, err := ReconnectHolderStreamProcess(opts, provider, holderPID)
 			if err != nil {
-				m.logger.Warn("reconnect to holder failed", "sessionId", id, "error", err)
-				if isStopped {
-					// For stopped sessions, we only reconnect; don't start a new holder
-					continue
-				}
-				m.logger.Info("will start new holder for working session", "sessionId", id)
+				m.logger.Warn("reconnect to holder failed, will start new holder", "sessionId", id, "error", err)
 			} else {
 				m.wireSessionIDCallback(id, sp)
 				m.streamMu.Lock()
 				m.streamProcesses[id] = sp
 				m.streamMu.Unlock()
-				m.logger.Info("reconnected to existing holder", "sessionId", id, "holderPid", holderPID, "status", statusStr)
+				m.logger.Info("reconnected to existing holder", "sessionId", id, "holderPid", holderPID)
 				continue
 			}
-		} else if isStopped {
-			// Stopped session with no alive holder - nothing to recover
-			continue
 		}
 
-		// Start new holder process (only for working sessions)
+		// Start new holder process
 		sp, err := StartHolderStreamProcess(opts, provider)
 		if err != nil {
 			m.logger.Error("recover stream processes: start holder failed", "sessionId", id, "error", err)
@@ -187,7 +174,6 @@ func (m *Manager) RecoverStreamProcesses() {
 		m.streamMu.Lock()
 		m.streamProcesses[id] = sp
 		m.streamMu.Unlock()
-		// Persist new holder PID
 		m.updateHolderPID(id, sp.HolderPID())
 		m.logger.Info("recovered stream process via new holder", "sessionId", id, "holderPid", sp.HolderPID())
 	}


### PR DESCRIPTION
## Summary
- Delete()でstreamProcessesマップにエントリがない場合でも、DB上の`holder_pid`から直接holderプロセスをkillするようにした
- RecoverStreamProcesses()の対象を`status='stopped'`かつ`holder_pid > 0`のセッションにも拡大し、停止中セッションのholderもstreamProcessesマップに復元するようにした

## Test plan
- [ ] `make build` / `make test` パス済み
- [ ] サーバー再起動後にstoppedセッションのholderがstreamProcessesに復元されることを確認
- [ ] Delete操作でorphanプロセスが正しくkillされることを確認

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)