### PR TITLE
Update installation URLs to use specific release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@
 
 ```bash
 # macOS (Apple Silicon)
-curl -L -o agmux https://github.com/myuon/agmux/releases/latest/download/agmux-darwin-arm64
+curl -L -o agmux https://github.com/myuon/agmux/releases/download/main/agmux-darwin-arm64
 chmod +x agmux
 mv agmux ~/.local/bin/
 
 # macOS (Intel)
-curl -L -o agmux https://github.com/myuon/agmux/releases/latest/download/agmux-darwin-amd64
+curl -L -o agmux https://github.com/myuon/agmux/releases/download/main/agmux-darwin-amd64
 chmod +x agmux
 mv agmux ~/.local/bin/
 
 # Linux (amd64)
-curl -L -o agmux https://github.com/myuon/agmux/releases/latest/download/agmux-linux-amd64
+curl -L -o agmux https://github.com/myuon/agmux/releases/download/main/agmux-linux-amd64
 chmod +x agmux
 mv agmux ~/.local/bin/
 ```


### PR DESCRIPTION
## Summary
Updated the installation instructions in README.md to point to a specific release tag instead of the latest release endpoint.

## Changes
- Changed download URLs from `/releases/latest/download/` to `/releases/download/main/` for all three platform variants:
  - macOS (Apple Silicon)
  - macOS (Intel)
  - Linux (amd64)

## Details
This change ensures that users download from a specific release tag (`main`) rather than relying on the `/latest` endpoint, which can be less reliable or may not always point to the intended release. This provides more predictable and stable installation instructions.

https://claude.ai/code/session_01Negz89UJysF7QpeJUhaQy7