### PR TITLE
feat: フォーク時のコンテキスト維持を選択可能に

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -452,22 +452,26 @@ func resolveTemplate(name string) (*struct {
 }
 
 func sessionForkCmd() *cobra.Command {
-	return &cobra.Command{
+	var noContext bool
+	cmd := &cobra.Command{
 		Use:   "fork <id>",
 		Short: "Fork an existing session",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return forkSessionViaAPI(args[0])
+			return forkSessionViaAPI(args[0], !noContext)
 		},
 	}
+	cmd.Flags().BoolVar(&noContext, "no-context", false, "Fork without preserving conversation context")
+	return cmd
 }
 
-func forkSessionViaAPI(id string) error {
+func forkSessionViaAPI(id string, preserveContext bool) error {
 	cfg, _ := config.Load()
 	port := cfg.Server.Port
 
 	url := fmt.Sprintf("http://localhost:%d/api/sessions/%s/fork", port, id)
-	resp, err := http.Post(url, "application/json", nil)
+	body, _ := json.Marshal(map[string]bool{"preserveContext": preserveContext})
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to connect to agmux server on port %d (is it running?): %w", port, err)
 	}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -62,8 +62,12 @@ export const api = {
   duplicateSession: (id: string) =>
     request<Session>(`/sessions/${id}/duplicate`, { method: "POST" }),
 
-  forkSession: (id: string) =>
-    request<Session>(`/sessions/${id}/fork`, { method: "POST" }),
+  forkSession: (id: string, preserveContext: boolean = true) =>
+    request<Session>(`/sessions/${id}/fork`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ preserveContext }),
+    }),
 
   sendToSession: (id: string, text: string, images?: { data: string; mediaType: string }[]) =>
     request<{ status: string }>(`/sessions/${id}/send`, {

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -128,6 +128,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
   const [showForkModal, setShowForkModal] = useState(false);
   const [forkMessage, setForkMessage] = useState("");
   const [forkLoading, setForkLoading] = useState(false);
+  const [forkPreserveContext, setForkPreserveContext] = useState(true);
 
   const providerVersion = deferred.providerVersion;
   const streamCursorRef = useRef<number | null>(null);
@@ -405,6 +406,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
                   onClick={() => {
                     setShowActionMenu(false);
                     setForkMessage("");
+                    setForkPreserveContext(true);
                     setShowForkModal(true);
                   }}
                 />
@@ -883,7 +885,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
             if (forkLoading || !session) return;
             setForkLoading(true);
             try {
-              const newSession = await api.forkSession(session.id);
+              const newSession = await api.forkSession(session.id, forkPreserveContext);
               if (forkMessage.trim()) {
                 await api.sendToSession(newSession.id, forkMessage.trim());
               }
@@ -897,6 +899,15 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
           }}
           className="space-y-3"
         >
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={forkPreserveContext}
+              onChange={(e) => setForkPreserveContext(e.target.checked)}
+              className="rounded border-gray-300"
+            />
+            コンテキストを維持する
+          </label>
           <textarea
             value={forkMessage}
             onChange={(e) => setForkMessage(e.target.value)}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -350,7 +350,19 @@ func (s *Server) forkSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, "controller session cannot be forked")
 		return
 	}
