### PR TITLE
fix: bufio.Scannerのバッファサイズを全箇所で10MBに統一

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -33,7 +33,7 @@ func NewServer() *Server {
 // Run starts the MCP server on stdin/stdout (JSON-RPC 2.0).
 func (s *Server) Run() error {
 	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -965,7 +965,7 @@ func (s *Server) getLogs(w http.ResponseWriter, r *http.Request) {
 	// Read all lines, keep last N
 	var lines []string
 	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}


### PR DESCRIPTION
## Summary
- `internal/mcp/server.go` と `internal/server/server.go` の `bufio.Scanner` バッファ上限を1MBから10MBに拡大
- holder関連ファイルでは既に10MBが設定されていたが、上記2箇所が1MBのままだったため統一

## Test plan
- [x] `go test ./...` パス確認済み

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)