### PR TITLE
feat: バックグラウンドタスクの dismiss 機能を追加

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -180,6 +180,11 @@ export const api = {
   getPromptTemplates: () =>
     request<PromptTemplate[]>("/prompt-templates"),
 
+  dismissTask: (sessionId: string, taskId: string): Promise<void> =>
+    request<void>(`/sessions/${sessionId}/tasks/${taskId}/dismiss`, {
+      method: "POST",
+    }),
+
 };
 
 export interface RecentProject {

--- a/frontend/src/components/session/StreamOutputView.tsx
+++ b/frontend/src/components/session/StreamOutputView.tsx
@@ -9,6 +9,7 @@ import { Modal } from "../ui/Modal";
 import { ToolInputView } from "./ToolInputView";
 import { RefreshCw } from "lucide-react";
 import { motion } from "motion/react";
+import { api } from "../../api/client";
 
 const roleStyles: Record<string, { bg: string; label: string; text: string }> = {
   user: { bg: "bg-blue-50", label: "User", text: "text-blue-700" },
@@ -296,7 +297,7 @@ function ActiveTaskItem({ task, onDismiss }: { task: ActiveTask; onDismiss?: (ta
 const COLLAPSE_THRESHOLD = 4;
 const VISIBLE_WHEN_COLLAPSED = 3;
 
-export function ActiveTasksPanel({ tasks }: { tasks: ActiveTask[] }) {
+export function ActiveTasksPanel({ tasks, sessionId }: { tasks: ActiveTask[]; sessionId?: string }) {
   const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
   // Track previous task snapshots to detect task_progress updates for hidden tasks
   const prevTasksRef = useRef<Map<string, ActiveTask>>(new Map());
@@ -335,9 +336,16 @@ export function ActiveTasksPanel({ tasks }: { tasks: ActiveTask[] }) {
     }
   }, [visibleTasks.length]);
 
-  const handleDismiss = useCallback((taskId: string) => {
+  const handleDismiss = useCallback(async (taskId: string) => {
     setHiddenIds((prev) => new Set(prev).add(taskId));
-  }, []);
+    if (sessionId) {
+      try {
+        await api.dismissTask(sessionId, taskId);
+      } catch (e) {
+        console.error("Failed to dismiss task", e);
+      }
+    }
+  }, [sessionId]);
 
   if (visibleTasks.length === 0) return null;
 

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -832,7 +832,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
           }} />
           {activeTasks.length > 0 && (
             <div className="shrink-0 pt-2 px-4 sm:px-8 -mx-4 sm:-mx-8">
-              <ActiveTasksPanel tasks={activeTasks} />
+              <ActiveTasksPanel tasks={activeTasks} sessionId={sessionId} />
             </div>
           )}
           {sessionId && <ForkPanel sessionId={sessionId} />}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -152,6 +152,7 @@ func (s *Server) setupRoutes() {
 		r.Get("/sessions/{id}/permission", s.getPendingPermission)
 		r.Post("/sessions/{id}/permission", s.createPermission)
 		r.Post("/sessions/{id}/permission/respond", s.respondPermission)
+		r.Post("/sessions/{id}/tasks/{taskId}/dismiss", s.dismissTask)
 		r.Post("/sessions/{id}/notify", s.sendNotification)
 		r.Post("/sessions/broadcast", s.broadcastToSessions)
 		r.Post("/sessions/controller/restart", s.restartController)
@@ -1872,4 +1873,14 @@ func (s *Server) recordSessionAction(sessionID, actionType, detail string) {
 			"timestamp":  time.Now(),
 		},
 	})
+}
+
+func (s *Server) dismissTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	taskID := chi.URLParam(r, "taskId")
+	if err := s.sessions.DismissTask(id, taskID); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "dismissed"})
 }

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -881,3 +881,17 @@ func (sp *HolderStreamProcess) IsExited() bool {
 		return false
 	}
 }
