### PR TITLE
feat: プロバイダーごとのデフォルトモデル指定を追加

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -130,6 +130,7 @@ func initManager(cfg *config.Config, port int, logger *slog.Logger) (session.Ses
 	}
 	mgr := session.NewManager(database, cfg.Session.ClaudeCommand, cfg.Claude.ClaudePermissionMode(), cfg.Server.Port, logger, cfg.Session.SystemPrompt)
 	mgr.SetCodexCommand(cfg.Session.CodexCommand)
+	mgr.SetDefaultModels(cfg.Session.ClaudeDefaultModel, cfg.Session.CodexDefaultModel)
 
 	// Configure background task notification interval
 	bgNotifyIntervalStr := cfg.Daemon.BackgroundTaskNotificationInterval

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -208,9 +208,9 @@ export interface PromptTemplate {
 }
 
 export interface AppConfig {
-  server: { port: number };
+  server: { port: number; frontendDir?: string };
   daemon: { interval: string };
-  session: { claudeCommand: string; defaultRole?: string; defaultModel?: string };
+  session: { claudeCommand: string; defaultRole?: string; defaultModel?: string; claudeDefaultModel?: string; codexDefaultModel?: string };
   devMode: boolean;
   prompts?: { systemPrompt: string };
   templates: RoleTemplate[];

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -101,14 +101,25 @@ export function ConfigPage() {
               className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
             />
           </Field>
-          <Field label="Default Model (optional)">
+          <Field label="Claude Default Model (optional)">
             <input
               type="text"
-              value={config.session.defaultModel || ""}
+              value={config.session.claudeDefaultModel || ""}
               onChange={(e) =>
-                setConfig({ ...config, session: { ...config.session, defaultModel: e.target.value || undefined } })
+                setConfig({ ...config, session: { ...config.session, claudeDefaultModel: e.target.value || undefined } })
               }
               placeholder="e.g. claude-sonnet-4-5"
+              className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
+            />
+          </Field>
+          <Field label="Codex Default Model (optional)">
+            <input
+              type="text"
+              value={config.session.codexDefaultModel || ""}
+              onChange={(e) =>
+                setConfig({ ...config, session: { ...config.session, codexDefaultModel: e.target.value || undefined } })
+              }
+              placeholder="e.g. o4-mini"
               className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
             />
           </Field>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,11 +42,13 @@ type DaemonConfig struct {
 }
 
 type SessionConfig struct {
-	ClaudeCommand string `toml:"claude_command"`
-	CodexCommand  string `toml:"codex_command"`
-	SystemPrompt  string `toml:"system_prompt"`
-	DefaultRole   string `toml:"default_role" json:"default_role,omitempty"`
-	DefaultModel  string `toml:"default_model" json:"default_model,omitempty"`
+	ClaudeCommand      string `toml:"claude_command"`
+	CodexCommand       string `toml:"codex_command"`
+	SystemPrompt       string `toml:"system_prompt"`
+	DefaultRole        string `toml:"default_role" json:"default_role,omitempty"`
+	DefaultModel       string `toml:"default_model" json:"default_model,omitempty"`       // Deprecated: use ClaudeDefaultModel
+	ClaudeDefaultModel string `toml:"claude_default_model" json:"claude_default_model,omitempty"`
+	CodexDefaultModel  string `toml:"codex_default_model" json:"codex_default_model,omitempty"`
 }
 
 // DefaultPermissionMode is the default Claude CLI permission mode.
@@ -148,6 +150,11 @@ func Load() (*Config, error) {
 
 	if _, err := toml.DecodeFile(configPath, cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	// Backward compat: if old default_model is set but claude_default_model is not, copy it over.
+	if cfg.Session.DefaultModel != "" && cfg.Session.ClaudeDefaultModel == "" {
+		cfg.Session.ClaudeDefaultModel = cfg.Session.DefaultModel
 	}
 
 	return cfg, nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1055,9 +1055,11 @@ type configDaemonJSON struct {
 	Interval string `json:"interval"`
 }
 type configSessionJSON struct {
-	ClaudeCommand string `json:"claudeCommand"`
-	DefaultRole   string `json:"defaultRole,omitempty"`
-	DefaultModel  string `json:"defaultModel,omitempty"`
+	ClaudeCommand      string `json:"claudeCommand"`
+	DefaultRole        string `json:"defaultRole,omitempty"`
+	DefaultModel       string `json:"defaultModel,omitempty"` // Deprecated: use ClaudeDefaultModel
+	ClaudeDefaultModel string `json:"claudeDefaultModel,omitempty"`
+	CodexDefaultModel  string `json:"codexDefaultModel,omitempty"`
 }
 type configClaudeJSON struct {
 	PermissionMode string `json:"permissionMode"`
@@ -1077,7 +1079,7 @@ func configToJSON(cfg *config.Config) configJSON {
 	return configJSON{
 		Server:          configServerJSON{Port: cfg.Server.Port},
 		Daemon:          configDaemonJSON{Interval: cfg.Daemon.Interval},
-		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand, DefaultRole: cfg.Session.DefaultRole, DefaultModel: cfg.Session.DefaultModel},
+		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand, DefaultRole: cfg.Session.DefaultRole, DefaultModel: cfg.Session.DefaultModel, ClaudeDefaultModel: cfg.Session.ClaudeDefaultModel, CodexDefaultModel: cfg.Session.CodexDefaultModel},
 		Claude:          configClaudeJSON{PermissionMode: cfg.Claude.ClaudePermissionMode()},
 		DevMode:         cfg.DevMode,
 		Templates:       templates,
@@ -1099,7 +1101,7 @@ func jsonToConfig(j configJSON) *config.Config {
 	return &config.Config{
 		Server:          config.ServerConfig{Port: j.Server.Port},
 		Daemon:          config.DaemonConfig{Interval: j.Daemon.Interval},
-		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand, DefaultRole: j.Session.DefaultRole, DefaultModel: j.Session.DefaultModel},
+		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand, DefaultRole: j.Session.DefaultRole, DefaultModel: j.Session.DefaultModel, ClaudeDefaultModel: j.Session.ClaudeDefaultModel, CodexDefaultModel: j.Session.CodexDefaultModel},
 		Claude:          config.ClaudeConfig{PermissionMode: j.Claude.PermissionMode},
 		DevMode:         j.DevMode,
 		Templates:       templates,

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -18,15 +18,17 @@ import (
 )
 
 type Manager struct {
-	db              *sql.DB
-	claudeCommand   string
-	codexCommand    string
-	permissionMode  string
-	apiPort         int
-	systemPrompt    string
-	notifyInterval  time.Duration
-	streamProcesses map[string]*HolderStreamProcess
-	streamMu        sync.Mutex
+	db                 *sql.DB
+	claudeCommand      string
+	codexCommand       string
+	permissionMode     string
+	apiPort            int
+	systemPrompt       string
+	claudeDefaultModel string
+	codexDefaultModel  string
+	notifyInterval     time.Duration
+	streamProcesses    map[string]*HolderStreamProcess
+	streamMu           sync.Mutex
 	// deletingSet tracks sessions currently being deleted so that auto-recovery
 	// (RecoverStreamProcesses, SendKeysWithImages) does not spawn a new holder
 	// while Delete() is in progress.
@@ -92,6 +94,12 @@ func (m *Manager) SetCodexCommand(cmd string) {
 	if cmd != "" {
 		m.codexCommand = cmd
 	}
+}
+
+// SetDefaultModels configures provider-specific default models.
+func (m *Manager) SetDefaultModels(claudeDefaultModel, codexDefaultModel string) {
+	m.claudeDefaultModel = claudeDefaultModel
+	m.codexDefaultModel = codexDefaultModel
 }
 
 // SetOnNewLines sets a callback that fires when new stream lines arrive for any session.
@@ -299,9 +307,18 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		}
 	}
 
-	// For Codex, resolve default model from config if not explicitly specified
-	if pn == ProviderCodex && model == "" {
-		model = ReadCodexDefaultModel()
+	// Resolve default model from config if not explicitly specified
+	if model == "" {
+		switch pn {
+		case ProviderClaude:
+			model = m.claudeDefaultModel
+		case ProviderCodex:
+			if m.codexDefaultModel != "" {
+				model = m.codexDefaultModel
+			} else {
+				model = ReadCodexDefaultModel()
+			}
+		}
 	}
 
 	provider := m.getProvider(pn)


### PR DESCRIPTION
## Summary

- `SessionConfig` に `ClaudeDefaultModel` / `CodexDefaultModel` を追加 (TOML: `claude_default_model`, `codex_default_model`)
- 既存の `default_model` は後方互換として `claude_default_model` にフォールバック
- セッション作成時にプロバイダーに応じたデフォルトモデルを適用 (`manager.go`)
- 設定画面の「Default Model」欄を「Claude Default Model」と「Codex Default Model」の 2 入力欄に分割

## Test plan

- [ ] `make build && make test` が通ること
- [ ] 設定画面で Claude / Codex それぞれのデフォルトモデルを入力・保存できること
- [ ] 既存 config に `default_model` がある場合、`claude_default_model` として引き継がれること
- [ ] model 未指定でセッション作成時、プロバイダーに応じたデフォルトモデルが適用されること

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)