### PR TITLE
feat: ephemeral session DB + モデル層 (#606)

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -323,6 +323,18 @@ func migrate(db *sql.DB) error {
 	// Backfill: sessions with a non-empty cli_session_id and initial_prompt are assumed to have started.
 	_, _ = db.Exec(`UPDATE sessions SET conversation_started = 1 WHERE cli_session_id != '' AND initial_prompt != '' AND initial_prompt IS NOT NULL`)
 
+	// Migration: add ephemeral_timeout_seconds column if missing
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN ephemeral_timeout_seconds INTEGER`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
+	// Migration: add completion_report column if missing
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN completion_report TEXT`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,18 +203,18 @@ func (s *Server) NewHTTPServer(addr string) *http.Server {
 // API handlers
 
 type createSessionRequest struct {
-	Name            string `json:"name"`
-	ProjectPath     string `json:"projectPath"`
-	Prompt          string `json:"prompt,omitempty"`
-	Worktree        bool   `json:"worktree,omitempty"`
-	Provider        string `json:"provider,omitempty"`
-	Model           string `json:"model,omitempty"`
-	AutoApprove     bool   `json:"autoApprove,omitempty"`
-	SystemPrompt    string `json:"systemPrompt,omitempty"`
-	ParentSessionID string `json:"parentSessionId,omitempty"`
-	RoleTemplate    string `json:"roleTemplate,omitempty"`
-	Ephemeral       bool   `json:"ephemeral,omitempty"`
-	EphemeralTimeoutSeconds *int `json:"ephemeralTimeoutSeconds,omitempty"`
+	Name                    string `json:"name"`
+	ProjectPath             string `json:"projectPath"`
+	Prompt                  string `json:"prompt,omitempty"`
+	Worktree                bool   `json:"worktree,omitempty"`
+	Provider                string `json:"provider,omitempty"`
+	Model                   string `json:"model,omitempty"`
+	AutoApprove             bool   `json:"autoApprove,omitempty"`
+	SystemPrompt            string `json:"systemPrompt,omitempty"`
+	ParentSessionID         string `json:"parentSessionId,omitempty"`
+	RoleTemplate            string `json:"roleTemplate,omitempty"`
+	Ephemeral               bool   `json:"ephemeral,omitempty"`
+	EphemeralTimeoutSeconds *int   `json:"ephemeralTimeoutSeconds,omitempty"`
 }
 
 type sendImageData struct {
@@ -306,9 +306,9 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 
 type sessionResponse struct {
 	*session.Session
-	GithubURL  string      `json:"githubUrl,omitempty"`
-	Branch     string      `json:"branch,omitempty"`
-	PullRequests []prInfo  `json:"pullRequests,omitempty"`
+	GithubURL    string   `json:"githubUrl,omitempty"`
+	Branch       string   `json:"branch,omitempty"`
+	PullRequests []prInfo `json:"pullRequests,omitempty"`
 }
 
 type prInfo struct {
@@ -1057,15 +1057,15 @@ type configTemplateJSON struct {
 }
 
 type configJSON struct {
-	Server          configServerJSON           `json:"server"`
-	Daemon          configDaemonJSON           `json:"daemon"`
-	Session         configSessionJSON          `json:"session"`
-	Claude          configClaudeJSON           `json:"claude"`
-	DevMode         bool                       `json:"devMode"`
-	Prompts         *configPromptsJSON         `json:"prompts,omitempty"`
-	Templates       []configTemplateJSON       `json:"templates"`
+	Server          configServerJSON        `json:"server"`
+	Daemon          configDaemonJSON        `json:"daemon"`
+	Session         configSessionJSON       `json:"session"`
+	Claude          configClaudeJSON        `json:"claude"`
+	DevMode         bool                    `json:"devMode"`
+	Prompts         *configPromptsJSON      `json:"prompts,omitempty"`
+	Templates       []configTemplateJSON    `json:"templates"`
 	PromptTemplates []config.PromptTemplate `json:"promptTemplates"`
-	ConfigPath      string                     `json:"configPath,omitempty"`
+	ConfigPath      string                  `json:"configPath,omitempty"`
 }
 
 type configPromptsJSON struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -213,6 +213,8 @@ type createSessionRequest struct {
 	SystemPrompt    string `json:"systemPrompt,omitempty"`
 	ParentSessionID string `json:"parentSessionId,omitempty"`
 	RoleTemplate    string `json:"roleTemplate,omitempty"`
+	Ephemeral       bool   `json:"ephemeral,omitempty"`
+	EphemeralTimeoutSeconds *int `json:"ephemeralTimeoutSeconds,omitempty"`
 }
 
 type sendImageData struct {
@@ -292,7 +294,7 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "name and projectPath are required")
 		return
 	}
-	sess, err := s.sessions.Create(req.Name, req.ProjectPath, req.Prompt, req.Worktree, session.CreateOpts{Provider: session.ProviderName(req.Provider), Model: req.Model, FullAuto: req.AutoApprove, SystemPrompt: req.SystemPrompt, ParentSessionID: req.ParentSessionID, RoleTemplate: req.RoleTemplate})
+	sess, err := s.sessions.Create(req.Name, req.ProjectPath, req.Prompt, req.Worktree, session.CreateOpts{Provider: session.ProviderName(req.Provider), Model: req.Model, FullAuto: req.AutoApprove, SystemPrompt: req.SystemPrompt, ParentSessionID: req.ParentSessionID, RoleTemplate: req.RoleTemplate, Ephemeral: req.Ephemeral, EphemeralTimeoutSeconds: req.EphemeralTimeoutSeconds})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -283,6 +283,8 @@ type CreateOpts struct {
 	SystemPrompt    string // per-session custom system prompt (appended to defaultSystemPrompt)
 	ParentSessionID string // parent session ID for sub-session creation
 	RoleTemplate    string // name of the role template used to create this session
+	Ephemeral       bool   // create session with type=ephemeral
+	EphemeralTimeoutSeconds *int // timeout in seconds for the ephemeral session
 }
 
 func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts ...CreateOpts) (*Session, error) {
@@ -292,6 +294,8 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	customSystemPrompt := ""
 	parentSessionID := ""
 	roleTemplate := ""
+	ephemeral := false
+	var ephemeralTimeoutSeconds *int
 	if len(opts) > 0 {
 		if opts[0].Provider != "" {
 			pn = opts[0].Provider
@@ -301,6 +305,8 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		customSystemPrompt = opts[0].SystemPrompt
 		parentSessionID = opts[0].ParentSessionID
 		roleTemplate = opts[0].RoleTemplate
+		ephemeral = opts[0].Ephemeral
+		ephemeralTimeoutSeconds = opts[0].EphemeralTimeoutSeconds
 	}
 
 	// Validate parent session exists when creating a sub-session
@@ -381,6 +387,10 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	m.streamMu.Unlock()
 
 	now := time.Now()
+	sessionType := TypeWorker
+	if ephemeral {
+		sessionType = TypeEphemeral
+	}
 	s := &Session{
 		ID:              id,
 		Name:            name,
@@ -388,19 +398,24 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		InitialPrompt:   prompt,
 		SystemPrompt:    customSystemPrompt,
 		Status:          StatusIdle,
-		Type:            TypeWorker,
+		Type:            sessionType,
 		Provider:        pn,
 		Model:           model,
 		ParentSessionID: parentSessionID,
 		RoleTemplate:    roleTemplate,
+		EphemeralTimeoutSeconds: ephemeralTimeoutSeconds,
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
 
+	var ephemeralTimeoutArg interface{}
+	if s.EphemeralTimeoutSeconds != nil {
+		ephemeralTimeoutArg = *s.EphemeralTimeoutSeconds
+	}
 	if _, err := m.db.Exec(
-		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, system_prompt, parent_session_id, role_template, holder_pid, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, s.RoleTemplate, sp.HolderPID(), s.CreatedAt, s.UpdatedAt,
+		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, system_prompt, parent_session_id, role_template, holder_pid, ephemeral_timeout_seconds, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, s.RoleTemplate, sp.HolderPID(), ephemeralTimeoutArg, s.CreatedAt, s.UpdatedAt,
 	); err != nil {
 		return nil, fmt.Errorf("insert session: %w", err)
 	}
@@ -410,7 +425,7 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 
 func (m *Manager) List() ([]Session, error) {
 	rows, err := m.db.Query(
-		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, ephemeral_timeout_seconds, completion_report, created_at, updated_at
 		 FROM sessions ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -424,9 +439,10 @@ func (m *Manager) List() ([]Session, error) {
 		var status string
 		var sessionType string
 		var providerStr string
-		var prompt, systemPrompt, parentSessionID, roleTemplate, currentTask, goal, goalsJSON, lastError sql.NullString
+		var prompt, systemPrompt, parentSessionID, roleTemplate, currentTask, goal, goalsJSON, lastError, completionReport sql.NullString
 		var conversationStartedInt int
-		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		var ephemeralTimeoutSeconds sql.NullInt64
+		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &ephemeralTimeoutSeconds, &completionReport, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		s.ConversationStarted = conversationStartedInt != 0
@@ -460,6 +476,14 @@ func (m *Manager) List() ([]Session, error) {
 		if lastError.Valid {
 			s.LastError = lastError.String
 		}
+		if ephemeralTimeoutSeconds.Valid {
+			v := int(ephemeralTimeoutSeconds.Int64)
+			s.EphemeralTimeoutSeconds = &v
+		}
+		if completionReport.Valid {
+			v := completionReport.String
+			s.CompletionReport = &v
+		}
 
 		sessions = append(sessions, s)
 	}
@@ -472,12 +496,13 @@ func (m *Manager) Get(id string) (*Session, error) {
 	var status string
 	var sessionType string
 	var providerStr string
-	var prompt, systemPrompt, parentSessionID, roleTemplate, currentTask, goal, goalsJSON, lastError sql.NullString
+	var prompt, systemPrompt, parentSessionID, roleTemplate, currentTask, goal, goalsJSON, lastError, completionReport sql.NullString
 	var conversationStartedInt int
+	var ephemeralTimeoutSeconds sql.NullInt64
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, ephemeral_timeout_seconds, completion_report, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id,
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &ephemeralTimeoutSeconds, &completionReport, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
@@ -514,6 +539,14 @@ func (m *Manager) Get(id string) (*Session, error) {
 	}
 	if lastError.Valid {
 		s.LastError = lastError.String
+	}
+	if ephemeralTimeoutSeconds.Valid {
+		v := int(ephemeralTimeoutSeconds.Int64)
+		s.EphemeralTimeoutSeconds = &v
+	}
+	if completionReport.Valid {
+		v := completionReport.String
+		s.CompletionReport = &v
 	}
 	return &s, nil
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -36,8 +36,8 @@ type Manager struct {
 	deletingSet map[string]struct{}
 	deletingMu  sync.Mutex
 	// spawnMu prevents concurrent holder spawns for the same session in SendKeysWithImages.
-	spawnMu sync.Mutex
-	logger  *slog.Logger
+	spawnMu        sync.Mutex
+	logger         *slog.Logger
 	onNewLines     func(sessionID string, newLines []string, total int)
 	onStatusChange func(sessionID string, status Status, lastError string)
 }
@@ -277,14 +277,14 @@ func (m *Manager) killStaleHolder(sessionID string) {
 
 // CreateOpts contains optional parameters for creating a session.
 type CreateOpts struct {
-	Provider        ProviderName
-	Model           string
-	FullAuto        bool   // enable full-auto mode (bypasses permission prompts for Codex)
-	SystemPrompt    string // per-session custom system prompt (appended to defaultSystemPrompt)
-	ParentSessionID string // parent session ID for sub-session creation
-	RoleTemplate    string // name of the role template used to create this session
-	Ephemeral       bool   // create session with type=ephemeral
-	EphemeralTimeoutSeconds *int // timeout in seconds for the ephemeral session
+	Provider                ProviderName
+	Model                   string
+	FullAuto                bool   // enable full-auto mode (bypasses permission prompts for Codex)
+	SystemPrompt            string // per-session custom system prompt (appended to defaultSystemPrompt)
+	ParentSessionID         string // parent session ID for sub-session creation
+	RoleTemplate            string // name of the role template used to create this session
+	Ephemeral               bool   // create session with type=ephemeral
+	EphemeralTimeoutSeconds *int   // timeout in seconds for the ephemeral session
 }
 
 func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts ...CreateOpts) (*Session, error) {
@@ -392,20 +392,20 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		sessionType = TypeEphemeral
 	}
 	s := &Session{
-		ID:              id,
-		Name:            name,
-		ProjectPath:     projectPath,
-		InitialPrompt:   prompt,
-		SystemPrompt:    customSystemPrompt,
-		Status:          StatusIdle,
-		Type:            sessionType,
-		Provider:        pn,
-		Model:           model,
-		ParentSessionID: parentSessionID,
-		RoleTemplate:    roleTemplate,
+		ID:                      id,
+		Name:                    name,
+		ProjectPath:             projectPath,
+		InitialPrompt:           prompt,
+		SystemPrompt:            customSystemPrompt,
+		Status:                  StatusIdle,
+		Type:                    sessionType,
+		Provider:                pn,
+		Model:                   model,
+		ParentSessionID:         parentSessionID,
+		RoleTemplate:            roleTemplate,
 		EphemeralTimeoutSeconds: ephemeralTimeoutSeconds,
-		CreatedAt:       now,
-		UpdatedAt:       now,
+		CreatedAt:               now,
+		UpdatedAt:               now,
 	}
 
 	var ephemeralTimeoutArg interface{}
@@ -489,7 +489,6 @@ func (m *Manager) List() ([]Session, error) {
 	}
 	return sessions, rows.Err()
 }
-
 
 func (m *Manager) Get(id string) (*Session, error) {
 	var s Session

--- a/internal/session/manager_holderPID_test.go
+++ b/internal/session/manager_holderPID_test.go
@@ -40,6 +40,8 @@ func newTestDB(t *testing.T) *sql.DB {
 			goals TEXT NOT NULL DEFAULT '[]',
 			last_error TEXT,
 			conversation_started INTEGER NOT NULL DEFAULT 0,
+			ephemeral_timeout_seconds INTEGER,
+			completion_report TEXT,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -15,12 +15,12 @@ type RecentProject struct {
 type Status string
 
 const (
-	StatusIdle         Status = "idle"           // Initial state / turn complete, waiting for user
-	StatusWorking      Status = "working"        // AI is working
-	StatusPaused       Status = "paused"         // User explicitly stopped the session
-	StatusExited       Status = "exited"         // Process died unexpectedly
-	StatusWaitingInput Status = "waiting_input"  // Waiting for user input (escalation/permission)
-	StatusArchived     Status = "archived"       // Ephemeral session finished and archived
+	StatusIdle         Status = "idle"          // Initial state / turn complete, waiting for user
+	StatusWorking      Status = "working"       // AI is working
+	StatusPaused       Status = "paused"        // User explicitly stopped the session
+	StatusExited       Status = "exited"        // Process died unexpectedly
+	StatusWaitingInput Status = "waiting_input" // Waiting for user input (escalation/permission)
+	StatusArchived     Status = "archived"      // Ephemeral session finished and archived
 )
 
 type SessionType string
@@ -33,29 +33,29 @@ const (
 )
 
 type Session struct {
-	ID              string       `json:"id"`
-	Name            string       `json:"name"`
-	ProjectPath     string       `json:"projectPath"`
-	InitialPrompt   string       `json:"initialPrompt,omitempty"`
-	SystemPrompt    string       `json:"systemPrompt,omitempty"`
-	Status          Status       `json:"status"`
-	Type            SessionType  `json:"type"`
-	Provider        ProviderName `json:"provider"`
-	CliSessionID    string       `json:"cliSessionId,omitempty"`
-	Model           string       `json:"model,omitempty"`
-	ParentSessionID string       `json:"parentSessionId,omitempty"`
-	RoleTemplate    string       `json:"roleTemplate,omitempty"`
-	CurrentTask     string       `json:"currentTask,omitempty"`
-	Goal            string       `json:"goal,omitempty"`
-	Goals           GoalStack    `json:"goals,omitempty"`
-	LastError       string       `json:"lastError,omitempty"`
-	HolderPID            int          `json:"holderPid,omitempty"`
-	ClearOffset          int64        `json:"clearOffset"`
-	ConversationStarted  bool         `json:"conversationStarted"`
-	EphemeralTimeoutSeconds *int      `json:"ephemeralTimeoutSeconds,omitempty"`
-	CompletionReport     *string      `json:"completionReport,omitempty"`
-	CreatedAt            time.Time    `json:"createdAt"`
-	UpdatedAt            time.Time    `json:"updatedAt"`
+	ID                      string       `json:"id"`
+	Name                    string       `json:"name"`
+	ProjectPath             string       `json:"projectPath"`
+	InitialPrompt           string       `json:"initialPrompt,omitempty"`
+	SystemPrompt            string       `json:"systemPrompt,omitempty"`
+	Status                  Status       `json:"status"`
+	Type                    SessionType  `json:"type"`
+	Provider                ProviderName `json:"provider"`
+	CliSessionID            string       `json:"cliSessionId,omitempty"`
+	Model                   string       `json:"model,omitempty"`
+	ParentSessionID         string       `json:"parentSessionId,omitempty"`
+	RoleTemplate            string       `json:"roleTemplate,omitempty"`
+	CurrentTask             string       `json:"currentTask,omitempty"`
+	Goal                    string       `json:"goal,omitempty"`
+	Goals                   GoalStack    `json:"goals,omitempty"`
+	LastError               string       `json:"lastError,omitempty"`
+	HolderPID               int          `json:"holderPid,omitempty"`
+	ClearOffset             int64        `json:"clearOffset"`
+	ConversationStarted     bool         `json:"conversationStarted"`
+	EphemeralTimeoutSeconds *int         `json:"ephemeralTimeoutSeconds,omitempty"`
+	CompletionReport        *string      `json:"completionReport,omitempty"`
+	CreatedAt               time.Time    `json:"createdAt"`
+	UpdatedAt               time.Time    `json:"updatedAt"`
 }
 
 type GoalEntry struct {

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -20,6 +20,7 @@ const (
 	StatusPaused       Status = "paused"         // User explicitly stopped the session
 	StatusExited       Status = "exited"         // Process died unexpectedly
 	StatusWaitingInput Status = "waiting_input"  // Waiting for user input (escalation/permission)
+	StatusArchived     Status = "archived"       // Ephemeral session finished and archived
 )
 
 type SessionType string
@@ -28,6 +29,7 @@ const (
 	TypeWorker     SessionType = "worker"
 	TypeController SessionType = "controller"
 	TypeExternal   SessionType = "external"
+	TypeEphemeral  SessionType = "ephemeral"
 )
 
 type Session struct {
@@ -50,6 +52,8 @@ type Session struct {
 	HolderPID            int          `json:"holderPid,omitempty"`
 	ClearOffset          int64        `json:"clearOffset"`
 	ConversationStarted  bool         `json:"conversationStarted"`
+	EphemeralTimeoutSeconds *int      `json:"ephemeralTimeoutSeconds,omitempty"`
+	CompletionReport     *string      `json:"completionReport,omitempty"`
 	CreatedAt            time.Time    `json:"createdAt"`
 	UpdatedAt            time.Time    `json:"updatedAt"`
 }


### PR DESCRIPTION
## Summary

親イシュー #591 のサブタスク #606 として、ephemeral session を実装するための DB とモデル層の土台を追加する。`complete_goal` による自動 archive、タイムアウト goroutine、CLI フラグ、フロントエンド UI は本 PR のスコープ外（#607 / #608 / #609 にて対応）。

- `SessionType` に `ephemeral` を追加し、`Status` に `archived` を追加
- `Session` 構造体に `EphemeralTimeoutSeconds *int` / `CompletionReport *string` を追加
- sessions テーブルに `ephemeral_timeout_seconds INTEGER` / `completion_report TEXT` カラムを追加するマイグレーションを追加
- `CreateOpts` に `Ephemeral bool` / `EphemeralTimeoutSeconds *int` を追加し、`Manager.Create()` で `Ephemeral=true` のときに `type=ephemeral` とタイムアウト値を永続化
- `createSessionRequest` に `ephemeral` / `ephemeralTimeoutSeconds` を追加して `CreateOpts` に伝搬

## Test plan

- [x] `make build` 通過
- [x] `make test` 通過
- [ ] 既存セッションを持つ DB でもマイグレーションが壊れないこと（`ALTER TABLE` の duplicate check 経由で冪等）
- [ ] 後続 PR (#607 以降) で ephemeral type のセッションが作成でき、`archived` へ遷移できること

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)