### PR TITLE
feat: Codexセッションのステータスをturn.completedでidle/workingに切り替え

### DIFF
--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -269,6 +269,14 @@ func (sp *HolderStreamProcess) readLoop() {
 					tcb(sp.streamOpts.SessionID)
 				}
 			}
+		case "turn.completed":
+			// Codex emits turn.completed when a turn finishes.
+			sp.mu.RLock()
+			tcb := sp.onTurnComplete
+			sp.mu.RUnlock()
+			if tcb != nil {
+				tcb(sp.streamOpts.SessionID)
+			}
 		}
 
 		// Normalize the line

--- a/internal/session/stream_process.go
+++ b/internal/session/stream_process.go
@@ -320,6 +320,14 @@ func (sp *StreamProcess) readLoop(stdout io.Reader) {
 					tcb(sp.streamOpts.SessionID)
 				}
 			}
+		case "turn.completed":
+			// Codex emits turn.completed when a turn finishes.
+			sp.mu.RLock()
+			tcb := sp.onTurnComplete
+			sp.mu.RUnlock()
+			if tcb != nil {
+				tcb(sp.streamOpts.SessionID)
+			}
 		}
 
 		// Normalize the line into Claude-compatible format.


### PR DESCRIPTION
## Summary

- Codexストリームの `turn.completed` イベントを検知して `onTurnComplete` コールバックを呼び出す
- `stream_process.go` と `holder_stream.go` の両方の readLoop に対応を追加
- Claude の `result` イベント（`subtype: "success"`）による既存の `onTurnComplete` 呼び出しと競合しない設計（異なるプロバイダーが異なるイベントを使用するため）

## Test plan

- [ ] Codex セッションが完了したとき、ステータスが `working` から `idle` に切り替わる
- [ ] Claude セッションの動作が引き続き正常（`result` イベントによる切り替えが機能する）

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)