### PR TITLE
fix: ExternalDetectorが既存セッションを二重表示する問題を修正

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -68,34 +68,20 @@ func NewManager(db *sql.DB, claudeCommand string, permissionMode string, apiPort
 }
 
 // ManagedHolderPIDs returns the PIDs of all holder processes currently managed by this Manager.
-// It combines PIDs from the in-memory streamProcesses map and PIDs stored in the DB (holder_pid > 0),
-// so that sessions whose holder processes survived a server restart are also excluded from external detection.
+// DB holder_pid is always positive for active sessions, so querying the DB is sufficient.
 func (m *Manager) ManagedHolderPIDs() []int {
-	m.streamMu.Lock()
-	inMemoryPIDs := make(map[int]bool)
-	for _, sp := range m.streamProcesses {
-		if pid := sp.HolderPID(); pid > 0 {
-			inMemoryPIDs[pid] = true
-		}
+	rows, err := m.db.Query("SELECT holder_pid FROM sessions WHERE holder_pid > 0")
+	if err != nil {
+		return nil
 	}
-	m.streamMu.Unlock()
+	defer rows.Close()
 
-	// Also query the DB for holder PIDs not yet tracked in streamProcesses
-	// (e.g. alive holders from before a server restart, before RecoverStreamProcesses completes).
-	rows, err := m.db.Query(`SELECT holder_pid FROM sessions WHERE holder_pid > 0`)
-	if err == nil {
-		defer rows.Close()
-		for rows.Next() {
-			var pid int
-			if err := rows.Scan(&pid); err == nil && pid > 0 {
-				inMemoryPIDs[pid] = true
-			}
+	var pids []int
+	for rows.Next() {
+		var pid int
+		if err := rows.Scan(&pid); err == nil {
+			pids = append(pids, pid)
 		}
-	}
-
-	pids := make([]int, 0, len(inMemoryPIDs))
-	for pid := range inMemoryPIDs {
-		pids = append(pids, pid)
 	}
 	return pids
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -68,15 +68,34 @@ func NewManager(db *sql.DB, claudeCommand string, permissionMode string, apiPort
 }
 
 // ManagedHolderPIDs returns the PIDs of all holder processes currently managed by this Manager.
+// It combines PIDs from the in-memory streamProcesses map and PIDs stored in the DB (holder_pid > 0),
+// so that sessions whose holder processes survived a server restart are also excluded from external detection.
 func (m *Manager) ManagedHolderPIDs() []int {
 	m.streamMu.Lock()
-	defer m.streamMu.Unlock()
-
-	var pids []int
+	inMemoryPIDs := make(map[int]bool)
 	for _, sp := range m.streamProcesses {
 		if pid := sp.HolderPID(); pid > 0 {
-			pids = append(pids, pid)
+			inMemoryPIDs[pid] = true
 		}
+	}
+	m.streamMu.Unlock()
+
+	// Also query the DB for holder PIDs not yet tracked in streamProcesses
+	// (e.g. alive holders from before a server restart, before RecoverStreamProcesses completes).
+	rows, err := m.db.Query(`SELECT holder_pid FROM sessions WHERE holder_pid > 0`)
+	if err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			var pid int
+			if err := rows.Scan(&pid); err == nil && pid > 0 {
+				inMemoryPIDs[pid] = true
+			}
+		}
+	}
+
+	pids := make([]int, 0, len(inMemoryPIDs))
+	for pid := range inMemoryPIDs {
+		pids = append(pids, pid)
 	}
 	return pids
 }


### PR DESCRIPTION
## Summary

- `ManagedHolderPIDs()` がインメモリの `streamProcesses` マップのみを参照していたため、サーバー再起動後に DB の `holder_pid` を持つセッションのホルダープロセスが `ExternalDetector` に除外されず二重表示されていた
- `ManagedHolderPIDs()` を DB (`sessions WHERE holder_pid > 0`) も参照するように修正し、インメモリ・DB 両方の holder PID を返すようにした
- これにより `collectProcessTree()` が holder PID とその子プロセス（claude CLI 等）を正しく除外できるようになる

## Test plan

- [ ] `make build` が通ること
- [ ] `make test` が通ること
- [ ] サーバー再起動後にセッション一覧で `(external)` の二重表示が出ないこと

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)