### PR TITLE
fix: サブエージェントのgit pushハングを防止

### DIFF
--- a/internal/session/provider_claude.go
+++ b/internal/session/provider_claude.go
@@ -92,6 +92,8 @@ func (p *ClaudeProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
 			cmd.Env = append(cmd.Env, env)
 		}
 	}
+	// Prevent git from hanging on interactive auth prompts (e.g. HTTPS push)
+	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary
- サブエージェントのCLIプロセス起動時に `GIT_TERMINAL_PROMPT=0` 環境変数を追加
- HTTPS push時に credential helper が未設定の場合、認証プロンプト待ちでハングする問題を防止
- プロンプトの代わりに即エラーを返すことで、エージェントが適切にエラーハンドリングできるようになる

## Test plan
- [x] `make build` 成功
- [x] `make test` 全テストパス

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)