### PR TITLE
fix: メッセージ送信エラー時のハンドリングを追加

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -321,10 +321,14 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
     const images = pendingImages.length > 0
       ? pendingImages.map(({ data, mediaType }) => ({ data, mediaType }))
       : undefined;
-    await api.sendToSession(sessionId, message, images);
-    setMessage("");
-    setPendingImages([]);
-    // Stream mode updates arrive via WebSocket automatically
+    try {
+      await api.sendToSession(sessionId, message, images);
+      setMessage("");
+      setPendingImages([]);
+      // Stream mode updates arrive via WebSocket automatically
+    } catch (err) {
+      console.error("Failed to send message:", err);
+    }
   };
 
   const sendForm = session ? (


### PR DESCRIPTION
## Summary
- `handleSend`に`try-catch`を追加し、`api.sendToSession()`が例外をスローした場合にメッセージ欄がクリアされないようにした
- エラー時は`console.error`でログ出力し、ユーザーはメッセージを保持したまま再送信可能

## Test plan
- [ ] メッセージ送信が成功した場合、メッセージ欄がクリアされることを確認
- [ ] ネットワークエラー等でAPI呼び出しが失敗した場合、メッセージ欄が保持されることを確認

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)