### PR TITLE
fix: holderプロセスがSIGTERMでCLIを停止してしまう問題を修正

### DIFF
--- a/internal/session/holder.go
+++ b/internal/session/holder.go
@@ -111,37 +111,24 @@ func RunHolder(sessionID string, cmdArgs []string, projectPath string, env []str
 	// Accept socket connections in a goroutine
 	go h.acceptLoop()
 
-	// Handle signals
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	// Ignore SIGTERM so that holder survives server restarts (launchctl kickstart -k).
+	// Holder shutdown is controlled via socket "stop" command, not OS signals.
+	signal.Ignore(syscall.SIGTERM)
 
-	// Wait for CLI process to exit or signal
-	select {
-	case <-h.done:
-		// CLI process exited naturally
-		exitCode := 0
-		if err := cmd.Wait(); err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
-				exitCode = exitErr.ExitCode()
-			}
-		}
-		slog.Info("holder: CLI process exited", "code", exitCode, "sessionId", sessionID)
-		h.broadcastControl(HolderControlMessage{
-			Type:  "control",
-			Event: "exited",
-			Code:  exitCode,
-		})
-	case sig := <-sigCh:
-		slog.Info("holder: received signal, stopping CLI process", "signal", sig, "sessionId", sessionID)
-		stdinPipe.Close()
-		select {
-		case <-h.done:
-			cmd.Wait()
-		case <-time.After(5 * time.Second):
-			cmd.Process.Kill()
-			cmd.Wait()
+	// Wait for CLI process to exit
+	<-h.done
+	exitCode := 0
+	if err := cmd.Wait(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
 		}
 	}
+	slog.Info("holder: CLI process exited", "code", exitCode, "sessionId", sessionID)
+	h.broadcastControl(HolderControlMessage{
+		Type:  "control",
+		Event: "exited",
+		Code:  exitCode,
+	})
 
 	// Give clients a moment to receive the exit notification
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
## Summary
- holderプロセスの`RunHolder()`でSIGTERM/SIGINTシグナルハンドリングを削除し、`signal.Ignore(syscall.SIGTERM)`に置換
- `launchctl kickstart -k`によるサーバー再起動時にholderとCLIプロセスが生存するようになる
- holderの停止は引き続きソケット経由の`stop`コマンドで制御

## Test plan
- [x] `make build` 成功
- [x] `make test` 全テスト通過
- [ ] `launchctl kickstart -k`後にholderプロセスが生存することを確認
- [ ] サーバー再起動後のRecoverStreamProcessesでソケット再接続が成功することを確認

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)