### PR TITLE
refactor: MCPをHTTPトランスポートに移行しper-sessionプロセスを廃止

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -188,7 +188,7 @@ func serveCmd() *cobra.Command {
 
 			var srv *server.Server
 
-			srv = server.New(mgr, hub, devMode, logger, database)
+			srv = server.New(mgr, hub, devMode, logger, database, port)
 
 			// Wire managed holder PIDs into external detector so holder
 			// processes and their children are not detected as external.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -30,6 +30,50 @@ func NewServer() *Server {
 	}
 }
 
+// NewServerForHTTP creates an MCP server for use via HTTP transport.
+// sessionID and apiURL are provided directly instead of via environment variables.
+func NewServerForHTTP(sessionID, apiURL string) *Server {
+	return &Server{
+		sessionID: sessionID,
+		apiURL:    apiURL,
+	}
+}
+
+// HandleJSONRPC processes a single JSON-RPC request body and returns the response body.
+// This is intended for use from an HTTP handler.
+func (s *Server) HandleJSONRPC(requestBody []byte) []byte {
+	var req jsonRPCRequest
+	if err := json.Unmarshal(requestBody, &req); err != nil {
+		resp := jsonRPCResponse{
+			JSONRPC: "2.0",
+			Error:   &jsonRPCError{Code: -32700, Message: "parse error"},
+		}
+		out, _ := json.Marshal(resp)
+		return out
+	}
+
+	// Notifications have no id — return empty
+	if req.ID == nil {
+		return nil
+	}
+
+	result, rpcErr := s.handleMethod(req.Method, req.Params)
+	resp := jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+	}
+	if rpcErr != nil {
+		resp.Error = rpcErr
+	} else {
+		raw, _ := json.Marshal(result)
+		rawMsg := json.RawMessage(raw)
+		resp.Result = &rawMsg
+	}
+
+	out, _ := json.Marshal(resp)
+	return out
+}
+
 // Run starts the MCP server on stdin/stdout (JSON-RPC 2.0).
 func (s *Server) Run() error {
 	scanner := bufio.NewScanner(os.Stdin)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -15,7 +15,7 @@ import (
 // sessionIDProperty is the shared JSON Schema property for session_id across all tools.
 var sessionIDProperty = map[string]interface{}{
 	"type":        "string",
-	"description": "agmuxのセッションID。環境変数 AGMUX_SESSION_ID が設定されていない場合に必要です。",
+	"description": "agmuxのセッションID。",
 }
 
 type Server struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net"
@@ -22,6 +23,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/myuon/agmux/internal/config"
 	"github.com/myuon/agmux/internal/db"
+	"github.com/myuon/agmux/internal/mcp"
 	"github.com/myuon/agmux/internal/otel"
 	"github.com/myuon/agmux/internal/session"
 )
@@ -110,6 +112,9 @@ func (s *Server) setupRoutes() {
 	}
 
 	r.Get("/ws", s.hub.HandleWS)
+
+	// MCP HTTP transport endpoint
+	r.Post("/mcp/{sessionID}", s.handleMCP)
 
 	// OTLP receiver endpoints
 	r.Post("/v1/metrics", s.otelReceiver.HandleMetrics)
@@ -1743,6 +1748,35 @@ func generateNewFileDiff(projectPath, filePath string) (string, error) {
 		return "", nil
 	}
 	return strings.TrimRight(string(out), "\n"), nil
+}
+
+func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
+	sessionID := chi.URLParam(r, "sessionID")
+
+	cfg, err := config.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load config")
+		return
+	}
+	apiURL := fmt.Sprintf("http://localhost:%d", cfg.Server.Port)
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+
+	mcpServer := mcp.NewServerForHTTP(sessionID, apiURL)
+	respBody := mcpServer.HandleJSONRPC(body)
+	if respBody == nil {
+		// Notification — no response needed
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(respBody)
 }
 
 func (s *Server) recordSessionAction(sessionID, actionType, detail string) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -101,6 +101,7 @@ func (s *Server) setupRoutes() {
 	r := chi.NewRouter()
 	r.Use(slogRequestLogger(s.logger))
 	r.Use(middleware.Recoverer)
+	r.Use(middleware.Compress(5))
 
 	if s.devMode {
 		r.Use(cors.Handler(cors.Options{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,6 +33,7 @@ type Server struct {
 	hub              *Hub
 	router           chi.Router
 	devMode          bool
+	port             int
 	logger           *slog.Logger
 	escalations      *EscalationStore
 	permissions      *PermissionStore
@@ -41,13 +42,14 @@ type Server struct {
 	externalDetector *session.ExternalDetector
 }
 
-func New(sessions session.SessionService, hub *Hub, devMode bool, logger *slog.Logger, sqlDB *sql.DB) *Server {
+func New(sessions session.SessionService, hub *Hub, devMode bool, logger *slog.Logger, sqlDB *sql.DB, port int) *Server {
 	extDetector := session.NewExternalDetector(logger, 10*time.Second)
 
 	s := &Server{
 		sessions:         sessions,
 		hub:              hub,
 		devMode:          devMode,
+		port:             port,
 		logger:           logger.With("component", "server"),
 		escalations:      NewEscalationStore(),
 		permissions:      NewPermissionStore(),
@@ -1754,12 +1756,12 @@ func generateNewFileDiff(projectPath, filePath string) (string, error) {
 func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 	sessionID := chi.URLParam(r, "sessionID")
 
-	cfg, err := config.Load()
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load config")
+	if _, err := s.sessions.Get(sessionID); err != nil {
+		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}
-	apiURL := fmt.Sprintf("http://localhost:%d", cfg.Server.Port)
+
+	apiURL := fmt.Sprintf("http://localhost:%d", s.port)
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -1777,7 +1779,9 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(respBody)
+	if _, err := w.Write(respBody); err != nil {
+		slog.Error("failed to write MCP response", "error", err)
+	}
 }
 
 func (s *Server) recordSessionAction(sessionID, actionType, detail string) {

--- a/internal/session/mcp_config.go
+++ b/internal/session/mcp_config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/myuon/agmux/internal/db"
@@ -15,9 +14,8 @@ type mcpConfig struct {
 }
 
 type mcpServerEntry struct {
-	Command string            `json:"command"`
-	Args    []string          `json:"args"`
-	Env     map[string]string `json:"env,omitempty"`
+	Type string `json:"type"`
+	URL  string `json:"url"`
 }
 
 const defaultSystemPrompt = `あなたはagmuxで管理されているセッションです。以下のルールを守ってください:
@@ -40,21 +38,11 @@ func writeMCPConfig(sessionID string, apiPort int) (string, error) {
 		return "", fmt.Errorf("create mcp-configs dir: %w", err)
 	}
 
-	agmuxPath, err := exec.LookPath("agmux")
-	if err != nil {
-		// Fallback to "agmux" if not found in PATH
-		agmuxPath = "agmux"
-	}
-
 	cfg := mcpConfig{
 		McpServers: map[string]mcpServerEntry{
 			"agmux": {
-				Command: agmuxPath,
-				Args:    []string{"mcp"},
-				Env: map[string]string{
-					"AGMUX_SESSION_ID": sessionID,
-					"AGMUX_API_URL":    fmt.Sprintf("http://localhost:%d", apiPort),
-				},
+				Type: "http",
+				URL:  fmt.Sprintf("http://localhost:%d/mcp/%s", apiPort, sessionID),
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- `mcp.NewServerForHTTP` と `HandleJSONRPC` を追加し、HTTP ハンドラから MCP サーバーを利用可能にした
- `/mcp/{sessionID}` エンドポイントを追加し、JSON-RPC リクエストを HTTP で処理できるようにした
- MCP 設定フォーマットを stdio コマンド形式から HTTP トランスポート形式に変更した
  - 旧: `{"command":"agmux","args":["mcp"],"env":{"AGMUX_SESSION_ID":"...","AGMUX_API_URL":"..."}}`
  - 新: `{"type":"http","url":"http://localhost:PORT/mcp/SESSION_ID"}`
- `AGMUX_SESSION_ID`/`AGMUX_API_URL` 環境変数注入が不要になったため除去した

## Test plan

- [ ] `make build && make test` が通ることを確認
- [ ] Claude セッション起動時に生成される mcp-configs/*.json が HTTP 形式になっていることを確認
- [ ] agmux MCP ツール（create_goal, escalate等）が正常に動作することを確認

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)