### PR TITLE
fix: external検出で全agmux holderの子プロセスを自動除外

### DIFF
--- a/internal/session/external.go
+++ b/internal/session/external.go
@@ -146,21 +146,57 @@ func findExternalProcesses(managedPIDs []int) ([]ExternalProcess, error) {
 		return nil, fmt.Errorf("ps command failed: %w", err)
 	}
 
-	// Collect all PIDs in the agmux process tree
-	psOutput := string(out)
+	externalPIDs := findExternalPIDsFromPS(myPID, managedPIDs, string(out))
+
+	if len(externalPIDs) == 0 {
+		return nil, nil
+	}
+
+	// Get CWD for each external process via lsof
+	var results []ExternalProcess
+	for _, p := range externalPIDs {
+		cwd := getCWD(p.PID)
+		results = append(results, ExternalProcess{
+			PID:      p.PID,
+			CWD:      cwd,
+			Provider: p.Provider,
+		})
+	}
+
+	return results, nil
+}
+
+type pidWithProvider struct {
+	PID      int
+	Provider ProviderName
+}
+
+// findExternalPIDsFromPS finds claude/codex PIDs that are not in the agmux process tree.
+// myPID is the current process PID (agmux server), managedPIDs are holder PIDs to exclude,
+// and psOutput is the raw output of "ps -eo pid,ppid,comm".
+// This function is extracted for testability.
+func findExternalPIDsFromPS(myPID int, managedPIDs []int, psOutput string) []pidWithProvider {
+	// Collect all PIDs in the agmux process tree (server and its direct children)
 	agmuxPIDs := collectProcessTree(myPID, psOutput)
 
-	// Also exclude process trees rooted at managed holder PIDs
+	// Also exclude process trees rooted at managed holder PIDs from DB
 	for _, pid := range managedPIDs {
 		for k, v := range collectProcessTree(pid, psOutput) {
 			agmuxPIDs[k] = v
 		}
 	}
 
-	type pidWithProvider struct {
-		PID      int
-		Provider ProviderName
+	// Additionally, auto-detect all agmux holder processes in ps output.
+	// Holder processes have PPID=1 (detached via Setsid+Release) and their comm
+	// basename is "agmux". Any claude/codex spawned under ANY agmux holder
+	// should not be classified as external, even if the holder isn't in the DB
+	// (e.g., from a different agmux instance or after a server restart race).
+	for _, holderPID := range detectAgmuxHolderPIDs(psOutput) {
+		for k, v := range collectProcessTree(holderPID, psOutput) {
+			agmuxPIDs[k] = v
+		}
 	}
+
 	var externalPIDs []pidWithProvider
 	for _, line := range strings.Split(psOutput, "\n") {
 		fields := strings.Fields(line)
@@ -183,22 +219,39 @@ func findExternalProcesses(managedPIDs []int) ([]ExternalProcess, error) {
 		externalPIDs = append(externalPIDs, pidWithProvider{PID: pid, Provider: provider})
 	}
 
-	if len(externalPIDs) == 0 {
-		return nil, nil
-	}
+	return externalPIDs
+}
 
-	// Get CWD for each external process via lsof
-	var results []ExternalProcess
-	for _, p := range externalPIDs {
-		cwd := getCWD(p.PID)
-		results = append(results, ExternalProcess{
-			PID:      p.PID,
-			CWD:      cwd,
-			Provider: p.Provider,
-		})
+// detectAgmuxHolderPIDs finds all detached agmux holder processes in ps output.
+// Holder processes have PPID=1 (detached via Setsid+Release) and comm basename "agmux".
+// This handles the case where holders are from different agmux server instances
+// or where the DB holder_pid hasn't been updated yet after a server restart.
+func detectAgmuxHolderPIDs(psOutput string) []int {
+	var holders []int
+	for _, line := range strings.Split(psOutput, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, err1 := strconv.Atoi(fields[0])
+		ppid, err2 := strconv.Atoi(fields[1])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		// Holder processes are detached (PPID=1) agmux processes
+		if ppid != 1 {
+			continue
+		}
+		comm := fields[2]
+		base := comm
+		if idx := strings.LastIndex(comm, "/"); idx >= 0 {
+			base = comm[idx+1:]
+		}
+		if base == "agmux" {
+			holders = append(holders, pid)
+		}
 	}
-
-	return results, nil
+	return holders
 }
 
 // collectProcessTree collects all PIDs that are descendants of rootPID.

--- a/internal/session/external_test.go
+++ b/internal/session/external_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"sort"
 	"testing"
 )
 
@@ -130,6 +131,262 @@ func TestProjectNameFromPath(t *testing.T) {
 		got := projectNameFromPath(tt.path)
 		if got != tt.want {
 			t.Errorf("projectNameFromPath(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+// extractPIDs is a helper to get sorted PID list from findExternalPIDsFromPS result.
+func extractPIDs(result []pidWithProvider) []int {
+	pids := make([]int, 0, len(result))
+	for _, p := range result {
+		pids = append(pids, p.PID)
+	}
+	sort.Ints(pids)
+	return pids
+}
+
+func TestFindExternalPIDsFromPS_HolderAlive(t *testing.T) {
+	// Scenario: holder is alive, its claude child should be excluded.
+	// Process tree:
+	//   server (1000) -> (nothing; holders are detached)
+	//   holder (200, PPID=1) -> claude (201, PPID=200) [managed]
+	//   external-claude (300, PPID=1) [not managed]
+	psOutput := `  PID  PPID COMM
+    1     0 /sbin/launchd
+ 1000     1 /Users/user/go/bin/agmux-server
+  200     1 /Users/user/go/bin/agmux
+  201   200 /Users/user/.local/bin/claude
+  300     1 /Users/user/.local/bin/claude`
+
+	myPID := 1000
+	managedPIDs := []int{200} // holder PID from DB
+
+	result := findExternalPIDsFromPS(myPID, managedPIDs, psOutput)
+	pids := extractPIDs(result)
+
+	if len(pids) != 1 || pids[0] != 300 {
+		t.Errorf("expected [300], got %v", pids)
+	}
+}
+
+func TestFindExternalPIDsFromPS_HolderDead_ChildReparented(t *testing.T) {
+	// Scenario: holder died, its child claude got reparented to PID=1.
+	// The DB still has the old holder PID (200) but it's not in ps output.
+	// The reparented claude (201, now PPID=1) should be treated as external
+	// because we can't know it was previously managed.
+	psOutput := `  PID  PPID COMM
+    1     0 /sbin/launchd
+ 1000     1 /Users/user/go/bin/agmux-server
+  201     1 /Users/user/.local/bin/claude`
+
+	myPID := 1000
+	managedPIDs := []int{200} // holder PID from DB (dead)
+
+	result := findExternalPIDsFromPS(myPID, managedPIDs, psOutput)
+	pids := extractPIDs(result)
+
+	// PID 201 is reparented to init, former holder 200 is dead.
+	// We cannot link 201 to the dead holder 200, so 201 appears external.
+	// This is expected behavior: the holder is dead, we can't exclude orphans.
+	if len(pids) != 1 || pids[0] != 201 {
+		t.Errorf("expected [201] (reparented orphan is external), got %v", pids)
+	}
+}
+
+func TestFindExternalPIDsFromPS_MultipleHolders(t *testing.T) {
+	// Scenario: two managed holders (200, 400), each with a claude child.
+	// One additional external claude (600).
+	psOutput := `  PID  PPID COMM
+    1     0 /sbin/launchd
+ 1000     1 /Users/user/go/bin/agmux-server
+  200     1 /Users/user/go/bin/agmux
+  201   200 /Users/user/.local/bin/claude
+  400     1 /Users/user/go/bin/agmux
+  401   400 /Users/user/.local/bin/claude
+  600     1 /Users/user/.local/bin/claude`
+
+	myPID := 1000
+	managedPIDs := []int{200, 400}
+
+	result := findExternalPIDsFromPS(myPID, managedPIDs, psOutput)
+	pids := extractPIDs(result)
+
+	if len(pids) != 1 || pids[0] != 600 {
+		t.Errorf("expected [600], got %v", pids)
+	}
+}
+
+func TestFindExternalPIDsFromPS_DeepTree(t *testing.T) {
+	// Scenario: holder spawns a node process which spawns codex.
+	// All should be excluded (BFS traverses multiple levels).
+	psOutput := `  PID  PPID COMM
+    1     0 /sbin/launchd
+ 1000     1 /Users/user/go/bin/agmux-server
+  200     1 /Users/user/go/bin/agmux
+  201   200 node
+  202   201 /Users/user/.nodebrew/node/v22/lib/node_modules/codex/codex
+  500     1 /Users/user/.local/bin/claude`
+
+	myPID := 1000
+	managedPIDs := []int{200}
+
+	result := findExternalPIDsFromPS(myPID, managedPIDs, psOutput)
+	pids := extractPIDs(result)
+
+	// PID 202 (codex via node) should be excluded; only 500 (external claude) should appear
+	if len(pids) != 1 || pids[0] != 500 {
+		t.Errorf("expected [500], got %v", pids)
+	}
+}
+
+func TestFindExternalPIDsFromPS_FullPathComm(t *testing.T) {
+	// Scenario: comm field contains full paths (as seen on macOS).
+	// detectProvider should still work via basename extraction.
+	psOutput := `  PID  PPID COMM
+    1     0 /sbin/launchd
+ 1000     1 /Users/user/go/bin/agmux
+  200     1 /Users/user/go/bin/agmux
+  201   200 /Users/user/.local/bin/claude
+  300     1 /Users/user/.local/bin/claude
+  400     1 /long/path/to/bin/codex`
+
+	myPID := 1000
+	managedPIDs := []int{200}
+
+	result := findExternalPIDsFromPS(myPID, managedPIDs, psOutput)
+	pids := extractPIDs(result)
+
+	// PID 201 is managed (child of holder 200)
+	// PID 300 (claude) and PID 400 (codex) are external
+	if len(pids) != 2 {
+		t.Errorf("expected 2 external PIDs, got %v", pids)
+	}
+	if pids[0] != 300 || pids[1] != 400 {
+		t.Errorf("expected [300 400], got %v", pids)
+	}
+}
+
+func TestFindExternalPIDsFromPS_NilManagedPIDs(t *testing.T) {
+	// Scenario: no managed PIDs (ManagedHolderPIDs returns nil/empty).
+	// All claude/codex processes not in server tree should be external.
+	psOutput := `  PID  PPID COMM
+    1     0 /sbin/launchd
+ 1000     1 /Users/user/go/bin/agmux-server
+  200     1 /Users/user/.local/bin/claude
+  201   200 node`
+
+	myPID := 1000
+	managedPIDs := []int{} // empty: no holder PIDs in DB
+
+	result := findExternalPIDsFromPS(myPID, managedPIDs, psOutput)
+	pids := extractPIDs(result)
+
+	if len(pids) != 1 || pids[0] != 200 {
+		t.Errorf("expected [200], got %v", pids)
+	}
+}
+
+func TestFindExternalPIDsFromPS_ServerChildrenExcluded(t *testing.T) {
+	// Scenario: the server itself has claude as a direct child (unusual but possible).
+	// That claude should be excluded since it's in the server's tree.
+	psOutput := `  PID  PPID COMM
+    1     0 /sbin/launchd
+ 1000     1 /Users/user/go/bin/agmux-server
+  101  1000 /Users/user/.local/bin/claude
+  200     1 /Users/user/.local/bin/claude`
+
+	myPID := 1000
+	managedPIDs := []int{}
+
+	result := findExternalPIDsFromPS(myPID, managedPIDs, psOutput)
+	pids := extractPIDs(result)
+
+	// 101 is a direct child of server, so excluded; 200 is external
+	if len(pids) != 1 || pids[0] != 200 {
+		t.Errorf("expected [200], got %v", pids)
+	}
+}
+
+func TestFindExternalPIDsFromPS_HolderNotInDB(t *testing.T) {
+	// Scenario (core bug): an agmux holder (PPID=1) and its claude child exist,
+	// but the holder PID is NOT in managedPIDs (e.g., different server instance,
+	// or holder_pid not yet written to DB).
+	// The claude child should still be excluded because detectAgmuxHolderPIDs
+	// auto-detects all PPID=1 agmux processes as holders.
+	psOutput := `  PID  PPID COMM
+    1     0 /sbin/launchd
+ 1000     1 /Users/user/go/bin/agmux-server
+  200     1 /Users/user/go/bin/agmux
+  201   200 /Users/user/.local/bin/claude
+  999     1 /Users/user/.local/bin/claude`
+
+	myPID := 1000
+	managedPIDs := []int{} // holder 200 NOT in DB
+
+	result := findExternalPIDsFromPS(myPID, managedPIDs, psOutput)
+	pids := extractPIDs(result)
+
+	// PID 201 should be excluded (its parent 200 is an agmux holder auto-detected by PPID=1)
+	// PID 999 is truly external (PPID=1 but not a child of any agmux holder)
+	if len(pids) != 1 || pids[0] != 999 {
+		t.Errorf("expected [999] (only truly external claude), got %v (holder-child 201 should be excluded)", pids)
+	}
+}
+
+func TestFindExternalPIDsFromPS_MultipleAgmuxInstances(t *testing.T) {
+	// Scenario: two agmux server instances, each with their own holders.
+	// Server 1000 tracks holder 200 in DB. Server 2000 tracks holder 300 in DB
+	// (but 2000 and 300 are from a different instance, not in our managedPIDs).
+	// Both sets of claude children should be excluded.
+	psOutput := `  PID  PPID COMM
+    1     0 /sbin/launchd
+ 1000     1 /Users/user/go/bin/agmux-server
+ 2000     1 /Users/user/go/bin/agmux-server
+  200     1 /Users/user/go/bin/agmux
+  201   200 /Users/user/.local/bin/claude
+  300     1 /Users/user/go/bin/agmux
+  301   300 /Users/user/.local/bin/claude
+  999     1 /Users/user/.local/bin/claude`
+
+	myPID := 1000
+	managedPIDs := []int{200} // only our instance's holder in DB
+
+	result := findExternalPIDsFromPS(myPID, managedPIDs, psOutput)
+	pids := extractPIDs(result)
+
+	// Both 201 (from our holder 200) and 301 (from other instance's holder 300) should be excluded.
+	// Only 999 (no agmux holder parent) is truly external.
+	if len(pids) != 1 || pids[0] != 999 {
+		t.Errorf("expected [999], got %v", pids)
+	}
+}
+
+func TestDetectAgmuxHolderPIDs(t *testing.T) {
+	psOutput := `  PID  PPID COMM
+    1     0 /sbin/launchd
+ 1000     1 /Users/user/go/bin/agmux-server
+  200     1 /Users/user/go/bin/agmux
+  201   200 /Users/user/.local/bin/claude
+  300     1 agmux
+  400   100 /Users/user/go/bin/agmux
+  500     1 /Users/user/.local/bin/claude`
+
+	holders := detectAgmuxHolderPIDs(psOutput)
+	sort.Ints(holders)
+
+	// 200: PPID=1, comm basename "agmux" -> holder
+	// 300: PPID=1, comm "agmux" -> holder
+	// 400: PPID=100 (not 1) -> not a holder (it's a server or child)
+	// 1000: PPID=1, comm "agmux-server" (not "agmux") -> not a holder
+	expected := []int{200, 300}
+	if len(holders) != len(expected) {
+		t.Errorf("expected %v, got %v", expected, holders)
+		return
+	}
+	for i, h := range holders {
+		if h != expected[i] {
+			t.Errorf("expected %v, got %v", expected, holders)
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- ExternalDetectorが自サーバーDBのholder_pidのみ参照していたため、別agmuxインスタンスのholderの子プロセスがexternalと誤判定されていた
- `detectAgmuxHolderPIDs()` を追加し、ps出力からPPID=1かつcomm basename="agmux"のプロセスを全て自動検出して除外対象に
- テスト用に `findExternalPIDsFromPS()` を抽出し、9テストケースを追加

## Test plan

- [x] `make test` 全テストPASS
- [x] 新規テスト9件（holder alive/dead/multiple/deep tree/full path comm/nil managed PIDs/server children excluded/holder not in DB/multiple instances）

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)