### PR TITLE
feat: バックグラウンドタスク完了通知の遅延を改善する定期通知機能を追加

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -130,6 +130,19 @@ func initManager(cfg *config.Config, port int, logger *slog.Logger) (session.Ses
 	}
 	mgr := session.NewManager(database, cfg.Session.ClaudeCommand, cfg.Claude.ClaudePermissionMode(), cfg.Server.Port, logger, cfg.Session.SystemPrompt)
 	mgr.SetCodexCommand(cfg.Session.CodexCommand)
+
+	// Configure background task notification interval
+	bgNotifyIntervalStr := cfg.Daemon.BackgroundTaskNotificationInterval
+	if bgNotifyIntervalStr == "" {
+		bgNotifyIntervalStr = "30m"
+	}
+	if d, err := time.ParseDuration(bgNotifyIntervalStr); err == nil {
+		mgr.SetNotifyInterval(d)
+	} else {
+		logger.Warn("invalid background_task_notification_interval, using default 30m", "value", bgNotifyIntervalStr, "error", err)
+		mgr.SetNotifyInterval(30 * time.Minute)
+	}
+
 	return mgr, database, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,8 @@ type ServerConfig struct {
 }
 
 type DaemonConfig struct {
-	Interval string `toml:"interval"`
+	Interval                          string `toml:"interval"`
+	BackgroundTaskNotificationInterval string `toml:"background_task_notification_interval"`
 }
 
 type SessionConfig struct {
@@ -85,7 +86,8 @@ func Default() *Config {
 			Port: 4321,
 		},
 		Daemon: DaemonConfig{
-			Interval: "30s",
+			Interval:                          "30s",
+			BackgroundTaskNotificationInterval: "30m",
 		},
 		Session: SessionConfig{
 			ClaudeCommand: "claude",

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -119,6 +120,11 @@ type HolderStreamProcess struct {
 
 	// modelCaptured is true once the model has been captured
 	modelCaptured bool
+
+	// Periodic notification fields
+	notifyInterval time.Duration              // notification interval for background tasks
+	notifyCancel   context.CancelFunc         // stops the periodic notification goroutine
+	sendKeysFunc   func(sessionID string, text string) error // injected send function
 
 	// Callbacks
 	onSessionID      func(cliSessionID string)
@@ -333,14 +339,24 @@ func (sp *HolderStreamProcess) readLoop() {
 			switch ev.Subtype {
 			case "task_started":
 				sp.mu.Lock()
+				prev := sp.runningTasks
 				sp.runningTasks++
 				sp.mu.Unlock()
+				// Start periodic notification when first background task begins
+				if prev == 0 {
+					sp.startPeriodicNotification()
+				}
 			case "task_notification":
 				sp.mu.Lock()
 				if sp.runningTasks > 0 {
 					sp.runningTasks--
 				}
+				remaining := sp.runningTasks
 				sp.mu.Unlock()
+				// Stop periodic notification when all background tasks complete
+				if remaining == 0 {
+					sp.stopPeriodicNotification()
+				}
 			}
 		}
 		switch ev.Type {
@@ -453,6 +469,20 @@ func (sp *HolderStreamProcess) SetOnHolderRestart(fn func(sessionID string, newP
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 	sp.onHolderRestart = fn
+}
+
+// SetNotifyInterval sets the interval for periodic background task notifications.
+func (sp *HolderStreamProcess) SetNotifyInterval(d time.Duration) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.notifyInterval = d
+}
+
+// SetSendKeysFunc sets the function used to send periodic notification messages.
+func (sp *HolderStreamProcess) SetSendKeysFunc(fn func(sessionID string, text string) error) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.sendKeysFunc = fn
 }
 
 // Send writes a user message to the holder's socket.
@@ -745,8 +775,67 @@ func (sp *HolderStreamProcess) ClearLines() {
 	sp.lines = nil
 }
 
+// stopPeriodicNotification cancels the periodic notification goroutine if running.
+func (sp *HolderStreamProcess) stopPeriodicNotification() {
+	sp.mu.Lock()
+	cancel := sp.notifyCancel
+	sp.notifyCancel = nil
+	sp.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// startPeriodicNotification starts a goroutine that periodically sends a message
+// to the parent session to trigger Claude Code to poll for background task completion.
+func (sp *HolderStreamProcess) startPeriodicNotification() {
+	if sp.notifyInterval <= 0 {
+		return
+	}
+
+	// Stop any existing notification goroutine first
+	sp.stopPeriodicNotification()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sp.mu.Lock()
+	sp.notifyCancel = cancel
+	sp.mu.Unlock()
+
+	go func() {
+		startTime := time.Now()
+		ticker := time.NewTicker(sp.notifyInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				elapsed := time.Since(startTime).Truncate(time.Minute)
+				sp.mu.RLock()
+				sid := sp.streamOpts.SessionID
+				tasks := sp.runningTasks
+				fn := sp.sendKeysFunc
+				sp.mu.RUnlock()
+
+				if tasks > 0 && fn != nil {
+					msg := fmt.Sprintf("バックグラウンドタスク実行中: %v経過", elapsed)
+					if err := fn(sid, msg); err != nil {
+						slog.Warn("periodic notification: sendKeys failed", "sessionId", sid, "error", err)
+					}
+				}
+			case <-ctx.Done():
+				return
+			case <-sp.done:
+				return
+			}
+		}
+	}()
+}
+
 // Stop sends a stop command to the holder.
 func (sp *HolderStreamProcess) Stop() {
+	sp.stopPeriodicNotification()
+
 	sp.mu.Lock()
 	sp.stopped = true
 	sp.mu.Unlock()

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -24,6 +24,7 @@ type Manager struct {
 	permissionMode  string
 	apiPort         int
 	systemPrompt    string
+	notifyInterval  time.Duration
 	streamProcesses map[string]*HolderStreamProcess
 	streamMu        sync.Mutex
 	// deletingSet tracks sessions currently being deleted so that auto-recovery
@@ -688,7 +689,9 @@ func (m *Manager) Delete(id string) error {
 
 // wireSessionIDCallback sets up the onSessionID callback on a stream process
 // so that when the CLI session ID is captured, it gets persisted to the DB.
+// It also wires periodic notification for background task tracking.
 func (m *Manager) wireSessionIDCallback(sessionID string, sp *HolderStreamProcess) {
+	m.wireNotifyCallback(sp)
 	sp.SetOnSessionID(func(cliSessionID string) {
 		if err := m.UpdateCliSessionID(sessionID, cliSessionID); err != nil {
 			m.logger.Error("failed to persist cli session id", "sessionId", sessionID, "cliSessionId", cliSessionID, "error", err)
@@ -782,6 +785,19 @@ func (m *Manager) stopStreamProcess(id string) {
 	m.streamMu.Unlock()
 	if ok {
 		sp.Stop()
+	}
+}
+
+// SetNotifyInterval sets the periodic notification interval for background task tracking.
+func (m *Manager) SetNotifyInterval(d time.Duration) {
+	m.notifyInterval = d
+}
+
+// wireNotifyCallback configures the periodic notification on a stream process.
+func (m *Manager) wireNotifyCallback(sp *HolderStreamProcess) {
+	if m.notifyInterval > 0 {
+		sp.SetNotifyInterval(m.notifyInterval)
+		sp.SetSendKeysFunc(m.SendKeys)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `DaemonConfig` に `background_task_notification_interval` フィールドを追加（デフォルト `30m`）
- `HolderStreamProcess` にバックグラウンドタスク実行中に定期的に親セッションへメッセージを送信する goroutine を追加
- `task_started` イベントで goroutine を起動（0→1 になったタイミング）、`task_notification` イベントで停止（1→0 になったタイミング）、`Stop()` でも確実に停止
- `Manager.SetNotifyInterval()` で設定し、`wireSessionIDCallback` 内で全 `HolderStreamProcess` に注入

## Test plan

- [ ] `make build` でビルドが通ること
- [ ] `make test` でテストが通ること
- [ ] config.toml に `background_task_notification_interval = "1m"` を設定し、バックグラウンドエージェントを起動すると定期的にメッセージが送られること

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)