### PR TITLE
fix: チップコンポーネントのサイズ不統一を修正

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -612,7 +612,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
                       href={href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="hover:opacity-80"
+                      className="hover:opacity-80 inline-flex"
                     >
                       {chip}
                     </a>


### PR DESCRIPTION
## Summary
- Provider チップを囲む `<a>` タグに `inline-flex` を追加し、モデルチップとのサイズ不統一を解消

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)