### PR TITLE
fix: GoalPanelのタイトル改行位置を修正

### DIFF
--- a/frontend/src/components/ui/GoalPanel.tsx
+++ b/frontend/src/components/ui/GoalPanel.tsx
@@ -23,13 +23,13 @@ export function GoalPanel({ currentTask, goal, goals }: GoalPanelProps) {
       {currentTask && (
         <div className="flex items-start gap-1.5 text-xs text-gray-700">
           <ListTodo className="w-3.5 h-3.5 shrink-0 mt-0.5 text-indigo-400" />
-          <span>{currentTask}</span>
+          <span className="min-w-0 break-words">{currentTask}</span>
         </div>
       )}
       {goal && (
         <div className="flex items-start gap-1.5 text-xs text-gray-500">
           <Target className="w-3.5 h-3.5 shrink-0 mt-0.5 text-emerald-400" />
-          <span>{goal}</span>
+          <span className="min-w-0 break-words">{goal}</span>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- GoalPanel内のcurrentTask/goalテキストが長い場合に、折り返し位置がアイコンの下にずれる問題を修正
- テキストのspan要素に `min-w-0 break-words` を追加し、テキスト開始位置に揃って改行されるようにした

Closes #430

## Test plan
- [ ] 長いcurrentTask/goalテキストを持つセッションで、テキストがアイコンの右側（テキスト開始位置）に揃って折り返されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)