### PR TITLE
fix(session): holderがSIGKILLされても子プロセスが確実に終了する仕組みを追加

### DIFF
--- a/internal/session/holder.go
+++ b/internal/session/holder.go
@@ -132,6 +132,27 @@ func RunHolder(sessionID string, cmdArgs []string, projectPath string, env []str
 	}()
 	defer signal.Stop(sigCh)
 
+	// Watch for parent process death (e.g. holder is SIGKILLed or server crashes).
+	// When the parent dies, this process is re-parented to init (ppid == 1),
+	// so we detect that and close stdin to trigger a clean shutdown of the CLI child.
+	go func() {
+		originalPPID := os.Getppid()
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if os.Getppid() != originalPPID {
+					slog.Info("holder: parent process died, closing stdin", "sessionId", sessionID)
+					h.stdin.Close()
+					return
+				}
+			case <-h.done:
+				return
+			}
+		}
+	}()
+
 	// Wait for CLI process to exit
 	<-h.done
 	exitCode := 0

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -647,25 +647,27 @@ func (m *Manager) Delete(id string) error {
 	// holder は SIGTERM を受けると stdin.Close() を実行し、子プロセスの claude CLI が
 	// stdin EOF で正常終了する。SIGKILL を使うと stdin.Close() が実行されず、
 	// claude CLI が孤児化して external process として残留する。
-	// この問題は #441, #472, #502, #529, #569 と5回再発している。
+	// この問題は #441, #472, #502, #529, #569, #574 と6回再発している。
 	// 修正時は holder.go の SIGTERM ハンドラとの整合性を必ず確認すること。
-	// See: https://github.com/myuon/agmux/issues/569
+	//
+	// プロセスグループ単位で kill することで、holder が SIGKILL されても
+	// 子プロセス (claude CLI) も確実に終了する。holder は Setsid: true で起動されるため
+	// holder の PID = PGID になっており、-PID でグループ全体を kill できる。
+	// See: https://github.com/myuon/agmux/issues/574
 	var holderPID int
 	if err := m.db.QueryRow("SELECT holder_pid FROM sessions WHERE id = ?", id).Scan(&holderPID); err == nil {
 		if holderPID > 0 && IsHolderAlive(holderPID) {
-			if proc, err := os.FindProcess(holderPID); err == nil {
-				// Send SIGTERM first so the holder can graceful-shutdown (close stdin → claude CLI exits cleanly)
-				proc.Signal(syscall.SIGTERM)
-				// Wait up to 3 seconds for graceful termination
+			// Send SIGTERM to the entire process group so claude CLI also receives the signal
+			syscall.Kill(-holderPID, syscall.SIGTERM)
+			// Wait up to 3 seconds for graceful termination
+			waitForProcessExit(holderPID, 3*time.Second, 100*time.Millisecond)
+			if !IsHolderAlive(holderPID) {
+				m.logger.Info("terminated process group via SIGTERM", "sessionId", id, "holderPid", holderPID)
+			} else {
+				// Fallback: kill the entire process group with SIGKILL
+				syscall.Kill(-holderPID, syscall.SIGKILL)
 				waitForProcessExit(holderPID, 3*time.Second, 100*time.Millisecond)
-				if !IsHolderAlive(holderPID) {
-					m.logger.Info("terminated holder process via SIGTERM", "sessionId", id, "holderPid", holderPID)
-				} else {
-					// Fallback to SIGKILL if the process didn't exit in time
-					proc.Kill()
-					waitForProcessExit(holderPID, 3*time.Second, 100*time.Millisecond)
-					m.logger.Info("killed holder process via SIGKILL (SIGTERM fallback)", "sessionId", id, "holderPid", holderPID)
-				}
+				m.logger.Info("killed process group via SIGKILL (SIGTERM fallback)", "sessionId", id, "holderPid", holderPID)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- `Manager.Delete()` でのkillをプロセスグループ単位に変更（`proc.Signal` → `syscall.Kill(-pid, sig)`）し、holderがSIGKILLされても子プロセス（claude CLI）も確実に終了するようにした
- `holder.go` に親プロセス死亡監視ゴルーチンを追加。`os.Getppid()` を1秒ごとにチェックし、ppidが変わったら（親が死んで init に re-parent された）`stdin.Close()` を呼んでCLIのクリーンシャットダウンをトリガーする

## 変更詳細

### `internal/session/manager.go`

`proc.Signal(syscall.SIGTERM)` / `proc.Kill()` を `syscall.Kill(-holderPID, syscall.SIGTERM/SIGKILL)` に変更。
holder は `Setsid: true` で起動されるため holder PID = PGID であり、`-PID` でプロセスグループ全体にシグナルを送れる。

### `internal/session/holder.go`

`RunHolder()` 内のCLI起動後、SIGTERMハンドラと並行してppid監視ゴルーチンを起動する。

## Test plan

- [x] `make build` でビルド成功を確認
- [x] `make test` でテスト通過を確認

Closes #574