### PR TITLE
feat: ロールとモデルのデフォルト値を設定できるようにする

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -210,7 +210,7 @@ export interface PromptTemplate {
 export interface AppConfig {
   server: { port: number };
   daemon: { interval: string };
-  session: { claudeCommand: string };
+  session: { claudeCommand: string; defaultRole?: string; defaultModel?: string };
   devMode: boolean;
   prompts?: { systemPrompt: string };
   templates: RoleTemplate[];

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -43,6 +43,18 @@ export function CreateSession({ onClose, onCreate }: Props) {
     api.getConfig()
       .then((cfg) => {
         setTemplates(cfg.templates || []);
+        if (cfg.session.defaultRole) {
+          setSelectedTemplate(cfg.session.defaultRole);
+          const tmpl = (cfg.templates || []).find((t) => t.name === cfg.session.defaultRole);
+          if (tmpl) {
+            if (tmpl.provider) setProvider(tmpl.provider);
+            if (tmpl.model) setModel(tmpl.model);
+            if (tmpl.systemPrompt) setSystemPrompt(tmpl.systemPrompt);
+          }
+        }
+        if (cfg.session.defaultModel) {
+          setModel(cfg.session.defaultModel);
+        }
       })
       .catch(() => setTemplates([]));
   }, []);

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -90,6 +90,28 @@ export function ConfigPage() {
               className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
             />
           </Field>
+          <Field label="Default Role (optional)">
+            <input
+              type="text"
+              value={config.session.defaultRole || ""}
+              onChange={(e) =>
+                setConfig({ ...config, session: { ...config.session, defaultRole: e.target.value || undefined } })
+              }
+              placeholder="Template name"
+              className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
+            />
+          </Field>
+          <Field label="Default Model (optional)">
+            <input
+              type="text"
+              value={config.session.defaultModel || ""}
+              onChange={(e) =>
+                setConfig({ ...config, session: { ...config.session, defaultModel: e.target.value || undefined } })
+              }
+              placeholder="e.g. claude-sonnet-4-5"
+              className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
+            />
+          </Field>
         </Section>
 
         <NotificationStatus />

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,8 @@ type SessionConfig struct {
 	ClaudeCommand string `toml:"claude_command"`
 	CodexCommand  string `toml:"codex_command"`
 	SystemPrompt  string `toml:"system_prompt"`
+	DefaultRole   string `toml:"default_role" json:"default_role,omitempty"`
+	DefaultModel  string `toml:"default_model" json:"default_model,omitempty"`
 }
 
 // DefaultPermissionMode is the default Claude CLI permission mode.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1056,6 +1056,8 @@ type configDaemonJSON struct {
 }
 type configSessionJSON struct {
 	ClaudeCommand string `json:"claudeCommand"`
+	DefaultRole   string `json:"defaultRole,omitempty"`
+	DefaultModel  string `json:"defaultModel,omitempty"`
 }
 type configClaudeJSON struct {
 	PermissionMode string `json:"permissionMode"`
@@ -1075,7 +1077,7 @@ func configToJSON(cfg *config.Config) configJSON {
 	return configJSON{
 		Server:          configServerJSON{Port: cfg.Server.Port},
 		Daemon:          configDaemonJSON{Interval: cfg.Daemon.Interval},
-		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand},
+		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand, DefaultRole: cfg.Session.DefaultRole, DefaultModel: cfg.Session.DefaultModel},
 		Claude:          configClaudeJSON{PermissionMode: cfg.Claude.ClaudePermissionMode()},
 		DevMode:         cfg.DevMode,
 		Templates:       templates,
@@ -1097,7 +1099,7 @@ func jsonToConfig(j configJSON) *config.Config {
 	return &config.Config{
 		Server:          config.ServerConfig{Port: j.Server.Port},
 		Daemon:          config.DaemonConfig{Interval: j.Daemon.Interval},
-		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand},
+		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand, DefaultRole: j.Session.DefaultRole, DefaultModel: j.Session.DefaultModel},
 		Claude:          config.ClaudeConfig{PermissionMode: j.Claude.PermissionMode},
 		DevMode:         j.DevMode,
 		Templates:       templates,


### PR DESCRIPTION
## Summary
- `SessionConfig` に `default_role` / `default_model` フィールドを追加
- GET/PUT `/api/config` でこれらの値を読み書きできるよう `configSessionJSON` を拡張
- `CreateSession` フォームで設定ページのデフォルト値を初期値として反映
- `ConfigPage` の Session セクションに Default Role / Default Model の入力欄を追加

## Test plan
- [ ] `make build` / `make test` が通ること
- [ ] 設定ページで Default Role / Default Model を入力・保存できること
- [ ] セッション作成フォームを開いた際にデフォルト値が反映されていること

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)