### PR TITLE
fix: サーバー再起動後にholder配下プロセスがexternalと誤検出される

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -167,10 +167,14 @@ func serveCmd() *cobra.Command {
 
 			// Wire managed holder PIDs into external detector so holder
 			// processes and their children are not detected as external.
+			// SetManagedPIDsFunc must be called BEFORE Start() to avoid
+			// the first detect() cycle seeing nil and misclassifying
+			// holder-managed processes as external.
 			if extDet := srv.ExternalDetector(); extDet != nil {
 				if m, ok := mgr.(*session.Manager); ok {
 					extDet.SetManagedPIDsFunc(m.ManagedHolderPIDs)
 				}
+				go extDet.Start()
 			}
 
 			// Recover stream processes AFTER server.New() so that

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -44,7 +44,6 @@ type Server struct {
 
 func New(sessions session.SessionService, hub *Hub, devMode bool, logPath string, logger *slog.Logger, sqlDB *sql.DB) *Server {
 	extDetector := session.NewExternalDetector(logger, 10*time.Second)
-	go extDetector.Start()
 
 	s := &Server{
 		sessions:         sessions,


### PR DESCRIPTION
## Summary
- `ExternalDetector.Start()` の呼び出しを `server.New()` 内から `cmd/agmux/main.go` に移動し、`SetManagedPIDsFunc()` の後に実行されるようにした
- これにより最初の `detect()` サイクルで `managedPIDsFunc` が nil でなくなり、holder配下プロセスの誤検出を防止

## Root Cause
`server.New()` 内で `ExternalDetector` を作成直後に `go extDetector.Start()` していたため、`main.go` で `SetManagedPIDsFunc()` が呼ばれる前に最初の `detect()` が実行され、holder配下プロセスが external と誤判定されていた。

## Test plan
- [x] `make build` 成功
- [x] `make test` 全テスト通過

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)