### PR TITLE
fix: タスク通知の縦幅バラつきを解消（1行省略表示）

### DIFF
--- a/frontend/src/components/NotificationPanel.tsx
+++ b/frontend/src/components/NotificationPanel.tsx
@@ -82,15 +82,15 @@ export function NotificationPanel({ headerExtra }: { headerExtra?: React.ReactNo
 
                   {/* Content */}
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className={`text-xs font-medium ${config.textColor}`}>{config.label}</span>
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className={`text-xs font-medium shrink-0 ${config.textColor}`}>{config.label}</span>
                       {n.sessionId && (
-                        <span className="text-xs text-gray-400">
+                        <span className="text-xs text-gray-400 truncate">
                           {n.sessionName || n.sessionId.slice(0, 8)}
                         </span>
                       )}
                     </div>
-                    <p className="text-sm text-gray-700 leading-snug mt-0.5 break-words line-clamp-2">
+                    <p className="text-sm text-gray-700 leading-snug mt-0.5 truncate">
                       {n.message}
                     </p>
                   </div>


### PR DESCRIPTION
## Summary

- `NotificationPanel` の通知リストアイテムで、メッセージテキストを `truncate`（1行 + `…` 省略）に変更
- ラベル行に `min-w-0` / `shrink-0` を追加し、ラベルが折り返さないよう修正

## Test plan

- [ ] 長いメッセージの通知が1行で `…` 省略表示されることを確認
- [ ] ラベル（Notification / Escalation / System）が折り返さないことを確認
- [ ] 通知リストの各行の高さが均一になることを確認

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)