-	sess, err := s.sessions.Fork(id)
+
+	// Parse optional request body for preserveContext (default: true)
+	preserveContext := true
+	if r.Body != nil {
+		var body struct {
+			PreserveContext *bool `json:"preserveContext"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err == nil && body.PreserveContext != nil {
+			preserveContext = *body.PreserveContext
+		}
+	}
+
+	sess, err := s.sessions.Fork(id, preserveContext)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -475,7 +475,7 @@ func (m *Manager) Duplicate(id string) (*Session, error) {
 
 // Fork creates a new session by forking an existing session's conversation history.
 // It copies the stream JSONL file and starts a new CLI process with --resume --fork-session.
-func (m *Manager) Fork(id string) (*Session, error) {
+func (m *Manager) Fork(id string, preserveContext bool) (*Session, error) {
 	src, err := m.Get(id)
 	if err != nil {
 		return nil, err
@@ -483,29 +483,32 @@ func (m *Manager) Fork(id string) (*Session, error) {
 
 	provider := m.getProvider(src.Provider)
 
-	// Read the CLI session ID from the source session's stream file
-	cliSessionID := src.CliSessionID
-	if cliSessionID == "" {
-		cliSessionID = ReadCLISessionID(id, provider)
-	}
-	if cliSessionID == "" {
-		return nil, fmt.Errorf("cannot fork: source session has no CLI session ID")
-	}
-
 	newID, err := newSessionID()
 	if err != nil {
 		return nil, fmt.Errorf("generate session id: %w", err)
 	}
 
-	// Copy stream JSONL file from source to new session
-	streamsDir, err := db.StreamsDir()
-	if err != nil {
-		return nil, fmt.Errorf("get streams dir: %w", err)
-	}
-	srcPath := filepath.Join(streamsDir, id+".jsonl")
-	dstPath := filepath.Join(streamsDir, newID+".jsonl")
-	if err := copyFile(srcPath, dstPath); err != nil {
-		return nil, fmt.Errorf("copy stream file: %w", err)
+	var cliSessionID string
+	if preserveContext {
+		// Read the CLI session ID from the source session's stream file
+		cliSessionID = src.CliSessionID
+		if cliSessionID == "" {
+			cliSessionID = ReadCLISessionID(id, provider)
+		}
+		if cliSessionID == "" {
+			return nil, fmt.Errorf("cannot fork: source session has no CLI session ID")
+		}
+
+		// Copy stream JSONL file from source to new session
+		streamsDir, err := db.StreamsDir()
+		if err != nil {
+			return nil, fmt.Errorf("get streams dir: %w", err)
+		}
+		srcPath := filepath.Join(streamsDir, id+".jsonl")
+		dstPath := filepath.Join(streamsDir, newID+".jsonl")
+		if err := copyFile(srcPath, dstPath); err != nil {
+			return nil, fmt.Errorf("copy stream file: %w", err)
+		}
 	}
 
 	// Generate MCP config for new session
@@ -516,14 +519,14 @@ func (m *Manager) Fork(id string) (*Session, error) {
 
 	effectiveSystemPrompt := m.buildEffectiveSystemPrompt(src.SystemPrompt)
 
-	// Start new CLI process with --resume --fork-session via holder
+	// Start new CLI process via holder
 	sp, err := StartHolderStreamProcess(StreamOpts{
 		SessionID:     newID,
 		ProjectPath:   src.ProjectPath,
 		MCPConfigPath: mcpConfigPath,
 		SystemPrompt:  effectiveSystemPrompt,
-		Resume:        true,
-		ForkSession:   true,
+		Resume:        preserveContext,
+		ForkSession:   preserveContext,
 		CLISessionID:  cliSessionID,
 		Model:         src.Model,
 		APIPort:       m.apiPort,

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -13,7 +13,7 @@ type SessionService interface {
 	// Duplicate creates a copy of an existing session.
 	Duplicate(id string) (*Session, error)
 	// Fork creates a new session by forking an existing session's conversation history.
-	Fork(id string) (*Session, error)
+	Fork(id string, preserveContext bool) (*Session, error)
 	// Stop stops a running session.
 	Stop(id string) error
 	// Delete deletes a session.


### PR DESCRIPTION
## Summary
- フォーク時に `preserveContext` パラメータを追加し、会話コンテキストを維持するかどうかを選択可能に
- デフォルトは `true`（従来動作と互換）。`false` の場合、JSONL コピーや `--resume --fork-session` フラグをスキップし新規セッションとして起動
- フロントエンドのフォークモーダルに「コンテキストを維持する」チェックボックスを追加
- CLI に `--no-context` フラグを追加

## 変更箇所
- `internal/session/service.go`: `Fork` インターフェースに `preserveContext bool` パラメータ追加
- `internal/session/manager.go`: `preserveContext=false` 時に JSONL コピーと resume/fork フラグをスキップ
- `internal/server/server.go`: リクエストボディから `preserveContext` を解析
- `frontend/src/api/client.ts`: `forkSession` に `preserveContext` パラメータ追加
- `frontend/src/pages/SessionPage.tsx`: フォークモーダルにチェックボックス追加
- `cmd/agmux/main.go`: `--no-context` フラグ追加

Closes #486

## Test plan
- [ ] `make build` 成功確認済み
- [ ] `make test` 全テスト通過確認済み
- [ ] コンテキスト維持ONでフォーク -> 従来通り会話履歴が引き継がれること
- [ ] コンテキスト維持OFFでフォーク -> 新規セッションとして起動されること
- [ ] CLI `agmux session fork <id> --no-context` が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)