### PR TITLE
fix: Frontend Dir フィールドの長いパスのはみ出しを修正

### DIFF
--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -65,7 +65,7 @@ export function ConfigPage() {
           </Field>
           {config.server.frontendDir && (
             <Field label="Frontend Dir">
-              <span className="text-sm text-gray-700 font-mono">{config.server.frontendDir}</span>
+              <span className="text-sm text-gray-700 font-mono break-all">{config.server.frontendDir}</span>
             </Field>
           )}
         </Section>


### PR DESCRIPTION
## Summary

- 設定画面の Frontend Dir フィールドで長いパスがコンテナからはみ出す問題を修正
- `break-all` クラスを追加し、パス全体が折り返して表示されるようにした

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)