### PR TITLE
feat: 開発者モード設定を追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -96,6 +96,7 @@ function Dashboard() {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [broadcastOpen, setBroadcastOpen] = useState(false);
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>("logs");
+  const [devMode, setDevMode] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const mobileTab: MobileTab = (searchParams.get("tab") as MobileTab) || "sessions";
   const navigate = useNavigate();
@@ -107,6 +108,7 @@ function Dashboard() {
 
   useEffect(() => {
     loadSessions();
+    api.getConfig().then((cfg) => setDevMode(cfg.devMode)).catch(() => {});
   }, []);
 
   const handleWsMessage = useCallback((msg: { type: string; data: unknown }) => {
@@ -150,16 +152,20 @@ function Dashboard() {
               <path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" />
             </svg>
           </button>
-          <IconButton shape="rounded" to="/preview" title="UI Preview">
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
-            </svg>
-          </IconButton>
-          <IconButton shape="rounded" to="/scenarios" title="Scenario Test">
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v3.586l-1.293-1.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 11.586V8z" clipRule="evenodd" />
-            </svg>
-          </IconButton>
+          {devMode && (
+            <IconButton shape="rounded" to="/preview" title="UI Preview">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
+              </svg>
+            </IconButton>
+          )}
+          {devMode && (
+            <IconButton shape="rounded" to="/scenarios" title="Scenario Test">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6zm5 6a1 1 0 10-2 0v3.586l-1.293-1.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 11.586V8z" clipRule="evenodd" />
+              </svg>
+            </IconButton>
+          )}
           <IconButton shape="rounded" to="/metrics" title="Metrics">
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
               <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -208,8 +208,10 @@ export interface AppConfig {
   server: { port: number };
   daemon: { interval: string };
   session: { claudeCommand: string };
+  devMode: boolean;
   prompts?: { systemPrompt: string };
   templates: RoleTemplate[];
+  configPath?: string;
 }
 
 export interface MetricRow {

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -105,7 +105,27 @@ export function ConfigPage() {
           </Section>
         )}
 
+        <Section title="Developer">
+          <Field label="開発者モード">
+            <ToggleButton
+              enabled={config.devMode}
+              onClick={() => setConfig({ ...config, devMode: !config.devMode })}
+            >
+              {config.devMode ? "ON" : "OFF"}
+            </ToggleButton>
+          </Field>
+          <p className="text-xs text-gray-500">
+            有効にするとプレビュー・シナリオテストなどの開発者向け機能が表示されます
+          </p>
+        </Section>
+
         <TemplateManager templates={config.templates || []} onUpdate={(updater) => setConfig(updater)} />
+
+        {config.configPath && (
+          <div className="text-xs text-gray-400">
+            Config: {config.configPath}
+          </div>
+        )}
 
         <div className="pt-4">
           <button

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Daemon    DaemonConfig   `toml:"daemon"`
 	Session   SessionConfig  `toml:"session"`
 	Claude    ClaudeConfig   `toml:"claude"`
+	DevMode   bool           `toml:"dev_mode"`
 	Templates []RoleTemplate `toml:"templates" json:"templates"`
 }
 
@@ -96,6 +97,11 @@ func configPath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, ".agmux", "config.toml"), nil
+}
+
+// ConfigPath returns the path to the config file.
+func ConfigPath() (string, error) {
+	return configPath()
 }
 
 func Save(cfg *Config) error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1035,12 +1035,14 @@ type configTemplateJSON struct {
 }
 
 type configJSON struct {
-	Server    configServerJSON     `json:"server"`
-	Daemon    configDaemonJSON     `json:"daemon"`
-	Session   configSessionJSON    `json:"session"`
-	Claude    configClaudeJSON     `json:"claude"`
-	Prompts   *configPromptsJSON   `json:"prompts,omitempty"`
-	Templates []configTemplateJSON `json:"templates"`
+	Server     configServerJSON     `json:"server"`
+	Daemon     configDaemonJSON     `json:"daemon"`
+	Session    configSessionJSON    `json:"session"`
+	Claude     configClaudeJSON     `json:"claude"`
+	DevMode    bool                 `json:"devMode"`
+	Prompts    *configPromptsJSON   `json:"prompts,omitempty"`
+	Templates  []configTemplateJSON `json:"templates"`
+	ConfigPath string               `json:"configPath,omitempty"`
 }
 
 type configPromptsJSON struct {
@@ -1070,12 +1072,15 @@ func configToJSON(cfg *config.Config) configJSON {
 			SystemPrompt: t.SystemPrompt,
 		}
 	}
+	cfgPath, _ := config.ConfigPath()
 	return configJSON{
-		Server:    configServerJSON{Port: cfg.Server.Port},
-		Daemon:    configDaemonJSON{Interval: cfg.Daemon.Interval},
-		Session:   configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand},
-		Claude:    configClaudeJSON{PermissionMode: cfg.Claude.ClaudePermissionMode()},
-		Templates: templates,
+		Server:     configServerJSON{Port: cfg.Server.Port},
+		Daemon:     configDaemonJSON{Interval: cfg.Daemon.Interval},
+		Session:    configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand},
+		Claude:     configClaudeJSON{PermissionMode: cfg.Claude.ClaudePermissionMode()},
+		DevMode:    cfg.DevMode,
+		Templates:  templates,
+		ConfigPath: cfgPath,
 	}
 }
 
@@ -1094,6 +1099,7 @@ func jsonToConfig(j configJSON) *config.Config {
 		Daemon:    config.DaemonConfig{Interval: j.Daemon.Interval},
 		Session:   config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand},
 		Claude:    config.ClaudeConfig{PermissionMode: j.Claude.PermissionMode},
+		DevMode:   j.DevMode,
 		Templates: templates,
 	}
 }


### PR DESCRIPTION
## Summary
- 設定画面に「開発者モード」トグルを追加（デフォルトOFF）
- 開発者モードがOFFの場合、ダッシュボードのプレビュー・シナリオテストボタンを非表示
- 設定画面にconfigファイルのパス（`~/.agmux/config.toml`）を表示

## Test plan
- [ ] 設定画面で開発者モードトグルが表示されること
- [ ] デフォルトでOFFになっていること
- [ ] ONにして保存するとダッシュボードにプレビュー・シナリオテストボタンが表示されること
- [ ] OFFの場合はボタンが非表示であること
- [ ] configファイルのパスが設定画面下部に表示されること

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)