### PR TITLE
fix: macOS 26でlaunchctl load/unloadをbootstrap/bootoutにフォールバック対応

### DIFF
--- a/internal/daemon/launchd.go
+++ b/internal/daemon/launchd.go
@@ -8,6 +8,10 @@ import (
 	"text/template"
 )
 
+func launchctlDomain() string {
+	return fmt.Sprintf("gui/%d", os.Getuid())
+}
+
 const plistLabel = "com.myuon.agmux"
 
 const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
@@ -116,9 +120,15 @@ func Install() error {
 		return fmt.Errorf("execute template: %w", err)
 	}
 
-	// Load the agent
-	if out, err := exec.Command("launchctl", "load", ppath).CombinedOutput(); err != nil {
-		return fmt.Errorf("launchctl load failed: %s: %w", string(out), err)
+	// Load the agent: try bootstrap (macOS 26+) then fall back to load
+	domain := launchctlDomain()
+	// Attempt bootout first to avoid "already loaded" errors from bootstrap
+	_ = exec.Command("launchctl", "bootout", domain, ppath).Run()
+	if out, err := exec.Command("launchctl", "bootstrap", domain, ppath).CombinedOutput(); err != nil {
+		// Fallback for older macOS versions
+		if out2, err2 := exec.Command("launchctl", "load", ppath).CombinedOutput(); err2 != nil {
+			return fmt.Errorf("launchctl bootstrap failed (%s: %w); launchctl load also failed: %s: %w", string(out), err, string(out2), err2)
+		}
 	}
 
 	fmt.Printf("Installed and loaded %s\n", ppath)
@@ -138,7 +148,10 @@ func Uninstall() error {
 		return fmt.Errorf("plist not found at %s; nothing to uninstall", ppath)
 	}
 
-	// Unload the agent (ignore errors if not loaded)
+	// Unload the agent: try bootout (macOS 26+) then fall back to unload
+	domain := launchctlDomain()
+	_ = exec.Command("launchctl", "bootout", domain, ppath).Run()
+	// Fallback for older macOS versions (ignore errors if not loaded)
 	_ = exec.Command("launchctl", "unload", ppath).Run()
 
 	if err := os.Remove(ppath); err != nil {


### PR DESCRIPTION
## Summary

- macOS 26 (Tahoe) では `launchctl load` が SIGABRT (exit 134) で失敗する問題を修正
- `bootstrap`/`bootout` を優先して使い、失敗した場合は `load`/`unload` にフォールバックする
- `launchctlDomain()` ヘルパー関数を追加して `gui/<uid>` ドメインを取得

## Test plan

- [ ] macOS 26 環境で `agmux daemon install` が正常に動作する
- [ ] 旧 macOS 環境でも引き続き正常動作する（load/unload フォールバック）

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)