### PR TITLE
feat: Fork作成時に初期プロンプトを必須化し、方向転換を明示できるようにする

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -432,11 +432,15 @@ func resolveTemplate(name string) (*struct {
 
 func sessionForkCmd() *cobra.Command {
 	var noContext bool
+	var forkPrompt string
 	cmd := &cobra.Command{
 		Use:   "fork <id>",
 		Short: "Fork an existing session",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(forkPrompt) == "" {
+				return fmt.Errorf("--prompt is required")
+			}
 			cfg, err := config.Load()
 			if err != nil {
 				return fmt.Errorf("load config: %w", err)
@@ -446,7 +450,7 @@ func sessionForkCmd() *cobra.Command {
 				return err
 			}
 			defer database.Close()
-			sess, err := mgr.Fork(args[0], !noContext, "")
+			sess, err := mgr.Fork(args[0], !noContext, forkPrompt)
 			if err != nil {
 				return err
 			}
@@ -455,6 +459,7 @@ func sessionForkCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&noContext, "no-context", false, "Fork without preserving conversation context")
+	cmd.Flags().StringVar(&forkPrompt, "prompt", "", "Initial prompt for the fork (required)")
 	return cmd
 }
 

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -978,9 +978,9 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
           onSubmit={async (e) => {
             e.preventDefault();
             if (forkLoading || !session) return;
+            if (!forkMessage.trim()) return;
             setForkLoading(true);
             try {
-              if (!forkMessage.trim()) return;
               const newSession = await api.forkSession(session.id, forkMessage.trim(), forkPreserveContext);
               setShowForkModal(false);
               navigate(`/sessions/${newSession.id}`);


### PR DESCRIPTION
## Summary

- Fork API (`POST /api/sessions/{id}/fork`) と CLI (`agmux session fork --prompt`) で `prompt` パラメータを必須化（空の場合は400エラー）
- Fork セッション作成時に system prompt へ「親セッションからフォークされた」旨のリマインダーを自動追記し、Claude が新しい方向性に集中できるようにする
- Fork 後に initialPrompt を自動送信するよう変更（UI側での sendToSession 分離呼び出しを廃止）
- Fork ダイアログにテンプレートボタン（「別のアプローチを試す」「質問・相談する」「レビューする」）を追加
- プロンプトが空の場合はフォークボタンを無効化

## Test plan

- [ ] Fork ダイアログを開き、プロンプト未入力時にフォークボタンが無効であることを確認
- [ ] テンプレートボタンをクリックするとテキストエリアに文字が入ることを確認
- [ ] フォーク後に Fork セッションへ遷移し、指示した方向で Claude が応答することを確認
- [ ] `agmux session fork <id> --prompt "..."` が動作することを確認
- [ ] `agmux session fork <id>` (promptなし) がエラーになることを確認
- [ ] `make build && make test` 通過

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)