### PR TITLE
fix: task_started/task_notification が常にマッチしないバグを修正 (#563)

### DIFF
--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -329,17 +329,21 @@ func (sp *HolderStreamProcess) readLoop() {
 
 		// Track background tasks and detect turn completion.
 		ev := parseStreamEvent([]byte(line))
-		switch ev.Type {
-		case "task_started":
-			sp.mu.Lock()
-			sp.runningTasks++
-			sp.mu.Unlock()
-		case "task_notification":
-			sp.mu.Lock()
-			if sp.runningTasks > 0 {
-				sp.runningTasks--
+		if ev.Type == "system" {
+			switch ev.Subtype {
+			case "task_started":
+				sp.mu.Lock()
+				sp.runningTasks++
+				sp.mu.Unlock()
+			case "task_notification":
+				sp.mu.Lock()
+				if sp.runningTasks > 0 {
+					sp.runningTasks--
+				}
+				sp.mu.Unlock()
 			}
-			sp.mu.Unlock()
+		}
+		switch ev.Type {
 		case "result":
 			if ev.Subtype == "success" {
 				sp.mu.RLock()


### PR DESCRIPTION
## Summary

- `holder_stream.go` の `readLoop` で、`ev.Type` を `"task_started"` / `"task_notification"` と直接比較していたが、実際のイベントは `type: "system"`, `subtype: "task_started"` の形式になっている
- `ev.Type == "system"` の条件下で `ev.Subtype` を switch するよう修正し、`runningTasks` カウンターが正しくインクリメント/デクリメントされるようにした

## Test plan

- [x] `make build` で正常にビルドされることを確認
- [x] `make test` で全テストが通ることを確認

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)