### PR TITLE
fix(session): DBに記録されていないholderの子プロセスをexternal検出から除外

### DIFF
--- a/internal/session/external.go
+++ b/internal/session/external.go
@@ -135,6 +135,31 @@ func (d *ExternalDetector) detect() {
 	d.mu.Unlock()
 }
 
+// findHolderPIDsFromPS scans ps output (pid,args format) to find all agmux holder processes.
+// This catches holder processes whose PIDs are not yet (or no longer) recorded in the DB.
+// A process is considered a holder if its args contain the agmux executable path followed by "holder".
+func findHolderPIDsFromPS(psArgsOutput string, agmuxExe string) []int {
+	var pids []int
+	for _, line := range strings.Split(psArgsOutput, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		// fields[1] is the executable path (first token of args)
+		// fields[2] is the first argument - should be "holder" for holder processes
+		exe := fields[1]
+		subcommand := fields[2]
+		if exe == agmuxExe && subcommand == "holder" {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
 // findExternalProcesses finds Claude and Codex processes not managed by this agmux instance.
 // managedPIDs are additional root PIDs (e.g. holder processes) whose process trees should be excluded.
 func findExternalProcesses(managedPIDs []int) ([]ExternalProcess, error) {
@@ -150,10 +175,27 @@ func findExternalProcesses(managedPIDs []int) ([]ExternalProcess, error) {
 	psOutput := string(out)
 	agmuxPIDs := collectProcessTree(myPID, psOutput)
 
-	// Also exclude process trees rooted at managed holder PIDs
+	// Also exclude process trees rooted at managed holder PIDs (from DB)
 	for _, pid := range managedPIDs {
 		for k, v := range collectProcessTree(pid, psOutput) {
 			agmuxPIDs[k] = v
+		}
+	}
+
+	// Additionally, scan process args to find holder processes not in the DB.
+	// This handles cases where a holder was restarted and the old holder PID is no longer
+	// in the DB, but the old holder and its children are still running.
+	if agmuxExe, err := os.Executable(); err == nil {
+		argsOut, err := exec.Command("ps", "-eo", "pid,args").Output()
+		if err == nil {
+			holderPIDs := findHolderPIDsFromPS(string(argsOut), agmuxExe)
+			for _, pid := range holderPIDs {
+				if !agmuxPIDs[pid] {
+					for k, v := range collectProcessTree(pid, psOutput) {
+						agmuxPIDs[k] = v
+					}
+				}
+			}
 		}
 	}
 

--- a/internal/session/external_test.go
+++ b/internal/session/external_test.go
@@ -4,6 +4,90 @@ import (
 	"testing"
 )
 
+func TestFindHolderPIDsFromPS(t *testing.T) {
+	const agmuxExe = "/usr/local/bin/agmux"
+	psArgsOutput := `  PID ARGS
+    1 /sbin/launchd
+ 1000 /usr/local/bin/agmux holder --session-id abc123 --project-path /home/user/project -- /usr/local/bin/claude
+ 1001 /usr/local/bin/agmux server
+ 1002 /usr/local/bin/agmux
+ 1003 /usr/local/bin/notAgmux holder --session-id xyz
+ 1004 /usr/local/bin/claude
+ 2000 /usr/local/bin/agmux holder --session-id def456 --project-path /home/user/other -- /usr/local/bin/codex`
+
+	pids := findHolderPIDsFromPS(psArgsOutput, agmuxExe)
+
+	pidSet := make(map[int]bool)
+	for _, pid := range pids {
+		pidSet[pid] = true
+	}
+
+	if !pidSet[1000] {
+		t.Error("expected PID 1000 (agmux holder) to be found")
+	}
+	if !pidSet[2000] {
+		t.Error("expected PID 2000 (agmux holder) to be found")
+	}
+	if pidSet[1001] {
+		t.Error("PID 1001 (agmux server) should not be found")
+	}
+	if pidSet[1002] {
+		t.Error("PID 1002 (bare agmux) should not be found")
+	}
+	if pidSet[1003] {
+		t.Error("PID 1003 (different binary) should not be found")
+	}
+	if pidSet[1004] {
+		t.Error("PID 1004 (claude) should not be found")
+	}
+}
+
+// TestHolderChildrenExcludedFromExternalDetection verifies that children of holder processes
+// that are no longer tracked in the DB (e.g. after a session restart) are still excluded.
+// This is a regression test for the bug where stale holders' claude/codex children appeared external.
+func TestHolderChildrenExcludedFromExternalDetection(t *testing.T) {
+	// Simulate the scenario:
+	// - holder PID 35080 is running (not in DB because session was restarted)
+	// - holder PID 35080's child claude PID 35081 should NOT appear as external
+	//
+	// We test the core logic by verifying collectProcessTree correctly includes
+	// the grandchildren when given the right psOutput, and that findHolderPIDsFromPS
+	// correctly identifies the stale holder.
+
+	const agmuxExe = "/usr/local/bin/agmux"
+
+	// ps -eo pid,ppid,comm output
+	psCommOutput := `  PID  PPID COMM
+    1     0 launchd
+35080     1 /usr/local/bin/agmux
+35081 35080 /usr/local/bin/claude`
+
+	// ps -eo pid,args output - holder process identified by args
+	psArgsOutput := `  PID ARGS
+    1 /sbin/launchd
+35080 /usr/local/bin/agmux holder --session-id XYZ --project-path /home/user/project -- /usr/local/bin/claude
+35081 /usr/local/bin/claude -p --verbose`
+
+	// Verify findHolderPIDsFromPS finds the stale holder
+	holderPIDs := findHolderPIDsFromPS(psArgsOutput, agmuxExe)
+	holderPIDSet := make(map[int]bool)
+	for _, pid := range holderPIDs {
+		holderPIDSet[pid] = true
+	}
+	if !holderPIDSet[35080] {
+		t.Fatal("findHolderPIDsFromPS should find stale holder PID 35080")
+	}
+
+	// Verify collectProcessTree correctly finds the claude child
+	tree := collectProcessTree(35080, psCommOutput)
+	if !tree[35080] {
+		t.Error("process tree should include holder PID 35080")
+	}
+	if !tree[35081] {
+		t.Error("process tree should include claude child PID 35081 (regression: this was the bug)")
+	}
+}
+
 func TestCollectProcessTree(t *testing.T) {
 	// Simulated ps output
 	psOutput := `  PID  PPID COMM


### PR DESCRIPTION
## Summary
Closes #582

- セッション再起動時、古いholderプロセスのPIDがDBから消えるが、古いholderとその子プロセス(claude/codex)は生き続ける
- `findExternalProcesses`はDBの`holder_pid`のみを参照していたため、古いholderの子がexternalとして誤検出されていた
- `ps -eo pid,args`をスキャンして全`agmux holder`プロセスを発見する`findHolderPIDsFromPS`を追加し、DB外のholderも除外対象に含める

## Test plan
- [x] `TestFindHolderPIDsFromPS`: psArgsパースの正確性を検証
- [x] `TestHolderChildrenExcludedFromExternalDetection`: stale holderの子が除外される回帰テスト
- [x] `go test ./internal/session/` 全テストパス
- [x] `go build ./...` コンパイル成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)