### PR TITLE
feat: Cloudflare Tunnel + Accessによるインターネット公開

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ frontend/node_modules/
 # Installed skills (build artifacts from skill-lock)
 .agents/
 .claude/skills/
+
+# Terraform
+terraform/.terraform/
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#1e293b" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "4.52.7"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:u67GWw8GwD9NDlDzp9Y5VRnSQGcCrE8rSpkGPaBpDl0=",
+    "zh:0c904ce31a4c6c4a5b3bf7ff1560e77c0cc7e2450c8553ded8e8c90398e1418b",
+    "zh:36183d310c36373fe4cb936b83c595c6fd3b0a94bc7827f28e5789ccbf59752e",
+    "zh:556a568a6f0235e8f41647de9e4d3a1e7b1d6502df8b19b54ec441f1c653ea10",
+    "zh:633ebbd5b0245e75e500ef9be4d9e62288f97e8da3baaa51323892a786d90285",
+    "zh:6acfe60cf52a65ba8f044f748548d2119e7f4fd7f8ebcb14698960d87c68f529",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:904acc31ebb9d6ef68c792074b30532ee61bf515f19e0a3c75b46f126cca1f13",
+    "zh:a1d0a81246afc8750286d3f6fe7a8fbe6460dd2662407b28dbfbabb612e5fa9d",
+    "zh:a41a36fe253fc365fe2b7ffc749624688b2693b4634862fda161179ab100029f",
+    "zh:a7ef269e77ffa8715c8945a2c14322c7ff159ea44c15f62505f3cbb2cae3b32d",
+    "zh:b01aa3bed30610633b762df64332b26f8844a68c3960cebcb30f04918efc67fe",
+    "zh:b069cc2cd18cae10757df3ae030508eac8d55de7e49eda7a5e3e11f2f7fe6455",
+    "zh:b2d2c6313729ebb7465dceece374049e2d08bda34473901be9ff46a8836d42b2",
+    "zh:db0e114edaf4bc2f3d4769958807c83022bfbc619a00bdf4c4bd17faa4ab2d8b",
+    "zh:ecc0aa8b9044f664fd2aaf8fa992d976578f78478980555b4b8f6148e8d1a5fe",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.3.5"
+  hashes = [
+    "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
+    "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
+    "zh:a2ce38fda83a62fa5fb5a70e6ca8453b168575feb3459fa39803f6f40bd42154",
+    "zh:a6c72798f4a9a36d1d1433c0372006cc9b904e8cfd60a2ae03ac5b7d2abd2398",
+    "zh:a8a3141d2fc71c86bf7f3c13b0b3be8a1b0f0144a47572a15af4dfafc051e28a",
+    "zh:aa20a1242eb97445ad26ebcfb9babf2cd675bdb81cac5f989268ebefa4ef278c",
+    "zh:b58a22445fb8804e933dcf835ab06c29a0f33148dce61316814783ee7f4e4332",
+    "zh:cb5626a661ee761e0576defb2a2d75230a3244799d380864f3089c66e99d0dcc",
+    "zh:d1acb00d20445f682c4e705c965e5220530209c95609194c2dc39324f3d4fcce",
+    "zh:d91a254ba77b69a29d8eae8ed0e9367cbf0ea6ac1a85b58e190f8cb096a40871",
+    "zh:f6592327673c9f85cdb6f20336faef240abae7621b834f189c4a62276ea5db41",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,59 @@
+# --- Identity Provider: Google OAuth ---
+
+resource "cloudflare_zero_trust_access_identity_provider" "google" {
+  account_id = local.account_id
+  name       = "Google"
+  type       = "google"
+
+  config {
+    client_id     = local.google_client_id
+    client_secret = local.google_client_secret
+  }
+}
+
+# --- Access Application: main (authenticated) ---
+
+resource "cloudflare_zero_trust_access_application" "main" {
+  account_id       = local.account_id
+  name             = var.app_name
+  domain           = var.domain
+  type             = "self_hosted"
+  session_duration = var.session_duration
+  allowed_idps     = [cloudflare_zero_trust_access_identity_provider.google.id]
+}
+
+# --- Access Policy: Allow specific emails ---
+
+resource "cloudflare_zero_trust_access_policy" "allow_email" {
+  application_id = cloudflare_zero_trust_access_application.main.id
+  account_id     = local.account_id
+  name           = "Allow specific emails"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = var.allowed_emails
+  }
+}
+
+# --- Access Application: manifest.json bypass (for PWA) ---
+
+resource "cloudflare_zero_trust_access_application" "manifest_bypass" {
+  account_id       = local.account_id
+  name             = "${var.app_name} manifest.json (bypass)"
+  domain           = "${var.domain}/manifest.json"
+  type             = "self_hosted"
+  session_duration = "24h"
+}
+
+resource "cloudflare_zero_trust_access_policy" "bypass_manifest" {
+  application_id = cloudflare_zero_trust_access_application.manifest_bypass.id
+  account_id     = local.account_id
+  name           = "Bypass manifest.json"
+  precedence     = 1
+  decision       = "bypass"
+
+  include {
+    everyone = true
+  }
+}

