### PR TITLE
feat: 親セッションページ内でforkを並列表示

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -446,7 +446,7 @@ func sessionForkCmd() *cobra.Command {
 				return err
 			}
 			defer database.Close()
-			sess, err := mgr.Fork(args[0], !noContext)
+			sess, err := mgr.Fork(args[0], !noContext, "")
 			if err != nil {
 				return err
 			}

--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -325,6 +325,7 @@ func sessionCmd() *cobra.Command {
 	cmd.AddCommand(sessionBroadcastCmd())
 	cmd.AddCommand(sessionHistoryCmd())
 	cmd.AddCommand(sessionInfoCmd())
+	cmd.AddCommand(sessionRestartCmd())
 
 	return cmd
 }
@@ -515,6 +516,31 @@ func sessionStopCmd() *cobra.Command {
 				return err
 			}
 			fmt.Println("Session stopped.")
+			return nil
+		},
+	}
+}
+
+func sessionRestartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restart <id>",
+		Short: "Restart a session while preserving conversation history",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+			mgr, database, err := initManager(cfg, cfg.Server.Port, nil)
+			if err != nil {
+				return err
+			}
+			defer database.Close()
+			id := args[0]
+			if err := mgr.Restart(id); err != nil {
+				return err
+			}
+			fmt.Println("Session restarted.")
 			return nil
 		},
 	}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,6 +20,11 @@ async function request<T>(
 export const api = {
   listSessions: () => request<Session[]>("/sessions"),
 
+  listForkSessions: (parentSessionId: string) =>
+    request<Session[]>("/sessions").then((sessions) =>
+      sessions.filter((s) => s.parentSessionId === parentSessionId)
+    ),
+
   getRecentProjects: () =>
     request<RecentProject[]>("/projects/recent"),
 
@@ -65,11 +70,11 @@ export const api = {
   duplicateSession: (id: string) =>
     request<Session>(`/sessions/${id}/duplicate`, { method: "POST" }),
 
-  forkSession: (id: string, preserveContext: boolean = true) =>
+  forkSession: (id: string, prompt: string, preserveContext: boolean = true) =>
     request<Session>(`/sessions/${id}/fork`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ preserveContext }),
+      body: JSON.stringify({ preserveContext, prompt }),
     }),
 
   sendToSession: (id: string, text: string, images?: { data: string; mediaType: string }[]) =>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -93,6 +93,9 @@ export const api = {
   reconnectSession: (id: string) =>
     request<{ status: string }>(`/sessions/${id}/reconnect`, { method: "POST" }),
 
+  restartSession: (id: string) =>
+    request<{ status: string }>(`/sessions/${id}/restart`, { method: "POST" }),
+
   clearSession: (id: string) =>
     request<{ status: string }>(`/sessions/${id}/clear`, { method: "POST" }),
 

--- a/frontend/src/components/session/ForkPanel.tsx
+++ b/frontend/src/components/session/ForkPanel.tsx
@@ -1,0 +1,204 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Link } from "react-router-dom";
+import { ChevronDown, ChevronUp, X, GitBranch } from "lucide-react";
+import type { Session } from "../../types/session";
+import { api } from "../../api/client";
+import { StatusDot } from "../StatusBadge";
+import { StreamOutputView } from "./StreamOutputView";
+import { useWebSocket } from "../../hooks/useWebSocket";
+
+function ForkStreamPanel({ fork }: { fork: Session }) {
+  const [streamLines, setStreamLines] = useState<unknown[]>([]);
+  const [partialText, setPartialText] = useState("");
+  const [forkSession, setForkSession] = useState<Session>(fork);
+
+  useEffect(() => {
+    api.getStreamOutput(fork.id).then((r) => {
+      setStreamLines(r.lines);
+    }).catch(() => {});
+  }, [fork.id]);
+
+  const handleWsMessage = useCallback((msg: { type: string; data: unknown }) => {
+    if (msg.type === "stream_update") {
+      const data = msg.data as { sessionId: string; lines: unknown[]; total: number };
+      if (data.sessionId === fork.id && data.lines.length > 0) {
+        const regular: unknown[] = [];
+        for (const line of data.lines) {
+          const entry = line as Record<string, unknown>;
+          if (entry.type === "stream_event") {
+            const evt = entry.event as { type?: string; delta?: { type?: string; text?: string } } | undefined;
+            if (evt?.type === "content_block_delta" && evt.delta?.type === "text_delta" && evt.delta.text) {
+              setPartialText((prev) => prev + evt.delta!.text!);
+            }
+          } else {
+            if (entry.type === "assistant") {
+              setPartialText("");
+            }
+            regular.push(line);
+          }
+        }
+        if (regular.length > 0) {
+          setStreamLines((prev) => [...prev, ...regular]);
+        }
+      }
+    }
+    if (msg.type === "status_change") {
+      const data = msg.data as { sessionId: string; status: Session["status"] };
+      if (data.sessionId === fork.id) {
+        setForkSession((prev) => ({ ...prev, status: data.status }));
+      }
+    }
+  }, [fork.id]);
+
+  useWebSocket(handleWsMessage);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
+        <StatusDot status={forkSession.status} />
+        <Link
+          to={`/sessions/${fork.id}`}
+          className="text-sm font-medium text-blue-600 hover:underline truncate"
+        >
+          {fork.name}
+        </Link>
+        <span className="text-xs text-gray-400 ml-auto shrink-0">{forkSession.status}</span>
+      </div>
+      <StreamOutputView
+        lines={streamLines}
+        partialText={partialText}
+        className="flex-1 min-h-0"
+        sessionId={fork.id}
+        provider={fork.provider ?? undefined}
+      />
+    </div>
+  );
+}
+
+export function ForkPanel({ sessionId }: { sessionId: string }) {
+  const [forks, setForks] = useState<Session[]>([]);
+  const [selectedForkId, setSelectedForkId] = useState<string | null>(null);
+  const [minimized, setMinimized] = useState(false);
+  const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
+  const [showMobileOverlay, setShowMobileOverlay] = useState(false);
+  const prevForksRef = useRef<Session[]>([]);
+
+  useEffect(() => {
+    api.listForkSessions(sessionId).then((forkList) => {
+      setForks(forkList);
+      if (forkList.length > 0 && !selectedForkId) {
+        setSelectedForkId(forkList[0].id);
+      }
+    }).catch(() => {});
+
+    const interval = setInterval(() => {
+      api.listForkSessions(sessionId).then((forkList) => {
+        const prevIds = prevForksRef.current.map((f) => f.id);
+        const newIds = forkList.map((f) => f.id);
+        const hasNew = newIds.some((id) => !prevIds.includes(id));
+        setForks(forkList);
+        if (hasNew && forkList.length > 0) {
+          setSelectedForkId(forkList[forkList.length - 1].id);
+        }
+      }).catch(() => {});
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [sessionId, selectedForkId]);
+
+  useEffect(() => {
+    prevForksRef.current = forks;
+  }, [forks]);
+
+  if (forks.length === 0) return null;
+
+  const selectedFork = forks.find((f) => f.id === selectedForkId) ?? forks[0];
+
+  // Mobile: show as button that opens overlay
+  if (isMobile) {
+    return (
+      <>
+        <div className="shrink-0 border-t border-gray-200 bg-white px-4 py-2">
+          <button
+            onClick={() => setShowMobileOverlay(true)}
+            className="flex items-center gap-2 text-sm text-blue-600 font-medium"
+          >
+            <GitBranch className="w-4 h-4" />
+            Forks ({forks.length})
+          </button>
+        </div>
+
+        {showMobileOverlay && (
+          <div className="fixed inset-0 z-50 bg-white flex flex-col">
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200 shrink-0">
+              <button onClick={() => setShowMobileOverlay(false)} className="text-gray-500 hover:text-gray-700">
+                <X className="w-5 h-5" />
+              </button>
+              <span className="font-semibold text-sm">Forks</span>
+              <div className="flex gap-1 ml-4 overflow-x-auto">
+                {forks.map((fork) => (
+                  <button
+                    key={fork.id}
+                    onClick={() => setSelectedForkId(fork.id)}
+                    className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs shrink-0 ${
+                      fork.id === selectedForkId
+                        ? "bg-blue-100 text-blue-700"
+                        : "text-gray-600 hover:bg-gray-100"
+                    }`}
+                  >
+                    <StatusDot status={fork.status} />
+                    <span className="max-w-[120px] truncate">{fork.name}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="flex-1 min-h-0">
+              {selectedFork && <ForkStreamPanel key={selectedFork.id} fork={selectedFork} />}
+            </div>
+          </div>
+        )}
+      </>
+    );
+  }
+
+  // Desktop: nested panel at bottom
+  return (
+    <div className={`shrink-0 border-t border-gray-200 bg-gray-50 transition-all ${minimized ? "h-10" : "h-72"}`}>
+      {/* Panel header with tabs */}
+      <div className="flex items-center gap-1 px-3 h-10 border-b border-gray-200 bg-white overflow-x-auto">
+        <GitBranch className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+        <span className="text-xs text-gray-500 font-medium shrink-0 mr-2">Forks</span>
+        {forks.map((fork) => (
+          <button
+            key={fork.id}
+            onClick={() => { setSelectedForkId(fork.id); setMinimized(false); }}
+            className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs shrink-0 transition-colors ${
+              fork.id === selectedForkId && !minimized
+                ? "bg-blue-100 text-blue-700"
+                : "text-gray-600 hover:bg-gray-100"
+            }`}
+          >
+            <StatusDot status={fork.status} />
+            <span className="max-w-[140px] truncate">{fork.name}</span>
+          </button>
+        ))}
+        <div className="ml-auto flex items-center gap-1 shrink-0">
+          <button
+            onClick={() => setMinimized((v) => !v)}
+            className="p-1 text-gray-400 hover:text-gray-600 rounded"
+            title={minimized ? "Expand" : "Minimize"}
+          >
+            {minimized ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+          </button>
+        </div>
+      </div>
+
+      {/* Panel content */}
+      {!minimized && (
+        <div className="h-[calc(100%-40px)]">
+          {selectedFork && <ForkStreamPanel key={selectedFork.id} fork={selectedFork} />}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/session/ForkPanel.tsx
+++ b/frontend/src/components/session/ForkPanel.tsx
@@ -79,8 +79,16 @@ export function ForkPanel({ sessionId }: { sessionId: string }) {
   const [forks, setForks] = useState<Session[]>([]);
   const [selectedForkId, setSelectedForkId] = useState<string | null>(null);
   const [minimized, setMinimized] = useState(false);
-  const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== "undefined" && window.innerWidth < 768
+  );
   const [showMobileOverlay, setShowMobileOverlay] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < 768);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
   const prevForksRef = useRef<Session[]>([]);
 
   useEffect(() => {

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -478,7 +478,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
                     if (!confirm("会話履歴を保持したままセッションを再起動しますか？")) return;
                     try {
                       await api.restartSession(session.id);
-                      api.getSession(session.id).then(setSession);
+                      api.getSession(session.id).then(setSession).catch(() => {});
                       setRestartToast("success");
                       setTimeout(() => setRestartToast(null), 3000);
                     } catch {

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -118,6 +118,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
   const [escalationTimeoutSeconds, setEscalationTimeoutSeconds] = useState(300);
   const [pendingPermission, setPendingPermission] = useState<{ id: string; toolName: string; input: unknown; timedOut?: boolean; timeoutSeconds?: number } | null>(null);
   const [reconnectToast, setReconnectToast] = useState(false);
+  const [restartToast, setRestartToast] = useState<"success" | "error" | null>(null);
   const [disconnectToast, setDisconnectToast] = useState(false);
   const [clearToast, setClearToast] = useState<"success" | "error" | null>(null);
   const [copiedToast, setCopiedToast] = useState(false);
@@ -468,6 +469,25 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
                   }
                 }}
               />
+              {session.conversationStarted && (
+                <ActionMenuItem
+                  icon={<RotateCcw className="w-4 h-4" />}
+                  label="Restart (keep history)"
+                  onClick={async () => {
+                    setShowActionMenu(false);
+                    if (!confirm("会話履歴を保持したままセッションを再起動しますか？")) return;
+                    try {
+                      await api.restartSession(session.id);
+                      api.getSession(session.id).then(setSession);
+                      setRestartToast("success");
+                      setTimeout(() => setRestartToast(null), 3000);
+                    } catch {
+                      setRestartToast("error");
+                      setTimeout(() => setRestartToast(null), 3000);
+                    }
+                  }}
+                />
+              )}
               {session.status !== "paused" && session.status !== "exited" && session.type !== "controller" && (
                 <ActionMenuItem
                   icon={<Square className="w-4 h-4" />}
@@ -622,6 +642,8 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
     <div className={`${isDesktopPane ? "h-full pt-2" : "h-dvh pt-4 sm:pt-8"} flex flex-col px-4 sm:px-8 ${isDesktopPane ? "" : "max-w-4xl mx-auto"}`}>
       {disconnectToast && <Toast message="WebSocket接続が切断されました。再接続を試みています..." variant="warning" />}
       {reconnectToast && <Toast message="再接続に成功しました" />}
+      {restartToast === "success" && <Toast message="セッションを再起動しました" />}
+      {restartToast === "error" && <Toast message="再起動に失敗しました" variant="error" />}
       {clearToast === "success" && <Toast message="セッションをクリアしました" />}
       {clearToast === "error" && <Toast message="クリアに失敗しました" variant="error" />}
       {copiedToast && <Toast message="セッション名をコピーしました" />}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -22,6 +22,7 @@ import { StatusDot } from "../components/StatusBadge";
 import { setActiveSessionName } from "../activeSession";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { StreamOutputView, ActiveTasksPanel } from "../components/session/StreamOutputView";
+import { ForkPanel } from "../components/session/ForkPanel";
 import { DiffDropdown } from "../components/session/DiffDropdown";
 import { GoalPanel } from "../components/ui/GoalPanel";
 import { ConnectionStatusIndicator } from "../components/ui/ConnectionStatus";
@@ -834,6 +835,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
               <ActiveTasksPanel tasks={activeTasks} />
             </div>
           )}
+          {sessionId && <ForkPanel sessionId={sessionId} />}
           {pendingPermission && sessionId ? (
             <PermissionPromptBanner
               permission={pendingPermission}
@@ -978,10 +980,8 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
             if (forkLoading || !session) return;
             setForkLoading(true);
             try {
-              const newSession = await api.forkSession(session.id, forkPreserveContext);
-              if (forkMessage.trim()) {
-                await api.sendToSession(newSession.id, forkMessage.trim());
-              }
+              if (!forkMessage.trim()) return;
+              const newSession = await api.forkSession(session.id, forkMessage.trim(), forkPreserveContext);
               setShowForkModal(false);
               navigate(`/sessions/${newSession.id}`);
             } catch {
@@ -1001,13 +1001,30 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
             />
             コンテキストを維持する
           </label>
+          <div className="flex flex-wrap gap-1.5">
+            {[
+              "別のアプローチを試す",
+              "質問・相談する",
+              "レビューする",
+            ].map((template) => (
+              <button
+                key={template}
+                type="button"
+                onClick={() => setForkMessage(template)}
+                className="px-2.5 py-1 text-xs text-blue-700 bg-blue-50 hover:bg-blue-100 border border-blue-200 rounded-full"
+              >
+                {template}
+              </button>
+            ))}
+          </div>
           <textarea
             value={forkMessage}
             onChange={(e) => setForkMessage(e.target.value)}
-            placeholder="フォーク後に送信するメッセージ（省略可）"
+            placeholder="新しい方向性を入力してください（必須）"
             className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm resize-none focus:outline-none focus:ring-1 focus:ring-blue-400"
             rows={3}
             autoFocus
+            required
           />
           <div className="flex justify-end gap-2">
             <button
@@ -1019,7 +1036,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
             </button>
             <button
               type="submit"
-              disabled={forkLoading}
+              disabled={forkLoading || !forkMessage.trim()}
               className="px-3 py-1.5 text-sm text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50"
             >
               {forkLoading ? "フォーク中..." : "フォーク"}

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -13,6 +13,7 @@ export interface Session {
   goal?: string;
   goals?: { currentTask: string; goal: string }[];
   lastError?: string;
+  conversationStarted?: boolean;
   createdAt: string;
   updatedAt: string;
   githubUrl?: string;

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -140,6 +140,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/duplicate", s.duplicateSession)
 		r.Post("/sessions/{id}/fork", s.forkSession)
 		r.Post("/sessions/{id}/reconnect", s.reconnectSession)
+		r.Post("/sessions/{id}/restart", s.restartSession)
 		r.Post("/sessions/{id}/clear", s.clearSession)
 		r.Get("/sessions/{id}/stream", s.getSessionStream)
 		r.Get("/sessions/{id}/diff", s.getSessionDiff)
@@ -887,6 +888,16 @@ func (s *Server) reconnectSession(w http.ResponseWriter, r *http.Request) {
 	}
 	s.recordSessionAction(id, "session_reconnect", "")
 	writeJSON(w, http.StatusOK, map[string]string{"status": "reconnected"})
+}
+
+func (s *Server) restartSession(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.sessions.Restart(id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.recordSessionAction(id, "session_restart", "")
+	writeJSON(w, http.StatusOK, map[string]string{"status": "restarted"})
 }
 
 func (s *Server) clearSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -384,18 +384,29 @@ func (s *Server) forkSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse optional request body for preserveContext (default: true)
+	// Parse request body for prompt (required) and preserveContext (default: true).
 	preserveContext := true
+	var prompt string
 	if r.Body != nil {
 		var body struct {
-			PreserveContext *bool `json:"preserveContext"`
+			PreserveContext *bool  `json:"preserveContext"`
+			Prompt          string `json:"prompt"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err == nil && body.PreserveContext != nil {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+			return
+		}
+		if body.PreserveContext != nil {
 			preserveContext = *body.PreserveContext
 		}
+		prompt = body.Prompt
+	}
+	if strings.TrimSpace(prompt) == "" {
+		writeError(w, http.StatusBadRequest, "prompt is required")
+		return
 	}
 
-	sess, err := s.sessions.Fork(id, preserveContext)
+	sess, err := s.sessions.Fork(id, preserveContext, prompt)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1425,6 +1425,71 @@ func (m *Manager) Reconnect(id string) error {
 	return err
 }
 
+// Restart stops the existing holder/claude processes and spawns a new one with
+// --resume, preserving the conversation history (CLI session ID). Unlike Reconnect,
+// Restart explicitly requires conversation_started to be true and returns an error
+// if there is no CLI session ID to resume.
+func (m *Manager) Restart(id string) error {
+	s, err := m.Get(id)
+	if err != nil {
+		return err
+	}
+
+	if !s.ConversationStarted {
+		return fmt.Errorf("session %s has not started a conversation; use start instead of restart", id)
+	}
+
+	cliSessionID := s.CliSessionID
+	if cliSessionID == "" {
+		cliSessionID = ReadCLISessionID(id, m.getProvider(s.Provider))
+	}
+	if cliSessionID == "" {
+		return fmt.Errorf("session %s has no CLI session ID; cannot resume conversation", id)
+	}
+
+	provider := m.getProvider(s.Provider)
+
+	// Stop existing stream process
+	m.stopStreamProcess(id)
+
+	// Generate fresh MCP config
+	mcpConfigPath, err := provider.SetupMCP(id, m.apiPort)
+	if err != nil {
+		return fmt.Errorf("write mcp config: %w", err)
+	}
+
+	// Kill any stale holder process
+	m.killStaleHolder(id)
+
+	// Reset status to idle before spawning new holder
+	if _, err := m.db.Exec("UPDATE sessions SET status = ?, last_error = NULL, updated_at = ? WHERE id = ?", string(StatusIdle), time.Now(), id); err != nil {
+		return fmt.Errorf("reset session status: %w", err)
+	}
+
+	sp, err := StartHolderStreamProcess(StreamOpts{
+		SessionID:     id,
+		ProjectPath:   s.ProjectPath,
+		MCPConfigPath: mcpConfigPath,
+		SystemPrompt:  m.buildEffectiveSystemPrompt(s.SystemPrompt),
+		Resume:        true,
+		CLISessionID:  cliSessionID,
+		Model:         s.Model,
+		APIPort:       m.apiPort,
+		ClearOffset:   s.ClearOffset,
+	}, provider)
+	if err != nil {
+		return fmt.Errorf("start stream process: %w", err)
+	}
+	m.wireSessionIDCallback(id, sp)
+	m.streamMu.Lock()
+	m.streamProcesses[id] = sp
+	m.streamMu.Unlock()
+	m.updateHolderPID(id, sp.HolderPID())
+
+	_, err = m.db.Exec("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", string(StatusWorking), time.Now(), id)
+	return err
+}
+
 // waitForProcessExit polls until the given PID no longer exists or the timeout expires.
 // This is needed because os.Process.Wait() only works for child processes on Unix,
 // not for processes found via os.FindProcess() after a server restart.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -589,6 +589,14 @@ func (m *Manager) Fork(id string, preserveContext bool, initialPrompt string) (*
 	}
 
 	effectiveSystemPrompt := m.buildEffectiveSystemPrompt(src.SystemPrompt)
+	effectiveSystemPrompt += "\n\n" + forkSystemReminder
+
+	// For Codex, pass initialPrompt as command-line argument via StreamOpts.
+	// For Claude, the prompt is sent via stdin after the holder starts.
+	streamOptsInitialPrompt := ""
+	if src.Provider == ProviderCodex {
+		streamOptsInitialPrompt = initialPrompt
+	}
 
 	// Start new CLI process via holder
 	sp, err := StartHolderStreamProcess(StreamOpts{
@@ -601,10 +609,19 @@ func (m *Manager) Fork(id string, preserveContext bool, initialPrompt string) (*
 		CLISessionID:  cliSessionID,
 		Model:         src.Model,
 		APIPort:       m.apiPort,
+		InitialPrompt: streamOptsInitialPrompt,
 	}, provider)
 	if err != nil {
 		return nil, fmt.Errorf("start stream process: %w", err)
 	}
+
+	// For non-Codex providers (Claude), send the initial prompt via stdin.
+	if src.Provider != ProviderCodex {
+		if err := sp.Send(initialPrompt); err != nil {
+			return nil, fmt.Errorf("send initial prompt: %w", err)
+		}
+	}
+
 	m.wireSessionIDCallback(newID, sp)
 	m.streamMu.Lock()
 	m.streamProcesses[newID] = sp
@@ -616,6 +633,7 @@ func (m *Manager) Fork(id string, preserveContext bool, initialPrompt string) (*
 		ID:              newID,
 		Name:            newName,
 		ProjectPath:     src.ProjectPath,
+		InitialPrompt:   initialPrompt,
 		SystemPrompt:    src.SystemPrompt,
 		Status:          StatusIdle,
 		Type:            TypeWorker,
@@ -629,7 +647,7 @@ func (m *Manager) Fork(id string, preserveContext bool, initialPrompt string) (*
 	if _, err := m.db.Exec(
 		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, system_prompt, parent_session_id, holder_pid, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, "", "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, sp.HolderPID(), s.CreatedAt, s.UpdatedAt,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, sp.HolderPID(), s.CreatedAt, s.UpdatedAt,
 	); err != nil {
 		return nil, fmt.Errorf("insert session: %w", err)
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -535,9 +535,17 @@ func (m *Manager) Duplicate(id string) (*Session, error) {
 	})
 }
 
+// forkSystemReminder is appended to the system prompt when forking a session to
+// signal that the conversation is a fork and Claude should focus on the new direction.
+const forkSystemReminder = "この会話は親セッションからフォークされました。親の作業内容は参考情報として利用できますが、これから指示する新しい内容に集中してください。"
+
 // Fork creates a new session by forking an existing session's conversation history.
 // It copies the stream JSONL file and starts a new CLI process with --resume --fork-session.
-func (m *Manager) Fork(id string, preserveContext bool) (*Session, error) {
+// initialPrompt is required and must be non-empty.
+func (m *Manager) Fork(id string, preserveContext bool, initialPrompt string) (*Session, error) {
+	if strings.TrimSpace(initialPrompt) == "" {
+		return nil, fmt.Errorf("initialPrompt is required for fork")
+	}
 	src, err := m.Get(id)
 	if err != nil {
 		return nil, err
@@ -1486,7 +1494,7 @@ func (m *Manager) Restart(id string) error {
 	m.streamMu.Unlock()
 	m.updateHolderPID(id, sp.HolderPID())
 
-	_, err = m.db.Exec("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?", string(StatusWorking), time.Now(), id)
+	_, err = m.db.Exec("UPDATE sessions SET status = ?, last_error = NULL, updated_at = ? WHERE id = ?", string(StatusWorking), time.Now(), id)
 	return err
 }
 

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -13,7 +13,7 @@ type SessionService interface {
 	// Duplicate creates a copy of an existing session.
 	Duplicate(id string) (*Session, error)
 	// Fork creates a new session by forking an existing session's conversation history.
-	Fork(id string, preserveContext bool) (*Session, error)
+	Fork(id string, preserveContext bool, initialPrompt string) (*Session, error)
 	// Stop stops a running session.
 	Stop(id string) error
 	// Delete deletes a session.

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -26,6 +26,9 @@ type SessionService interface {
 
 	// Reconnect restarts the CLI process for an existing session.
 	Reconnect(id string) error
+	// Restart stops the existing holder and spawns a new one with --resume,
+	// preserving the conversation history.
+	Restart(id string) error
 	// Clear resets the session context.
 	Clear(id string) error
 


### PR DESCRIPTION
## Summary

- 親セッション詳細ページに `ForkPanel` コンポーネントを追加し、離れずに fork のログを確認できるようにした
- PC: セッション詳細下部にネストパネルとして展開。複数 fork はタブで切り替え。最小化/展開ボタン付き
- モバイル (< 768px): フルスクリーンオーバーレイで表示。親に戻るボタンで閉じられる
- WebSocket 経由でストリームをリアルタイム更新。既存の `StreamOutputView` コンポーネントを流用
- `api.listForkSessions()` を追加（既存の `/api/sessions` から `parentSessionId` でフィルタ）
- バックエンドの `Fork(id, preserveContext, initialPrompt)` 新シグネチャに合わせて CLI を修正

## Test plan

- [ ] `make build && make test` 通過確認
- [ ] fork がないセッションでは ForkPanel が表示されないことを確認
- [ ] fork があるセッションでパネルが展開されることを確認
- [ ] 複数 fork のタブ切り替えが動作することを確認
- [ ] モバイル幅でオーバーレイが表示されることを確認

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)