### PR TITLE
fix: Clear機能がプロセスを再起動しないよう修正

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -689,8 +689,8 @@ func (m *Manager) StopAllStreamProcesses() {
 	}
 }
 
-// Clear resets the session context by stopping the current process,
-// clearing the stream history, and restarting without --resume.
+// Clear resets the session context by truncating the JSONL stream file
+// and resetting the task, goal, and goals fields in the database.
 func (m *Manager) Clear(id string) error {
 	_, err := m.Get(id)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `Clear()` から `stopStreamProcess` と `StartHolderStreamProcess` の呼び出しを削除
- JSONLストリームのtruncateとDBリセット（task/goal）のみ行うよう変更
- 既存のCLIセッション・holderプロセスを維持し、再起動による不安定化を解消

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)