### PR TITLE
fix: holder_pidがDBに記録されないケースを修正

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -130,18 +130,6 @@ func serveCmd() *cobra.Command {
 
 			var srv *server.Server
 
-			// Create controller session (singleton)
-			controllerDir, err := db.ControllerDir()
-			if err != nil {
-				return fmt.Errorf("controller dir: %w", err)
-			}
-			controllerSess, err := mgr.CreateController(controllerDir)
-			if err != nil {
-				logger.Warn("failed to create controller session", "error", err)
-			} else {
-				logger.Info("controller session ready", "id", controllerSess.ID)
-			}
-
 			logPath, _ := logging.LogPath()
 			srv = server.New(mgr, hub, devMode, logPath, logger, database)
 
@@ -160,6 +148,19 @@ func serveCmd() *cobra.Command {
 			// Recover stream processes AFTER server.New() so that
 			// SetOnNewLines callback is already registered on the manager.
 			mgr.RecoverStreamProcesses()
+
+			// Create controller session (singleton) AFTER recovery so that
+			// a surviving controller holder can be reconnected first.
+			controllerDir, err := db.ControllerDir()
+			if err != nil {
+				return fmt.Errorf("controller dir: %w", err)
+			}
+			controllerSess, err := mgr.CreateController(controllerDir)
+			if err != nil {
+				logger.Warn("failed to create controller session", "error", err)
+			} else {
+				logger.Info("controller session ready", "id", controllerSess.ID)
+			}
 
 			if !devMode {
 				// Resolve frontend directory: CLI flag > config > embedded

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -37,12 +37,13 @@ type HolderStreamProcess struct {
 	modelCaptured bool
 
 	// Callbacks
-	onSessionID    func(cliSessionID string)
-	onModel        func(model string)
-	onNewLines     func(sessionID string, newLines []string, total int)
-	onProcessExit  func(sessionID string, exitErr error)
-	onTurnComplete func(sessionID string)
-	runningTasks   int
+	onSessionID      func(cliSessionID string)
+	onModel          func(model string)
+	onNewLines       func(sessionID string, newLines []string, total int)
+	onProcessExit    func(sessionID string, exitErr error)
+	onTurnComplete   func(sessionID string)
+	onHolderRestart  func(sessionID string, newPID int)
+	runningTasks     int
 }
 
 // StartHolderStreamProcess starts a CLI process via a holder subprocess.
@@ -325,6 +326,12 @@ func (sp *HolderStreamProcess) SetOnTurnComplete(fn func(sessionID string)) {
 	sp.onTurnComplete = fn
 }
 
+func (sp *HolderStreamProcess) SetOnHolderRestart(fn func(sessionID string, newPID int)) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.onHolderRestart = fn
+}
+
 // Send writes a user message to the holder's socket.
 func (sp *HolderStreamProcess) Send(message string) error {
 	return sp.SendWithImages(message, nil)
@@ -529,9 +536,14 @@ func (sp *HolderStreamProcess) restartForCodex(message, cliSessionID string) err
 	sp.holderPID = pid
 	sp.done = make(chan struct{})
 	sp.stopped = false
+	onRestart := sp.onHolderRestart
 	sp.mu.Unlock()
 
 	go sp.readLoop()
+
+	if onRestart != nil {
+		onRestart(opts.SessionID, pid)
+	}
 
 	return nil
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -113,7 +113,7 @@ func (m *Manager) buildEffectiveSystemPrompt(customSystemPrompt string) string {
 // Otherwise, start a new holder process with --resume.
 func (m *Manager) RecoverStreamProcesses() {
 	rows, err := m.db.Query(
-		`SELECT id, project_path, provider, cli_session_id, model, system_prompt, holder_pid FROM sessions WHERE holder_pid > 0 AND type != 'controller'`,
+		`SELECT id, project_path, provider, cli_session_id, model, system_prompt, holder_pid FROM sessions WHERE holder_pid > 0`,
 	)
 	if err != nil {
 		m.logger.Error("recover stream processes: query failed", "error", err)
@@ -614,6 +614,12 @@ func (m *Manager) wireSessionIDCallback(sessionID string, sp StreamProcessInterf
 			m.logger.Error("failed to update status after turn complete", "sessionId", sid, "error", err)
 		}
 	})
+	if hsp, ok := sp.(*HolderStreamProcess); ok {
+		hsp.SetOnHolderRestart(func(sid string, newPID int) {
+			m.logger.Info("holder restarted (codex resume), updating holder_pid", "sessionId", sid, "newPid", newPID)
+			m.updateHolderPID(sid, newPID)
+		})
+	}
 	sp.SetOnProcessExit(func(sid string, exitErr error) {
 		// For Codex provider, exit code 0 is normal (exec finishes after each prompt).
 		// Keep the session running and the stream process in the map so that
@@ -981,9 +987,9 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 	}
 
 	_, err = m.db.Exec(
-		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.CreatedAt, s.UpdatedAt,
+		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, holder_pid, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), sp.HolderPID(), s.CreatedAt, s.UpdatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert controller session: %w", err)


### PR DESCRIPTION
## Summary
- Controller: INSERT時に `holder_pid` を記録 + `RecoverStreamProcesses` の除外条件を削除
- Controller: 起動順序を `RecoverStreamProcesses` → `CreateController` に変更（生存holderに先に再接続）
- Codex: `restartForCodex` で新holder spawn時に `onHolderRestart` コールバック経由で `holder_pid` をDB更新

## 背景
サーバー再起動時に controller と codex のholderプロセスが再接続されず orphan 化していた。
原因は `holder_pid` が DB に記録されないため `RecoverStreamProcesses` の対象にならなかったこと。

## Test plan
- [x] `make test` パス
- [x] `make build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)