### PR TITLE
fix: トップページのNotificationsヘッダー重複を修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -264,9 +264,6 @@ function Dashboard() {
             mobileTab === "notifications" ? "flex-1 flex flex-col" : "hidden md:flex md:flex-col"
           }`}
         >
-          <h2 className="text-sm font-semibold text-gray-700 mb-2 hidden md:block">
-            Notifications
-          </h2>
           <div className="flex-1 min-h-0 flex flex-col">
             <NotificationPanel />
           </div>


### PR DESCRIPTION
## Summary
- App.tsxのページレベル `<h2>Notifications</h2>` を削除
- NotificationPanel内のバッジ付きヘッダーのみ残す

## Test plan
- [ ] トップページでNotificationsヘッダーが1つだけ表示される

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)