### PR TITLE
refactor: セッションステータスのリファクタリング

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,8 +75,8 @@ function useGlobalNotifications() {
       if (!notify) return;
       const data = msg.data as { sessionId: string; sessionName: string; status: string; summary: string };
       const defaultStatuses: Record<string, boolean> = {
-        working: false, idle: true, question_waiting: true,
-        alignment_needed: true, paused: false, stopped: false,
+        working: false, idle: true, waiting_input: true,
+        paused: false, exited: false,
       };
       const saved = localStorage.getItem("agmux-notify-statuses");
       const statusFilters = saved ? JSON.parse(saved) as Record<string, boolean> : defaultStatuses;

--- a/frontend/src/components/BroadcastModal.tsx
+++ b/frontend/src/components/BroadcastModal.tsx
@@ -3,7 +3,7 @@ import { Modal } from "./ui/Modal";
 import { api } from "../api/client";
 import type { Session } from "../types/session";
 
-const ACTIVE_STATUSES = new Set(["working", "idle", "question_waiting", "alignment_needed"]);
+const ACTIVE_STATUSES = new Set(["working", "idle", "waiting_input"]);
 
 interface Props {
   open: boolean;

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -99,7 +99,7 @@ export function SessionList({ sessions, onRestartController }: Props) {
                   timeAgo={timeAgo(s.createdAt)}
                   onClick={() => navigate(`/sessions/${s.id}`)}
                   actions={
-                    s.type === "controller" && s.status === "stopped" ? (
+                    s.type === "controller" && (s.status === "paused" || s.status === "exited") ? (
                       <SecondaryButton
                         onClick={(e) => { e.stopPropagation(); onRestartController(); }}
                       >

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -4,9 +4,8 @@ export const statusDots: Record<Session["status"], string> = {
   working: "bg-green-500",
   idle: "bg-blue-500",
   paused: "bg-yellow-500",
-  question_waiting: "bg-orange-500",
-  alignment_needed: "bg-red-500",
-  stopped: "bg-gray-400",
+  exited: "bg-gray-400",
+  waiting_input: "bg-orange-500",
 };
 
 export function StatusDot({ status }: { status: Session["status"] }) {

--- a/frontend/src/components/ui/SessionCard.tsx
+++ b/frontend/src/components/ui/SessionCard.tsx
@@ -52,7 +52,7 @@ export function SessionCard({
       {currentTask && (
         <p className="text-xs text-indigo-600 truncate mb-0.5">{currentTask}</p>
       )}
-      {status === "stopped" && lastError && (
+      {status === "exited" && lastError && (
         <p className="text-xs text-red-600 truncate mb-0.5" title={lastError}>
           Error: {lastError}
         </p>

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -120,19 +120,17 @@ export function ConfigPage() {
 const NOTIFY_STATUSES = [
   { key: "working", label: "Working" },
   { key: "idle", label: "Idle" },
-  { key: "question_waiting", label: "Question Waiting" },
-  { key: "alignment_needed", label: "Alignment Needed" },
+  { key: "waiting_input", label: "Waiting Input" },
   { key: "paused", label: "Paused" },
-  { key: "stopped", label: "Stopped" },
+  { key: "exited", label: "Exited" },
 ] as const;
 
 const DEFAULT_NOTIFY_STATUSES: Record<string, boolean> = {
   working: false,
   idle: true,
-  question_waiting: true,
-  alignment_needed: true,
+  waiting_input: true,
   paused: false,
-  stopped: false,
+  exited: false,
 };
 
 function GoalCompletionNotifySettings() {

--- a/frontend/src/pages/PreviewPage.tsx
+++ b/frontend/src/pages/PreviewPage.tsx
@@ -681,10 +681,10 @@ function SessionCardPreview() {
           onClick={() => {}}
         />
 
-        <p className="text-xs text-gray-500 font-medium mt-4">Controller (stopped, with Restart action)</p>
+        <p className="text-xs text-gray-500 font-medium mt-4">Controller (paused, with Restart action)</p>
         <SessionCard
           name="project-orchestrator"
-          status="stopped"
+          status="paused"
           type="controller"
           provider="claude"
           projectPath="/Users/dev/projects/my-app"
@@ -697,10 +697,10 @@ function SessionCardPreview() {
           }
         />
 
-        <p className="text-xs text-gray-500 font-medium mt-4">Stopped with error</p>
+        <p className="text-xs text-gray-500 font-medium mt-4">Exited with error</p>
         <SessionCard
           name="failing-worker"
-          status="stopped"
+          status="exited"
           type="worker"
           provider="claude"
           lastError="exit status 1"
@@ -756,7 +756,7 @@ function SessionListPreview() {
       id: "sess-002",
       name: "fix-css-layout",
       projectPath: "/Users/ioijoi/ghq/github.com/myuon/agmux",
-      status: "stopped",
+      status: "exited",
       type: "worker",
       provider: "claude",
       model: "claude-opus-4-6[1m]",
@@ -779,7 +779,7 @@ function SessionListPreview() {
     <PreviewSection title="SessionList">
       <div className="space-y-4">
         <div>
-          <p className="text-xs text-gray-500 mb-2">通常セッション + external + stopped + idle (プロジェクト別グループ)</p>
+          <p className="text-xs text-gray-500 mb-2">通常セッション + external + exited + idle (プロジェクト別グループ)</p>
           <div className="border border-gray-200 rounded-lg p-4 bg-gray-50">
             <SessionList sessions={mockSessions} onRestartController={() => {}} />
           </div>

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -416,7 +416,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
                   }
                 }}
               />
-              {session.status !== "stopped" && session.type !== "controller" && (
+              {session.status !== "paused" && session.status !== "exited" && session.type !== "controller" && (
                 <ActionMenuItem
                   icon={<Square className="w-4 h-4" />}
                   label="Stop session"
@@ -714,7 +714,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
         />
       )}
 
-      {session && session.status === "stopped" && session.lastError && (
+      {session && session.status === "exited" && session.lastError && (
         <div className="mb-2 shrink-0">
           <AlertBanner variant="error">
             {session.lastError}

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -3,7 +3,7 @@ export interface Session {
   name: string;
   projectPath: string;
   initialPrompt?: string;
-  status: "working" | "idle" | "paused" | "question_waiting" | "alignment_needed" | "stopped";
+  status: "working" | "idle" | "paused" | "exited" | "waiting_input";
   type: "worker" | "controller" | "external";
   provider: string;
   model?: string;

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -281,6 +281,16 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: convert deprecated status values to new ones
+	_, err = db.Exec(`UPDATE sessions SET status = 'paused' WHERE status = 'stopped'`)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(`UPDATE sessions SET status = 'waiting_input' WHERE status IN ('question_waiting', 'alignment_needed')`)
+	if err != nil {
+		return err
+	}
+
 	// Migration: create notifications table
 	_, err = db.Exec(`
 		CREATE TABLE IF NOT EXISTS notifications (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -348,7 +348,7 @@ func (s *Server) stopSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.recordSessionAction(id, "session_stop", "")
-	writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
+	writeJSON(w, http.StatusOK, map[string]string{"status": "paused"})
 }
 
 func (s *Server) sendToSession(w http.ResponseWriter, r *http.Request) {
@@ -409,10 +409,9 @@ func (s *Server) broadcastToSessions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		activeStatuses := map[session.Status]bool{
-			session.StatusWorking:         true,
-			session.StatusIdle:            true,
-			session.StatusQuestionWaiting: true,
-			session.StatusAlignmentNeeded: true,
+			session.StatusWorking:      true,
+			session.StatusIdle:         true,
+			session.StatusWaitingInput: true,
 		}
 		for _, sess := range sessions {
 			// Skip external sessions
@@ -578,6 +577,11 @@ func (s *Server) createEscalation(w http.ResponseWriter, r *http.Request) {
 	// Create escalation and get response channel
 	ch := s.escalations.Create(req.ID, sessionID, req.Message, timeoutSeconds)
 
+	// Update session status to waiting_input
+	if err := s.sessions.UpdateStatus(sessionID, session.StatusWaitingInput); err != nil {
+		slog.Error("failed to update session status to waiting_input", "error", err)
+	}
+
 	// Broadcast WebSocket notification (after timeout is determined)
 	s.hub.Broadcast(Message{
 		Type: "escalation",
@@ -595,6 +599,9 @@ func (s *Server) createEscalation(w http.ResponseWriter, r *http.Request) {
 	select {
 	case response := <-ch:
 		s.escalations.Cleanup(req.ID)
+		if err := s.sessions.UpdateStatus(sessionID, session.StatusWorking); err != nil {
+			slog.Error("failed to update session status to working after escalation response", "error", err)
+		}
 		writeJSON(w, http.StatusOK, map[string]interface{}{
 			"status":    "responded",
 			"response":  response,
@@ -603,6 +610,9 @@ func (s *Server) createEscalation(w http.ResponseWriter, r *http.Request) {
 	case <-time.After(timeout):
 		autoResponse := "ユーザーが未応答のため、あなたの判断で進めてください。判断が却下される可能性があるので、リバート可能な形（コミットを細かく打つなど）で作業を進めてください。"
 		s.escalations.MarkTimedOut(req.ID, autoResponse)
+		if err := s.sessions.UpdateStatus(sessionID, session.StatusWorking); err != nil {
+			slog.Error("failed to update session status to working after escalation timeout", "error", err)
+		}
 		// Broadcast timeout notification
 		s.hub.Broadcast(Message{
 			Type: "escalation_timeout",
@@ -729,6 +739,11 @@ func (s *Server) createPermission(w http.ResponseWriter, r *http.Request) {
 
 	ch := s.permissions.Create(req.ID, sessionID, req.ToolName, req.Input, timeoutSeconds)
 
+	// Update session status to waiting_input
+	if err := s.sessions.UpdateStatus(sessionID, session.StatusWaitingInput); err != nil {
+		slog.Error("failed to update session status to waiting_input", "error", err)
+	}
+
 	s.hub.Broadcast(Message{
 		Type: "permission_prompt",
 		Data: map[string]interface{}{
@@ -745,6 +760,9 @@ func (s *Server) createPermission(w http.ResponseWriter, r *http.Request) {
 	select {
 	case response := <-ch:
 		s.permissions.Cleanup(req.ID)
+		if err := s.sessions.UpdateStatus(sessionID, session.StatusWorking); err != nil {
+			slog.Error("failed to update session status to working after permission response", "error", err)
+		}
 		writeJSON(w, http.StatusOK, map[string]interface{}{
 			"status":    "responded",
 			"response":  response,
@@ -753,6 +771,9 @@ func (s *Server) createPermission(w http.ResponseWriter, r *http.Request) {
 	case <-time.After(timeout):
 		autoResponse := "allow"
 		s.permissions.MarkTimedOut(req.ID, autoResponse)
+		if err := s.sessions.UpdateStatus(sessionID, session.StatusWorking); err != nil {
+			slog.Error("failed to update session status to working after permission timeout", "error", err)
+		}
 		s.hub.Broadcast(Message{
 			Type: "permission_timeout",
 			Data: map[string]interface{}{

--- a/internal/session/external.go
+++ b/internal/session/external.go
@@ -111,7 +111,7 @@ func (d *ExternalDetector) detect() {
 			ID:          id,
 			Name:        fmt.Sprintf("%s (pid:%d)", p.Provider, p.PID),
 			ProjectPath: p.CWD,
-			Status:      StatusWorking,
+			Status:      StatusIdle,
 			Type:        TypeExternal,
 			Provider:    p.Provider,
 			CreatedAt:   createdAt,

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -300,7 +300,7 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		ProjectPath:   projectPath,
 		InitialPrompt: prompt,
 		SystemPrompt:  customSystemPrompt,
-		Status:        StatusWorking,
+		Status:        StatusIdle,
 		Type:          TypeWorker,
 		Provider:      pn,
 		Model:         model,
@@ -507,7 +507,7 @@ func (m *Manager) Fork(id string) (*Session, error) {
 		Name:            newName,
 		ProjectPath:     src.ProjectPath,
 		SystemPrompt:    src.SystemPrompt,
-		Status:          StatusWorking,
+		Status:          StatusIdle,
 		Type:            TypeWorker,
 		Provider:        src.Provider,
 		Model:           src.Model,
@@ -559,7 +559,7 @@ func (m *Manager) Stop(id string) error {
 	// Stop stream process if exists
 	m.stopStreamProcess(id)
 
-	_, err = m.db.Exec("UPDATE sessions SET status = ?, holder_pid = 0, updated_at = ? WHERE id = ?", string(StatusStopped), time.Now(), id)
+	_, err = m.db.Exec("UPDATE sessions SET status = ?, holder_pid = 0, updated_at = ? WHERE id = ?", string(StatusPaused), time.Now(), id)
 	return err
 }
 
@@ -638,11 +638,11 @@ func (m *Manager) wireSessionIDCallback(sessionID string, sp StreamProcessInterf
 		if exitErr != nil {
 			errMsg = exitErr.Error()
 		}
-		m.logger.Warn("claude process exited unexpectedly, updating status to stopped",
+		m.logger.Warn("claude process exited unexpectedly, updating status to exited",
 			"sessionId", sid,
 			"exitError", errMsg,
 		)
-		if err := m.UpdateStatusWithError(sid, StatusStopped, errMsg); err != nil {
+		if err := m.UpdateStatusWithError(sid, StatusExited, errMsg); err != nil {
 			m.logger.Error("failed to update status after process exit", "sessionId", sid, "error", err)
 		}
 		// Clean up the stream process from the map
@@ -978,7 +978,7 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	if existing != nil && (existing.Status == StatusWorking || existing.Status == StatusIdle || existing.Status == StatusQuestionWaiting) {
+	if existing != nil && (existing.Status == StatusWorking || existing.Status == StatusIdle || existing.Status == StatusWaitingInput) {
 		// Already running, return existing
 		return existing, nil
 	}
@@ -1022,7 +1022,7 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 		ID:          id,
 		Name:        name,
 		ProjectPath: projectPath,
-		Status:      StatusWorking,
+		Status:      StatusIdle,
 		Type:        TypeController,
 		Provider:    ProviderClaude,
 		CreatedAt:   now,

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -15,12 +15,11 @@ type RecentProject struct {
 type Status string
 
 const (
-	StatusWorking         Status = "working"
-	StatusIdle            Status = "idle"
-	StatusQuestionWaiting Status = "question_waiting"
-	StatusAlignmentNeeded Status = "alignment_needed"
-	StatusPaused          Status = "paused"
-	StatusStopped         Status = "stopped"
+	StatusIdle         Status = "idle"           // Initial state / turn complete, waiting for user
+	StatusWorking      Status = "working"        // AI is working
+	StatusPaused       Status = "paused"         // User explicitly stopped the session
+	StatusExited       Status = "exited"         // Process died unexpectedly
+	StatusWaitingInput Status = "waiting_input"  // Waiting for user input (escalation/permission)
 )
 
 type SessionType string


### PR DESCRIPTION
## Summary
- Removed unused status constants (`StatusQuestionWaiting`, `StatusAlignmentNeeded`, `StatusStopped`) and added `StatusExited` (process died) and `StatusWaitingInput` (escalation/permission pending)
- Changed initial session status from `StatusWorking` to `StatusIdle` for Create, Fork, CreateController, and external sessions
- Updated status transitions: user stop -> `paused`, process death -> `exited`, escalation/permission -> `waiting_input` / `working`
- Added DB migration to convert existing `stopped` -> `paused`, `question_waiting`/`alignment_needed` -> `waiting_input`
- Updated all frontend references to use new status values

## Test plan
- [x] `make test` passes (81 tests)
- [x] `make build` succeeds (frontend TypeScript compilation + Go build)
- [ ] Verify session lifecycle in UI: create -> idle -> working -> idle
- [ ] Verify stop action shows "paused" status
- [ ] Verify process crash shows "exited" status with error
- [ ] Verify escalation/permission shows "waiting_input" status

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)