### PR TITLE
fix: CGO_ENABLED=1を明示的に設定しネイティブビルドに修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           - os: macos-latest
             goos: darwin
             goarch: arm64
-          - os: macos-latest
+          - os: macos-13
             goos: darwin
             goarch: amd64
           - os: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build binary
         env:
-          CGO_ENABLED: "0"
+          CGO_ENABLED: "1"
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PORT ?= 4321
 .PHONY: build build-frontend reload-frontend dev clean test install restart
 
 build: build-frontend
-	go build -ldflags "-X main.version=$$(git describe --tags --always 2>/dev/null || echo dev) -X main.commit=$$(git rev-parse --short HEAD 2>/dev/null || echo none) -X main.buildDate=$$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o agmux ./cmd/agmux
+	CGO_ENABLED=1 go build -ldflags "-X main.version=$$(git describe --tags --always 2>/dev/null || echo dev) -X main.commit=$$(git rev-parse --short HEAD 2>/dev/null || echo none) -X main.buildDate=$$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o agmux ./cmd/agmux
 
 build-frontend:
 	cd frontend && npm ci && npm run build
@@ -23,7 +23,7 @@ test:
 	go test ./...
 
 install: build-frontend
-	go install -ldflags "-X main.version=$$(git describe --tags --always 2>/dev/null || echo dev) -X main.commit=$$(git rev-parse --short HEAD 2>/dev/null || echo none) -X main.buildDate=$$(date -u +%Y-%m-%dT%H:%M:%SZ)" ./cmd/agmux
+	CGO_ENABLED=1 go install -ldflags "-X main.version=$$(git describe --tags --always 2>/dev/null || echo dev) -X main.commit=$$(git rev-parse --short HEAD 2>/dev/null || echo none) -X main.buildDate=$$(date -u +%Y-%m-%dT%H:%M:%SZ)" ./cmd/agmux
 
 restart: install
 	@launchctl kickstart -k "gui/$$(id -u)/com.myuon.agmux"


### PR DESCRIPTION
## Summary
- release workflowの`CGO_ENABLED`を`0`→`1`に修正（PR #538で導入されたバグ）
- `darwin-amd64`ビルドのランナーを`macos-latest`(arm64)→`macos-13`(Intel x86_64)に変更し、クロスコンパイル不要に
- Makefileの`build`/`install`ターゲットに`CGO_ENABLED=1`を明示的に追加

## Background
PR #538でクロスコンパイルのために`CGO_ENABLED=0`が設定されたが、sqliteなどのネイティブ依存が壊れるバグを引き起こしていた。

## Test plan
- [ ] `make build`でCGO有効のバイナリが生成されること
- [ ] CIでdarwin-amd64, darwin-arm64, linux-amd64の全ビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)