### PR TITLE
fix: 完了したタスクがRunning Tasksに残り続けるバグを修正

### DIFF
--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -107,6 +107,11 @@ export function extractActiveTasks(entries: StreamEntry[]): ActiveTask[] {
   const tasks = new Map<string, ActiveTask>();
   for (const entry of entries) {
     const raw = entry as unknown as Record<string, unknown>;
+    // When a session completes (result event), clear all remaining active tasks
+    if (entry.type === "result") {
+      tasks.clear();
+      continue;
+    }
     if (entry.type !== "system") continue;
     const subtype = raw.subtype as string | undefined;
     if (subtype === "task_started") {


### PR DESCRIPTION
## Summary

- `extractActiveTasks` 関数で `result` イベントを検出したとき、残存するアクティブタスクを全件クリアするよう修正
- CLIが `task_notification` を送らずに終了した場合でも、セッション完了後にタスクが消えるようになった
- 変更箇所: `frontend/src/models/stream.ts`

## Test plan

- [ ] `make build` が通ること（TS コンパイル + Vite ビルド）
- [ ] `make test` が通ること
- [ ] セッション完了後、Running Tasks が空になることをブラウザで目視確認

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)