### PR TITLE
fix: 3paneレイアウトでセッション操作後にセッション一覧が自動再読み込みされない

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -237,6 +237,27 @@ func (s *Server) getRecentProjects(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, projects)
 }
 
+// broadcastSessionUpdate fetches the current session list (including external sessions)
+// and broadcasts it to all WebSocket clients as a "session_update" message.
+func (s *Server) broadcastSessionUpdate() {
+	sessions, err := s.sessions.List()
+	if err != nil {
+		s.logger.Error("broadcastSessionUpdate: failed to list sessions", "error", err)
+		return
+	}
+	if sessions == nil {
+		sessions = []session.Session{}
+	}
+	if s.externalDetector != nil {
+		external := s.externalDetector.Sessions()
+		sessions = append(sessions, external...)
+	}
+	s.hub.Broadcast(Message{
+		Type: "session_update",
+		Data: sessions,
+	})
+}
+
 func (s *Server) listSessions(w http.ResponseWriter, r *http.Request) {
 	sessions, err := s.sessions.List()
 	if err != nil {
@@ -272,6 +293,7 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.recordSessionAction(sess.ID, "session_create", "name: "+req.Name+", path: "+req.ProjectPath)
+	s.broadcastSessionUpdate()
 	writeJSON(w, http.StatusCreated, sess)
 }
 
@@ -320,6 +342,7 @@ func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.recordSessionAction(id, "session_delete", "")
+	s.broadcastSessionUpdate()
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
 
@@ -340,6 +363,7 @@ func (s *Server) duplicateSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.recordSessionAction(sess.ID, "session_duplicate", "duplicated from "+id)
+	s.broadcastSessionUpdate()
 	writeJSON(w, http.StatusCreated, sess)
 }
 
@@ -372,6 +396,7 @@ func (s *Server) forkSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.recordSessionAction(sess.ID, "session_fork", "forked from "+id)
+	s.broadcastSessionUpdate()
 	writeJSON(w, http.StatusCreated, sess)
 }
 


### PR DESCRIPTION
## Summary

- `createSession`、`deleteSession`、`forkSession`、`duplicateSession` の成功時に `broadcastSessionUpdate()` を呼び出すよう修正
- `broadcastSessionUpdate()` ヘルパーメソッドを追加：セッション一覧（external sessionsも含む）を取得し、WebSocket で `session_update` メッセージをブロードキャスト
- フロントエンドは既に `session_update` ハンドラを実装済みのため、バックエンドのみの変更

## Test plan

- [ ] セッション作成後、左ペインのセッション一覧が自動更新されることを確認
- [ ] セッション削除後、左ペインのセッション一覧から削除されることを確認
- [ ] セッションフォーク後、左ペインに新しいセッションが表示されることを確認
- [ ] `make build` でビルドが通ることを確認
- [ ] `make test` でテストが通ることを確認

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)