+
+// DecrementRunningTasks decrements the running task counter and stops periodic
+// notifications if no tasks remain. Called when a task is manually dismissed.
+func (sp *HolderStreamProcess) DecrementRunningTasks() {
+	sp.mu.Lock()
+	if sp.runningTasks > 0 {
+		sp.runningTasks--
+	}
+	remaining := sp.runningTasks
+	sp.mu.Unlock()
+	if remaining == 0 {
+		sp.stopPeriodicNotification()
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -3,6 +3,7 @@ package session
 import (
 	"bufio"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -1528,4 +1529,50 @@ func waitForProcessExit(pid int, timeout, interval time.Duration) {
 		}
 		time.Sleep(interval)
 	}
+}
+
+// DismissTask writes a dismissed task_notification event to the JSONL stream
+// and decrements the running task count in the stream process if available.
+func (m *Manager) DismissTask(sessionID, taskID string) error {
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		return fmt.Errorf("get streams dir: %w", err)
+	}
+
+	type dismissEvent struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+		TaskID  string `json:"task_id"`
+		Status  string `json:"status"`
+	}
+	ev := dismissEvent{
+		Type:    "system",
+		Subtype: "task_notification",
+		TaskID:  taskID,
+		Status:  "dismissed",
+	}
+	line, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("marshal dismiss event: %w", err)
+	}
+
+	path := filepath.Join(streamsDir, sessionID+".jsonl")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("open stream file: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(string(line) + "\n"); err != nil {
+		return fmt.Errorf("write dismiss event: %w", err)
+	}
+
+	// Decrement running tasks in stream process if present
+	m.streamMu.Lock()
+	sp, ok := m.streamProcesses[sessionID]
+	m.streamMu.Unlock()
+	if ok {
+		sp.DecrementRunningTasks()
+	}
+
+	return nil
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1532,7 +1532,9 @@ func waitForProcessExit(pid int, timeout, interval time.Duration) {
 }
 
 // DismissTask writes a dismissed task_notification event to the JSONL stream
-// and decrements the running task count in the stream process if available.
+// for frontend record-keeping, and directly decrements the running task count
+// in the stream process. The readLoop reads from the holder socket (claude stdout),
+// not the JSONL file, so there is no double-decrement risk.
 func (m *Manager) DismissTask(sessionID, taskID string) error {
 	streamsDir, err := db.StreamsDir()
 	if err != nil {
@@ -1557,7 +1559,7 @@ func (m *Manager) DismissTask(sessionID, taskID string) error {
 	}
 
 	path := filepath.Join(streamsDir, sessionID+".jsonl")
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("open stream file: %w", err)
 	}

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -74,6 +74,9 @@ type SessionService interface {
 
 	// ManagedHolderPIDs returns the PIDs of all holder processes currently managed.
 	ManagedHolderPIDs() []int
+
+	// DismissTask writes a dismissed event to the JSONL stream for the given task.
+	DismissTask(sessionID, taskID string) error
 }
 
 // Verify Manager implements SessionService at compile time.


### PR DESCRIPTION
## Summary

- `POST /api/sessions/{id}/tasks/{taskId}/dismiss` エンドポイントを追加
- `Manager.DismissTask` メソッド: JSONL に `{"type":"system","subtype":"task_notification","task_id":"...","status":"dismissed"}` を書き込み、`runningTasks` をデクリメント
- `HolderStreamProcess.DecrementRunningTasks` メソッドを追加（手動 dismiss 時の定期通知停止）
- フロントエンド `api.dismissTask` クライアントメソッドを追加
- `ActiveTasksPanel` の × ボタン押下時に API を呼び出して JSONL に永続化（再起動後も消えた状態を維持）

## Test plan

- [ ] `make build && make test` の通過を確認済み
- [ ] セッションページのタスク一覧で × ボタンが表示される
- [ ] × を押すとタスクが一覧から消える
- [ ] サーバー再起動後も dismissed タスクは表示されない（JSONL に記録）

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)