### PR TITLE
fix: session create後にholder_pidが0になるバグを修正

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -334,9 +334,6 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	m.streamProcesses[id] = sp
 	m.streamMu.Unlock()
 
-	// Persist holder PID
-	m.updateHolderPID(id, sp.HolderPID())
-
 	now := time.Now()
 	s := &Session{
 		ID:              id,
@@ -361,6 +358,9 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	); err != nil {
 		return nil, fmt.Errorf("insert session: %w", err)
 	}
+
+	// Persist holder PID after the session row exists in the DB.
+	m.updateHolderPID(id, sp.HolderPID())
 
 	return s, nil
 }


### PR DESCRIPTION
## Summary

- `Manager.Create` 内で `updateHolderPID` が `INSERT INTO sessions` より前に呼ばれていたため、`UPDATE` が空振りして `holder_pid` が常に 0 になっていた
- `updateHolderPID` の呼び出しを `INSERT` の直後に移動することで修正

## Root Cause

`internal/session/manager.go` の `Create` 関数内で:
1. ホルダープロセスを起動 (`StartHolderStreamProcess`)
2. `updateHolderPID(id, sp.HolderPID())` を呼ぶ ← DBにまだ行がない!
3. `INSERT INTO sessions ...` でDB行を作成

UPDATE文が存在しない行に対して実行されるため何も更新されず、`holder_pid = 0` のまま行が挿入されていた。

## Fix

`updateHolderPID` の呼び出しを `INSERT` の後に移動するだけ。

## Test plan

- [ ] `agmux session create` で新規セッション作成
- [ ] `agmux session info <id>` で Holder PID が 0 でないことを確認
- [ ] `agmux session delete` でプロセスが正常に終了することを確認

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)