### PR TITLE
feat: 通知一覧をフィード形式のデザインに改善

### DIFF
--- a/frontend/src/components/NotificationPanel.tsx
+++ b/frontend/src/components/NotificationPanel.tsx
@@ -4,6 +4,30 @@ import { api } from "../api/client";
 import type { NotificationEntry } from "../api/client";
 import { useWebSocket } from "../hooks/useWebSocket";
 
+function relativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffSec = Math.floor((now - then) / 1000);
+
+  if (diffSec < 60) return "just now";
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return `${diffHour}h ago`;
+  const diffDay = Math.floor(diffHour / 24);
+  return `${diffDay}d ago`;
+}
+
+function kindConfig(kind: string) {
+  if (kind === "escalation") {
+    return { color: "bg-orange-400", dotColor: "bg-orange-400", label: "Escalation", textColor: "text-orange-600" };
+  }
+  if (kind === "system") {
+    return { color: "bg-gray-400", dotColor: "bg-gray-400", label: "System", textColor: "text-gray-500" };
+  }
+  return { color: "bg-blue-400", dotColor: "bg-blue-400", label: "Notification", textColor: "text-blue-600" };
+}
+
 export function NotificationPanel() {
   const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
   const navigate = useNavigate();
@@ -16,7 +40,6 @@ export function NotificationPanel() {
     load();
   }, [load]);
 
-  // Reload on new notification via WebSocket
   const handleWsMessage = useCallback(
     (msg: { type: string }) => {
       if (msg.type === "agent_notification" || msg.type === "escalation" || msg.type === "notify") {
@@ -28,55 +51,55 @@ export function NotificationPanel() {
 
   useWebSocket(handleWsMessage);
 
-  const kindLabel = (kind: string) => {
-    if (kind === "escalation") return "Escalation";
-    if (kind === "system") return "System";
-    return "Notification";
-  };
-
-  const kindColor = (kind: string) => {
-    if (kind === "escalation") return "text-orange-400";
-    if (kind === "system") return "text-gray-400";
-    return "text-blue-400";
-  };
-
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-3 py-2 border-b border-gray-700 bg-gray-800 rounded-t-lg">
-        <h2 className="text-sm font-semibold text-gray-200">Notifications</h2>
-        <span className="text-xs text-gray-400">{notifications.length}</span>
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-200 bg-white rounded-t-lg">
+        <h2 className="text-sm font-semibold text-gray-800">Notifications</h2>
+        <span className="text-xs text-gray-400 bg-gray-100 rounded-full px-2 py-0.5">{notifications.length}</span>
       </div>
-      <div className="bg-gray-900 rounded-b-lg p-3 font-mono text-xs overflow-auto flex-1 min-h-0">
+      <div className="bg-white rounded-b-lg overflow-auto flex-1 min-h-0">
         {notifications.length === 0 ? (
-          <p className="text-gray-500">No notifications yet</p>
+          <p className="text-sm text-gray-400 px-4 py-6 text-center">No notifications yet</p>
         ) : (
-          <table className="w-full">
-            <tbody>
-              {notifications.map((n) => (
-                <tr key={n.id} className="align-top hover:bg-gray-800">
-                  <td className="text-gray-500 pr-2 whitespace-nowrap py-0.5">
-                    {new Date(n.createdAt).toLocaleTimeString()}
-                  </td>
-                  <td className={`pr-2 whitespace-nowrap py-0.5 ${kindColor(n.kind)}`}>
-                    {kindLabel(n.kind)}
-                  </td>
-                  <td className="text-gray-300 pr-2 whitespace-nowrap py-0.5">
-                    {n.sessionId ? (
-                      <button
-                        onClick={() => navigate(`/sessions/${n.sessionId}`)}
-                        className="text-cyan-400 underline hover:text-cyan-300 cursor-pointer"
-                      >
-                        {n.sessionName || n.sessionId.slice(0, 8)}
-                      </button>
-                    ) : null}
-                  </td>
-                  <td className="text-gray-100 py-0.5 break-all">
-                    {n.message}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <ul className="divide-y divide-gray-100">
+            {notifications.map((n) => {
+              const config = kindConfig(n.kind);
+              return (
+                <li
+                  key={n.id}
+                  className={`flex items-start gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors ${
+                    n.sessionId ? "cursor-pointer" : ""
+                  }`}
+                  onClick={n.sessionId ? () => navigate(`/sessions/${n.sessionId}`) : undefined}
+                >
+                  {/* Color bar / dot */}
+                  <div className="flex-shrink-0 pt-1.5">
+                    <div className={`w-2 h-2 rounded-full ${config.dotColor}`} />
+                  </div>
+
+                  {/* Content */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className={`text-xs font-medium ${config.textColor}`}>{config.label}</span>
+                      {n.sessionId && (
+                        <span className="text-xs text-gray-400">
+                          {n.sessionName || n.sessionId.slice(0, 8)}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-gray-700 leading-snug mt-0.5 break-words line-clamp-2">
+                      {n.message}
+                    </p>
+                  </div>
+
+                  {/* Relative time */}
+                  <span className="flex-shrink-0 text-xs text-gray-400 pt-0.5 whitespace-nowrap">
+                    {relativeTime(n.createdAt)}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- `NotificationPanel` を `<table>` ベースから `<ul>` リストアイテム形式に変更
- ダークテーマ(`bg-gray-900`)からライト系(`bg-white`)に変更し、セッションカードとの差別化を維持
- monospace から sans-serif に変更
- kind ごとにカラードット（escalation: オレンジ、system: グレー、その他: ブルー）を表示
- 相対時間表示（"3m ago", "1h ago" 等）を実装
- セッションIDがある通知はクリックでセッション詳細に遷移

Closes #504

## Test plan
- [ ] 通知一覧がフィード/リスト形式で表示されること
- [ ] escalation/system/通常の各kindで適切なカラードットが表示されること
- [ ] 相対時間が正しく表示されること
- [ ] セッションリンクのクリックでセッション詳細に遷移すること
- [ ] `make build` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)