### PR TITLE
fix: 3paneレイアウトで選択中セッションをハイライトする

### DIFF
--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useMatch } from "react-router-dom";
 import { TerminalSquare } from "lucide-react";
 import { motion } from "motion/react";
 import type { Session } from "../types/session";
@@ -61,6 +61,8 @@ interface Props {
 
 export function SessionList({ sessions, onRestartController }: Props) {
   const navigate = useNavigate();
+  const sessionMatch = useMatch("/sessions/:id");
+  const selectedSessionId = sessionMatch?.params.id ?? null;
   const childrenMap = useMemo(() => buildChildrenMap(sessions), [sessions]);
 
   const groupedSessions = useMemo(() => {
@@ -116,6 +118,7 @@ export function SessionList({ sessions, onRestartController }: Props) {
               projectPath={s.projectPath}
               timeAgo={timeAgo(s.createdAt)}
               isSubSession={depth > 0}
+              isSelected={s.id === selectedSessionId}
               onClick={() => navigate(`/sessions/${s.id}`, { viewTransition: true } as never)}
               actions={
                 s.type === "controller" && (s.status === "paused" || s.status === "exited") ? (

--- a/frontend/src/components/ui/SessionCard.tsx
+++ b/frontend/src/components/ui/SessionCard.tsx
@@ -14,6 +14,7 @@ interface SessionCardProps {
   projectPath: string;
   timeAgo: string;
   isSubSession?: boolean;
+  isSelected?: boolean;
   onClick?: () => void;
   actions?: React.ReactNode;
 }
@@ -30,6 +31,7 @@ export function SessionCard({
   projectPath,
   timeAgo,
   isSubSession,
+  isSelected,
   onClick,
   actions,
 }: SessionCardProps) {
@@ -40,7 +42,7 @@ export function SessionCard({
       tabIndex={0}
       onClick={onClick}
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick?.(); } }}
-      className={`text-left w-full border rounded-lg p-3 transition-shadow bg-white hover:shadow-sm cursor-pointer ${isSubSession ? "border-blue-200 border-l-blue-400 border-l-2" : "border-gray-200"}`}
+      className={`text-left w-full border rounded-lg p-3 transition-shadow cursor-pointer ${isSelected ? "bg-blue-50 border-blue-400 shadow-sm" : "bg-white hover:shadow-sm"} ${isSubSession && !isSelected ? "border-blue-200 border-l-blue-400 border-l-2" : ""} ${isSubSession && isSelected ? "border-l-2" : ""} ${!isSubSession && !isSelected ? "border-gray-200" : ""}`}
     >
       <div className="flex items-center gap-2 mb-1">
         <span className="inline-flex shrink-0" style={vtn("dot")}><StatusDot status={status} /></span>


### PR DESCRIPTION
## Summary
- `SessionCard` に `isSelected` プロップを追加
- `SessionList` で `useMatch` を使い現在のURLから選択中セッションIDを取得
- 選択中カードに `bg-blue-50 border-blue-400 shadow-sm` を適用してハイライト

## Test plan
- [ ] デスクトップ3paneレイアウトでセッションを選択し、対応するカードが青くハイライトされることを確認
- [ ] 別のセッションを選択すると前のカードのハイライトが消えることを確認
- [ ] サブセッション（インデント付き）でも同様に動作することを確認
- [ ] `make build` でビルド成功を確認済み
- [ ] `make test` でテスト全通過を確認済み

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)