--- a/terraform/setup-secrets.sh
+++ b/terraform/setup-secrets.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+VAULT="Secrets"
+ITEM_TITLE="agmux Cloudflare Access"
+
+echo "=== agmux Cloudflare Access secrets setup ==="
+echo ""
+
+# Create vault if not exists
+if ! op vault get "$VAULT" > /dev/null 2>&1; then
+  echo "Creating vault: $VAULT"
+  op vault create "$VAULT" > /dev/null
+fi
+
+read -rp "Cloudflare Account ID: " CF_ACCOUNT_ID
+read -rp "Cloudflare API Token: " CF_API_TOKEN
+read -rp "Google OAuth Client ID: " GOOGLE_CLIENT_ID
+read -rsp "Google OAuth Client Secret: " GOOGLE_CLIENT_SECRET
+echo ""
+
+# Check if item already exists
+if op item get "$ITEM_TITLE" --vault="$VAULT" > /dev/null 2>&1; then
+  echo "Updating existing item..."
+  op item edit "$ITEM_TITLE" \
+    --vault="$VAULT" \
+    "cloudflare_account_id=$CF_ACCOUNT_ID" \
+    "cloudflare_api_token=$CF_API_TOKEN" \
+    "google_client_id=$GOOGLE_CLIENT_ID" \
+    "google_client_secret=$GOOGLE_CLIENT_SECRET" \
+    > /dev/null
+  echo "Updated: $ITEM_TITLE"
+else
+  echo "Creating new item..."
+  op item create \
+    --category=login \
+    --title="$ITEM_TITLE" \
+    --vault="$VAULT" \
+    "cloudflare_account_id=$CF_ACCOUNT_ID" \
+    "cloudflare_api_token=$CF_API_TOKEN" \
+    "google_client_id=$GOOGLE_CLIENT_ID" \
+    "google_client_secret=$GOOGLE_CLIENT_SECRET" \
+    > /dev/null
+  echo "Created: $ITEM_TITLE"
+fi
+
+echo ""
+echo "Done. Terraform can read these via:"
+echo '  op read "op://Secrets/agmux Cloudflare Access/cloudflare_api_token"'

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,4 @@
+domain         = "agmux.ramda.io"
+app_name       = "agmux"
+allowed_emails = ["ioi.joi.koi.loi@gmail.com"]
+session_duration = "730h"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,20 @@
+variable "domain" {
+  type        = string
+  description = "Domain to protect with Cloudflare Access"
+}
+
+variable "app_name" {
+  type        = string
+  description = "Application name in Cloudflare Access"
+}
+
+variable "allowed_emails" {
+  type        = list(string)
+  description = "Email addresses allowed to access the application"
+}
+
+variable "session_duration" {
+  type        = string
+  default     = "730h"
+  description = "Session duration (Go duration format, e.g. 730h = ~30 days)"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 1.5"
+}
+
+provider "cloudflare" {
+  api_token = data.external.op_secrets.result["cloudflare_api_token"]
+}
+
+data "external" "op_secrets" {
+  program = ["bash", "-c", <<-EOF
+    echo '{'
+    echo '"cloudflare_api_token":"'$(op read "op://Secrets/agmux Cloudflare Access/cloudflare_api_token")'",'
+    echo '"cloudflare_account_id":"'$(op read "op://Secrets/agmux Cloudflare Access/cloudflare_account_id")'",'
+    echo '"google_client_id":"'$(op read "op://Secrets/agmux Cloudflare Access/google_client_id")'",'
+    echo '"google_client_secret":"'$(op read "op://Secrets/agmux Cloudflare Access/google_client_secret")'"'
+    echo '}'
+  EOF
+  ]
+}
+
+locals {
+  account_id           = data.external.op_secrets.result["cloudflare_account_id"]
+  google_client_id     = data.external.op_secrets.result["google_client_id"]
+  google_client_secret = data.external.op_secrets.result["google_client_secret"]
+}


### PR DESCRIPTION
## Summary
- Cloudflare Tunnel + Access (Google OAuth) でagmuxをインターネットに公開
- TerraformでCloudflare Access設定をIaC管理（1Password CLI連携）
- PWA対応のためmanifest.jsonにcrossorigin="use-credentials"を追加

## 構成
```
スマホ (ブラウザ) → Cloudflare Edge (Google OAuth) → Tunnel → Mac → agmux(:4321)
```

## 変更内容
- `terraform/` - Cloudflare Access Application/Policy/IdPのTerraform構成
- `terraform/setup-secrets.sh` - 1Passwordへの秘密情報登録スクリプト
- `frontend/index.html` - manifest.jsonのCORS対応
- `.gitignore` - Terraform state/workdir除外

## Test plan
- [x] `terraform apply` でCloudflare Accessリソースが作成される
- [x] `https://agmux.ramda.io` でGoogle OAuth認証が動作する
- [x] 認証後にagmux WebUIが表示される
- [ ] PWAインストールプロンプトが表示される

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)