### PR TITLE
feat: バージョン情報をSettings画面に表示する

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -202,6 +202,7 @@ func serveCmd() *cobra.Command {
 			var srv *server.Server
 
 			srv = server.New(mgr, hub, devMode, logger, database, port)
+			srv.SetVersion(version, commit, buildDate)
 
 			// Wire managed holder PIDs into external detector so holder
 			// processes and their children are not detected as external.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -210,7 +210,7 @@ export interface PromptTemplate {
 export interface AppConfig {
   server: { port: number };
   daemon: { interval: string };
-  session: { claudeCommand: string; defaultRole?: string; defaultModel?: string };
+  session: { claudeCommand: string };
   devMode: boolean;
   prompts?: { systemPrompt: string };
   templates: RoleTemplate[];

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -51,6 +51,9 @@ export const api = {
   getCodexVersion: () =>
     request<{ version: string }>("/codex/version"),
 
+  getAgmuxVersion: () =>
+    request<{ version: string; commit: string; buildDate: string }>("/version"),
+
   getSession: (id: string) => request<Session>(`/sessions/${id}`),
 
   stopSession: (id: string) =>
@@ -207,7 +210,7 @@ export interface PromptTemplate {
 export interface AppConfig {
   server: { port: number };
   daemon: { interval: string };
-  session: { claudeCommand: string };
+  session: { claudeCommand: string; defaultRole?: string; defaultModel?: string };
   devMode: boolean;
   prompts?: { systemPrompt: string };
   templates: RoleTemplate[];

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -41,7 +41,21 @@ export function CreateSession({ onClose, onCreate }: Props) {
       .then(setRecentProjects)
       .catch(() => setRecentProjects([]));
     api.getConfig()
-      .then((cfg) => setTemplates(cfg.templates || []))
+      .then((cfg) => {
+        setTemplates(cfg.templates || []);
+        if (cfg.session.defaultRole) {
+          setSelectedTemplate(cfg.session.defaultRole);
+          const tmpl = (cfg.templates || []).find((t) => t.name === cfg.session.defaultRole);
+          if (tmpl) {
+            if (tmpl.provider) setProvider(tmpl.provider);
+            if (tmpl.model) setModel(tmpl.model);
+            if (tmpl.systemPrompt) setSystemPrompt(tmpl.systemPrompt);
+          }
+        }
+        if (cfg.session.defaultModel) {
+          setModel(cfg.session.defaultModel);
+        }
+      })
       .catch(() => setTemplates([]));
   }, []);
 

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -43,18 +43,6 @@ export function CreateSession({ onClose, onCreate }: Props) {
     api.getConfig()
       .then((cfg) => {
         setTemplates(cfg.templates || []);
-        if (cfg.session.defaultRole) {
-          setSelectedTemplate(cfg.session.defaultRole);
-          const tmpl = (cfg.templates || []).find((t) => t.name === cfg.session.defaultRole);
-          if (tmpl) {
-            if (tmpl.provider) setProvider(tmpl.provider);
-            if (tmpl.model) setModel(tmpl.model);
-            if (tmpl.systemPrompt) setSystemPrompt(tmpl.systemPrompt);
-          }
-        }
-        if (cfg.session.defaultModel) {
-          setModel(cfg.session.defaultModel);
-        }
       })
       .catch(() => setTemplates([]));
   }, []);

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -90,28 +90,6 @@ export function ConfigPage() {
               className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
             />
           </Field>
-          <Field label="Default Role (optional)">
-            <input
-              type="text"
-              value={config.session.defaultRole || ""}
-              onChange={(e) =>
-                setConfig({ ...config, session: { ...config.session, defaultRole: e.target.value || undefined } })
-              }
-              placeholder="Template name"
-              className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
-            />
-          </Field>
-          <Field label="Default Model (optional)">
-            <input
-              type="text"
-              value={config.session.defaultModel || ""}
-              onChange={(e) =>
-                setConfig({ ...config, session: { ...config.session, defaultModel: e.target.value || undefined } })
-              }
-              placeholder="e.g. claude-sonnet-4-5"
-              className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
-            />
-          </Field>
         </Section>
 
         <NotificationStatus />

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate, useLoaderData } from "react-router-dom";
 import { api } from "../api/client";
 import type { AppConfig, RoleTemplate, PromptTemplate } from "../api/client";
@@ -90,6 +90,28 @@ export function ConfigPage() {
               className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
             />
           </Field>
+          <Field label="Default Role (optional)">
+            <input
+              type="text"
+              value={config.session.defaultRole || ""}
+              onChange={(e) =>
+                setConfig({ ...config, session: { ...config.session, defaultRole: e.target.value || undefined } })
+              }
+              placeholder="Template name"
+              className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
+            />
+          </Field>
+          <Field label="Default Model (optional)">
+            <input
+              type="text"
+              value={config.session.defaultModel || ""}
+              onChange={(e) =>
+                setConfig({ ...config, session: { ...config.session, defaultModel: e.target.value || undefined } })
+              }
+              placeholder="e.g. claude-sonnet-4-5"
+              className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
+            />
+          </Field>
         </Section>
 
         <NotificationStatus />
@@ -129,6 +151,8 @@ export function ConfigPage() {
           </div>
         )}
 
+        <VersionInfo />
+
         <div className="pt-4">
           <button
             onClick={handleSave}
@@ -139,6 +163,23 @@ export function ConfigPage() {
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function VersionInfo() {
+  const [info, setInfo] = useState<{ version: string; commit: string; buildDate: string } | null>(null);
+
+  useEffect(() => {
+    api.getAgmuxVersion().then(setInfo).catch(() => {});
+  }, []);
+
+  if (!info) return null;
+
+  return (
+    <div className="text-xs text-gray-400 space-y-0.5">
+      <div>Version: {info.version} ({info.commit})</div>
+      <div>Build date: {info.buildDate}</div>
     </div>
   );
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,8 +45,6 @@ type SessionConfig struct {
 	ClaudeCommand string `toml:"claude_command"`
 	CodexCommand  string `toml:"codex_command"`
 	SystemPrompt  string `toml:"system_prompt"`
-	DefaultRole   string `toml:"default_role" json:"default_role,omitempty"`
-	DefaultModel  string `toml:"default_model" json:"default_model,omitempty"`
 }
 
 // DefaultPermissionMode is the default Claude CLI permission mode.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,8 @@ type SessionConfig struct {
 	ClaudeCommand string `toml:"claude_command"`
 	CodexCommand  string `toml:"codex_command"`
 	SystemPrompt  string `toml:"system_prompt"`
+	DefaultRole   string `toml:"default_role" json:"default_role,omitempty"`
+	DefaultModel  string `toml:"default_model" json:"default_model,omitempty"`
 }
 
 // DefaultPermissionMode is the default Claude CLI permission mode.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1056,8 +1056,6 @@ type configDaemonJSON struct {
 }
 type configSessionJSON struct {
 	ClaudeCommand string `json:"claudeCommand"`
-	DefaultRole   string `json:"defaultRole,omitempty"`
-	DefaultModel  string `json:"defaultModel,omitempty"`
 }
 type configClaudeJSON struct {
 	PermissionMode string `json:"permissionMode"`
@@ -1077,7 +1075,7 @@ func configToJSON(cfg *config.Config) configJSON {
 	return configJSON{
 		Server:          configServerJSON{Port: cfg.Server.Port},
 		Daemon:          configDaemonJSON{Interval: cfg.Daemon.Interval},
-		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand, DefaultRole: cfg.Session.DefaultRole, DefaultModel: cfg.Session.DefaultModel},
+		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand},
 		Claude:          configClaudeJSON{PermissionMode: cfg.Claude.ClaudePermissionMode()},
 		DevMode:         cfg.DevMode,
 		Templates:       templates,
@@ -1099,7 +1097,7 @@ func jsonToConfig(j configJSON) *config.Config {
 	return &config.Config{
 		Server:          config.ServerConfig{Port: j.Server.Port},
 		Daemon:          config.DaemonConfig{Interval: j.Daemon.Interval},
-		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand, DefaultRole: j.Session.DefaultRole, DefaultModel: j.Session.DefaultModel},
+		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand},
 		Claude:          config.ClaudeConfig{PermissionMode: j.Claude.PermissionMode},
 		DevMode:         j.DevMode,
 		Templates:       templates,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,6 +40,9 @@ type Server struct {
 	otelReceiver     *otel.Receiver
 	sqlDB            *sql.DB
 	externalDetector *session.ExternalDetector
+	version          string
+	commit           string
+	buildDate        string
 }
 
 func New(sessions session.SessionService, hub *Hub, devMode bool, logger *slog.Logger, sqlDB *sql.DB, port int) *Server {
@@ -163,6 +166,7 @@ func (s *Server) setupRoutes() {
 		r.Get("/metrics", s.getMetrics)
 		r.Get("/metrics/summary", s.getMetricsSummary)
 		r.Get("/metrics/events", s.getMetricsEvents)
+		r.Get("/version", s.getVersion)
 
 	})
 
@@ -1052,6 +1056,8 @@ type configDaemonJSON struct {
 }
 type configSessionJSON struct {
 	ClaudeCommand string `json:"claudeCommand"`
+	DefaultRole   string `json:"defaultRole,omitempty"`
+	DefaultModel  string `json:"defaultModel,omitempty"`
 }
 type configClaudeJSON struct {
 	PermissionMode string `json:"permissionMode"`
@@ -1071,7 +1077,7 @@ func configToJSON(cfg *config.Config) configJSON {
 	return configJSON{
 		Server:          configServerJSON{Port: cfg.Server.Port},
 		Daemon:          configDaemonJSON{Interval: cfg.Daemon.Interval},
-		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand},
+		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand, DefaultRole: cfg.Session.DefaultRole, DefaultModel: cfg.Session.DefaultModel},
 		Claude:          configClaudeJSON{PermissionMode: cfg.Claude.ClaudePermissionMode()},
 		DevMode:         cfg.DevMode,
 		Templates:       templates,
@@ -1093,7 +1099,7 @@ func jsonToConfig(j configJSON) *config.Config {
 	return &config.Config{
 		Server:          config.ServerConfig{Port: j.Server.Port},
 		Daemon:          config.DaemonConfig{Interval: j.Daemon.Interval},
-		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand},
+		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand, DefaultRole: j.Session.DefaultRole, DefaultModel: j.Session.DefaultModel},
 		Claude:          config.ClaudeConfig{PermissionMode: j.Claude.PermissionMode},
 		DevMode:         j.DevMode,
 		Templates:       templates,
@@ -1378,6 +1384,22 @@ func (s *Server) getClaudeModels(w http.ResponseWriter, r *http.Request) {
 		{ID: "claude-haiku-4-5", Name: "Claude Haiku 4.5"},
 	}
 	writeJSON(w, http.StatusOK, models)
+}
+
+// SetVersion stores the build-time version info so it can be served via /api/version.
+func (s *Server) SetVersion(version, commit, buildDate string) {
+	s.version = version
+	s.commit = commit
+	s.buildDate = buildDate
+}
+
+// getVersion returns the agmux build version info.
+func (s *Server) getVersion(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{
+		"version":   s.version,
+		"commit":    s.commit,
+		"buildDate": s.buildDate,
+	})
 }
 
 // getClaudeVersion runs "claude --version" and returns the parsed version string.


### PR DESCRIPTION
## Summary

- `GET /api/version` エンドポイントを追加（version/commit/buildDate を返す）
- `Server.SetVersion()` メソッドで `main.go` からビルド時変数を注入
- `ConfigPage.tsx` に `VersionInfo` コンポーネントを追加し、Config path の下に表示
- フロントエンド API クライアントに `getAgmuxVersion()` を追加

## Test plan

- [ ] `make build` が通ること
- [ ] `make test` が通ること
- [ ] Settings 画面を開いて Version/Build date が表示されること
- [ ] `GET /api/version` が `{"version":"...","commit":"...","buildDate":"..."}` を返すこと

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)