### PR TITLE
feat: 長時間タスク実行時にエージェントへ定期通知する機能 (#558)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -208,6 +208,7 @@ export interface AppConfig {
   server: { port: number };
   daemon: { interval: string };
   session: { claudeCommand: string };
+  notification: { subagentElapsed: boolean };
   devMode: boolean;
   prompts?: { systemPrompt: string };
   templates: RoleTemplate[];

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -92,6 +92,28 @@ export function ConfigPage() {
           </Field>
         </Section>
 
+        <Section title="Agent Notifications">
+          <Field label="サブエージェント経過通知">
+            <ToggleButton
+              enabled={config.notification?.subagentElapsed ?? false}
+              onClick={() =>
+                setConfig({
+                  ...config,
+                  notification: {
+                    ...(config.notification ?? { subagentElapsed: false }),
+                    subagentElapsed: !(config.notification?.subagentElapsed ?? false),
+                  },
+                })
+              }
+            >
+              {(config.notification?.subagentElapsed ?? false) ? "ON" : "OFF"}
+            </ToggleButton>
+          </Field>
+          <p className="text-xs text-gray-500">
+            サブエージェント（Agent tool）が長時間実行中の場合、親セッションに経過時間を通知します（30分・1時間・2時間・3時間・5時間・12時間・24時間）。
+          </p>
+        </Section>
+
         <NotificationStatus />
 
         {config.prompts && (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,13 +22,18 @@ type PromptTemplate struct {
 }
 
 type Config struct {
-	Server          ServerConfig     `toml:"server"`
-	Daemon          DaemonConfig     `toml:"daemon"`
-	Session         SessionConfig    `toml:"session"`
-	Claude          ClaudeConfig     `toml:"claude"`
-	DevMode         bool             `toml:"dev_mode"`
-	Templates       []RoleTemplate   `toml:"templates" json:"templates"`
-	PromptTemplates []PromptTemplate `toml:"prompt_templates" json:"prompt_templates"`
+	Server          ServerConfig        `toml:"server"`
+	Daemon          DaemonConfig        `toml:"daemon"`
+	Session         SessionConfig       `toml:"session"`
+	Claude          ClaudeConfig        `toml:"claude"`
+	Notification    NotificationConfig  `toml:"notification"`
+	DevMode         bool                `toml:"dev_mode"`
+	Templates       []RoleTemplate      `toml:"templates" json:"templates"`
+	PromptTemplates []PromptTemplate    `toml:"prompt_templates" json:"prompt_templates"`
+}
+
+type NotificationConfig struct {
+	SubagentElapsed bool `toml:"subagent_elapsed"`
 }
 
 type ServerConfig struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1008,11 +1008,16 @@ type configJSON struct {
 	Daemon          configDaemonJSON           `json:"daemon"`
 	Session         configSessionJSON          `json:"session"`
 	Claude          configClaudeJSON           `json:"claude"`
+	Notification    configNotificationJSON     `json:"notification"`
 	DevMode         bool                       `json:"devMode"`
 	Prompts         *configPromptsJSON         `json:"prompts,omitempty"`
 	Templates       []configTemplateJSON       `json:"templates"`
-	PromptTemplates []config.PromptTemplate `json:"promptTemplates"`
+	PromptTemplates []config.PromptTemplate    `json:"promptTemplates"`
 	ConfigPath      string                     `json:"configPath,omitempty"`
+}
+
+type configNotificationJSON struct {
+	SubagentElapsed bool `json:"subagentElapsed"`
 }
 
 type configPromptsJSON struct {
@@ -1048,6 +1053,7 @@ func configToJSON(cfg *config.Config) configJSON {
 		Daemon:          configDaemonJSON{Interval: cfg.Daemon.Interval},
 		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand},
 		Claude:          configClaudeJSON{PermissionMode: cfg.Claude.ClaudePermissionMode()},
+		Notification:    configNotificationJSON{SubagentElapsed: cfg.Notification.SubagentElapsed},
 		DevMode:         cfg.DevMode,
 		Templates:       templates,
 		PromptTemplates: cfg.PromptTemplates,
@@ -1070,6 +1076,7 @@ func jsonToConfig(j configJSON) *config.Config {
 		Daemon:          config.DaemonConfig{Interval: j.Daemon.Interval},
 		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand},
 		Claude:          config.ClaudeConfig{PermissionMode: j.Claude.PermissionMode},
+		Notification:    config.NotificationConfig{SubagentElapsed: j.Notification.SubagentElapsed},
 		DevMode:         j.DevMode,
 		Templates:       templates,
 		PromptTemplates: j.PromptTemplates,

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -23,8 +23,10 @@ type ImageData struct {
 
 // streamEvent is a minimal struct for parsing event type and subtype from JSONL lines.
 type streamEvent struct {
-	Type    string `json:"type"`
-	Subtype string `json:"subtype"`
+	Type      string `json:"type"`
+	Subtype   string `json:"subtype"`
+	TaskType  string `json:"task_type"`
+	ToolUseID string `json:"tool_use_id"`
 }
 
 // parseStreamEvent parses the type and subtype from a JSONL line.
@@ -121,13 +123,28 @@ type HolderStreamProcess struct {
 	modelCaptured bool
 
 	// Callbacks
-	onSessionID      func(cliSessionID string)
-	onModel          func(model string)
-	onNewLines       func(sessionID string, newLines []string, total int)
-	onProcessExit    func(sessionID string, exitErr error)
-	onTurnComplete   func(sessionID string)
-	onHolderRestart  func(sessionID string, newPID int)
-	runningTasks     int
+	onSessionID           func(cliSessionID string)
+	onModel               func(model string)
+	onNewLines            func(sessionID string, newLines []string, total int)
+	onProcessExit         func(sessionID string, exitErr error)
+	onTurnComplete        func(sessionID string)
+	onHolderRestart       func(sessionID string, newPID int)
+	onSubagentElapsed     func(sessionID string, toolUseID string, elapsed time.Duration)
+	runningTasks          int
+
+	// subagent timer tracking: tool_use_id -> timer cancel func
+	subagentTimers        map[string]func()
+}
+
+// subagentNotifyIntervals defines the fixed elapsed times at which to notify.
+var subagentNotifyIntervals = []time.Duration{
+	30 * time.Minute,
+	1 * time.Hour,
+	2 * time.Hour,
+	3 * time.Hour,
+	5 * time.Hour,
+	12 * time.Hour,
+	24 * time.Hour,
 }
 
 // StartHolderStreamProcess starts a CLI process via a holder subprocess.
@@ -151,12 +168,13 @@ func StartHolderStreamProcess(opts StreamOpts, provider Provider) (*HolderStream
 	}
 
 	sp := &HolderStreamProcess{
-		conn:       conn,
-		done:       make(chan struct{}),
-		sessionID:  opts.CLISessionID,
-		provider:   provider,
-		holderPID:  pid,
-		streamOpts: opts,
+		conn:           conn,
+		done:           make(chan struct{}),
+		sessionID:      opts.CLISessionID,
+		provider:       provider,
+		holderPID:      pid,
+		streamOpts:     opts,
+		subagentTimers: make(map[string]func()),
 	}
 
 	// Load existing lines from JSONL file (respecting clear offset)
@@ -180,12 +198,13 @@ func ReconnectHolderStreamProcess(opts StreamOpts, provider Provider, holderPID 
 	}
 
 	sp := &HolderStreamProcess{
-		conn:       conn,
-		done:       make(chan struct{}),
-		sessionID:  opts.CLISessionID,
-		provider:   provider,
-		holderPID:  holderPID,
-		streamOpts: opts,
+		conn:           conn,
+		done:           make(chan struct{}),
+		sessionID:      opts.CLISessionID,
+		provider:       provider,
+		holderPID:      holderPID,
+		streamOpts:     opts,
+		subagentTimers: make(map[string]func()),
 	}
 
 	// Load all existing lines from JSONL file (respecting clear offset)
@@ -242,6 +261,7 @@ func (sp *HolderStreamProcess) loadExistingLines(sessionID string, clearOffset i
 }
 
 func (sp *HolderStreamProcess) readLoop() {
+	defer sp.cancelAllSubagentTimers()
 	defer close(sp.done)
 
 	reader := bufio.NewReader(sp.conn)
@@ -330,16 +350,27 @@ func (sp *HolderStreamProcess) readLoop() {
 		// Track background tasks and detect turn completion.
 		ev := parseStreamEvent([]byte(line))
 		switch ev.Type {
-		case "task_started":
-			sp.mu.Lock()
-			sp.runningTasks++
-			sp.mu.Unlock()
-		case "task_notification":
-			sp.mu.Lock()
-			if sp.runningTasks > 0 {
-				sp.runningTasks--
+		case "system":
+			switch ev.Subtype {
+			case "task_started":
+				sp.mu.Lock()
+				sp.runningTasks++
+				sp.mu.Unlock()
+				// Start subagent elapsed timer when a local_agent task is started
+				if ev.TaskType == "local_agent" && ev.ToolUseID != "" {
+					sp.startSubagentTimer(ev.ToolUseID, time.Now())
+				}
+			case "task_notification":
+				sp.mu.Lock()
+				if sp.runningTasks > 0 {
+					sp.runningTasks--
+				}
+				sp.mu.Unlock()
+				// Cancel subagent timer when the task completes
+				if ev.ToolUseID != "" {
+					sp.cancelSubagentTimer(ev.ToolUseID)
+				}
 			}
-			sp.mu.Unlock()
 		case "result":
 			if ev.Subtype == "success" {
 				sp.mu.RLock()
@@ -449,6 +480,77 @@ func (sp *HolderStreamProcess) SetOnHolderRestart(fn func(sessionID string, newP
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 	sp.onHolderRestart = fn
+}
+
+// SetOnSubagentElapsed sets a callback that fires when a local_agent subagent has been
+// running for a notable elapsed duration (30m, 1h, 2h, 3h, 5h, 12h, 24h).
+func (sp *HolderStreamProcess) SetOnSubagentElapsed(fn func(sessionID string, toolUseID string, elapsed time.Duration)) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.onSubagentElapsed = fn
+}
+
+// startSubagentTimer schedules notifications at each interval in subagentNotifyIntervals.
+// Each scheduled goroutine checks if the callback is still set before firing.
+func (sp *HolderStreamProcess) startSubagentTimer(toolUseID string, startedAt time.Time) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+
+	// Cancel any existing timer for this tool_use_id
+	if cancel, ok := sp.subagentTimers[toolUseID]; ok {
+		cancel()
+	}
+
+	done := make(chan struct{})
+	sp.subagentTimers[toolUseID] = func() {
+		select {
+		case <-done:
+		default:
+			close(done)
+		}
+	}
+
+	go func() {
+		for _, interval := range subagentNotifyIntervals {
+			delay := time.Until(startedAt.Add(interval))
+			if delay <= 0 {
+				continue
+			}
+			t := time.NewTimer(delay)
+			select {
+			case <-done:
+				t.Stop()
+				return
+			case <-t.C:
+			}
+			sp.mu.RLock()
+			cb := sp.onSubagentElapsed
+			sp.mu.RUnlock()
+			if cb != nil {
+				cb(sp.streamOpts.SessionID, toolUseID, interval)
+			}
+		}
+	}()
+}
+
+// cancelSubagentTimer cancels the timer for the given tool_use_id.
+func (sp *HolderStreamProcess) cancelSubagentTimer(toolUseID string) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	if cancel, ok := sp.subagentTimers[toolUseID]; ok {
+		cancel()
+		delete(sp.subagentTimers, toolUseID)
+	}
+}
+
+// cancelAllSubagentTimers cancels all running subagent timers.
+func (sp *HolderStreamProcess) cancelAllSubagentTimers() {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	for id, cancel := range sp.subagentTimers {
+		cancel()
+		delete(sp.subagentTimers, id)
+	}
 }
 
 // Send writes a user message to the holder's socket.
@@ -743,6 +845,8 @@ func (sp *HolderStreamProcess) ClearLines() {
 
 // Stop sends a stop command to the holder.
 func (sp *HolderStreamProcess) Stop() {
+	sp.cancelAllSubagentTimers()
+
 	sp.mu.Lock()
 	sp.stopped = true
 	sp.mu.Unlock()

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -511,6 +511,11 @@ func (sp *HolderStreamProcess) startSubagentTimer(toolUseID string, startedAt ti
 	}
 
 	go func() {
+		defer func() {
+			sp.mu.Lock()
+			delete(sp.subagentTimers, toolUseID)
+			sp.mu.Unlock()
+		}()
 		for _, interval := range subagentNotifyIntervals {
 			delay := time.Until(startedAt.Add(interval))
 			if delay <= 0 {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	gonanoid "github.com/matoous/go-nanoid/v2"
+	"github.com/myuon/agmux/internal/config"
 	"github.com/myuon/agmux/internal/db"
 )
 
@@ -695,6 +696,36 @@ func (m *Manager) wireSessionIDCallback(sessionID string, sp *HolderStreamProces
 	sp.SetOnHolderRestart(func(sid string, newPID int) {
 		m.logger.Info("holder restarted (codex resume), updating holder_pid", "sessionId", sid, "newPid", newPID)
 		m.updateHolderPID(sid, newPID)
+	})
+	sp.SetOnSubagentElapsed(func(sid string, toolUseID string, elapsed time.Duration) {
+		cfg, err := config.Load()
+		if err != nil || !cfg.Notification.SubagentElapsed {
+			return
+		}
+		var elapsedStr string
+		switch elapsed {
+		case 30 * time.Minute:
+			elapsedStr = "30分"
+		case 1 * time.Hour:
+			elapsedStr = "1時間"
+		case 2 * time.Hour:
+			elapsedStr = "2時間"
+		case 3 * time.Hour:
+			elapsedStr = "3時間"
+		case 5 * time.Hour:
+			elapsedStr = "5時間"
+		case 12 * time.Hour:
+			elapsedStr = "12時間"
+		case 24 * time.Hour:
+			elapsedStr = "24時間"
+		default:
+			elapsedStr = elapsed.String()
+		}
+		msg := fmt.Sprintf("[agmux] サブエージェントが起動から%s経過しています。", elapsedStr)
+		m.logger.Info("subagent elapsed notification", "sessionId", sid, "toolUseId", toolUseID, "elapsed", elapsed)
+		if err := m.SendKeys(sid, msg); err != nil {
+			m.logger.Warn("failed to send subagent elapsed notification", "sessionId", sid, "error", err)
+		}
 	})
 	sp.SetOnProcessExit(func(sid string, exitErr error) {
 		// For Codex provider, exit code 0 is normal (exec finishes after each prompt).


### PR DESCRIPTION
## Summary

- `internal/config/config.go`: `NotificationConfig` struct と `SubagentElapsed bool` フィールドを追加
- `internal/session/holder_stream.go`: `task_started` (task_type=local_agent) を検知してgoroutineタイマーを起動し、`task_notification` で解除。30m/1h/2h/3h/5h/12h/24h のタイミングで `onSubagentElapsed` コールバックを呼ぶ
- `internal/session/manager.go`: `wireSessionIDCallback` に `SetOnSubagentElapsed` フックを追加。設定が有効な場合に `SendKeys` で経過時間メッセージを送信
- `internal/server/server.go`: `configJSON` / `configToJSON` / `jsonToConfig` に `notification` フィールドを追加
- `frontend/src/api/client.ts`: `AppConfig` に `notification.subagentElapsed` を追加
- `frontend/src/pages/ConfigPage.tsx`: "Agent Notifications" セクションとトグルを追加

## Test plan

- [ ] `make build` が通ること（済み）
- [ ] `make test` が通ること（済み）
- [ ] 設定画面に「サブエージェント経過通知」トグルが表示され、ON/OFFを保存できること
- [ ] local_agent タスクが長時間実行された場合、設定ONのときのみ親セッションへ通知メッセージが届くこと

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)