### PR TITLE
fix: CGO_ENABLED=1に修正しgo-sqlite3のランタイム失敗を解決 (#554)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           - os: macos-latest
             goos: darwin
             goarch: arm64
-          - os: macos-latest
+          - os: macos-13
             goos: darwin
             goarch: amd64
           - os: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build binary
         env:
-          CGO_ENABLED: "0"
+          CGO_ENABLED: "1"
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PORT ?= 4321
 .PHONY: build build-frontend reload-frontend dev clean test install restart
 
 build: build-frontend
-	go build -ldflags "-X main.version=$$(git describe --tags --always 2>/dev/null || echo dev) -X main.commit=$$(git rev-parse --short HEAD 2>/dev/null || echo none) -X main.buildDate=$$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o agmux ./cmd/agmux
+	CGO_ENABLED=1 go build -ldflags "-X main.version=$$(git describe --tags --always 2>/dev/null || echo dev) -X main.commit=$$(git rev-parse --short HEAD 2>/dev/null || echo none) -X main.buildDate=$$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o agmux ./cmd/agmux
 
 build-frontend:
 	cd frontend && npm ci && npm run build
@@ -23,7 +23,7 @@ test:
 	go test ./...
 
 install: build-frontend
-	go install -ldflags "-X main.version=$$(git describe --tags --always 2>/dev/null || echo dev) -X main.commit=$$(git rev-parse --short HEAD 2>/dev/null || echo none) -X main.buildDate=$$(date -u +%Y-%m-%dT%H:%M:%SZ)" ./cmd/agmux
+	CGO_ENABLED=1 go install -ldflags "-X main.version=$$(git describe --tags --always 2>/dev/null || echo dev) -X main.commit=$$(git rev-parse --short HEAD 2>/dev/null || echo none) -X main.buildDate=$$(date -u +%Y-%m-%dT%H:%M:%SZ)" ./cmd/agmux
 
 restart: install
 	@launchctl kickstart -k "gui/$$(id -u)/com.myuon.agmux"


### PR DESCRIPTION
## Summary

- `.github/workflows/release.yml` の `CGO_ENABLED: "0"` を `CGO_ENABLED: "1"` に変更（go-sqlite3はCGOが必須のため、`"0"` だとランタイムで失敗する）
- `darwin-amd64` ビルドのランナーを `macos-latest`（arm64）から `macos-13`（x86_64）に変更し、CGO有効なままネイティブビルドを実現（arm64ランナー上でamd64向けにCGO付きクロスコンパイルする問題を回避）
- `Makefile` の `build` / `install` ターゲットに `CGO_ENABLED=1` を明示追加

Closes #554

## Test plan

- [ ] リリースワークフローが darwin-arm64、darwin-amd64、linux-amd64 すべてでビルド成功すること
- [ ] ビルドされたバイナリがSQLite操作（go-sqlite3）を含む機能で正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)