### PR TITLE
feat: ephemeral session DB + モデル層 (Closes #606)

### DIFF
--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -323,6 +323,18 @@ func migrate(db *sql.DB) error {
 	// Backfill: sessions with a non-empty cli_session_id and initial_prompt are assumed to have started.
 	_, _ = db.Exec(`UPDATE sessions SET conversation_started = 1 WHERE cli_session_id != '' AND initial_prompt != '' AND initial_prompt IS NOT NULL`)
 
+	// Migration: add ephemeral_timeout_seconds column if missing
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN ephemeral_timeout_seconds INTEGER`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
+	// Migration: add completion_report column if missing
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN completion_report TEXT`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,16 +203,18 @@ func (s *Server) NewHTTPServer(addr string) *http.Server {
 // API handlers
 
 type createSessionRequest struct {
-	Name            string `json:"name"`
-	ProjectPath     string `json:"projectPath"`
-	Prompt          string `json:"prompt,omitempty"`
-	Worktree        bool   `json:"worktree,omitempty"`
-	Provider        string `json:"provider,omitempty"`
-	Model           string `json:"model,omitempty"`
-	AutoApprove     bool   `json:"autoApprove,omitempty"`
-	SystemPrompt    string `json:"systemPrompt,omitempty"`
-	ParentSessionID string `json:"parentSessionId,omitempty"`
-	RoleTemplate    string `json:"roleTemplate,omitempty"`
+	Name                    string `json:"name"`
+	ProjectPath             string `json:"projectPath"`
+	Prompt                  string `json:"prompt,omitempty"`
+	Worktree                bool   `json:"worktree,omitempty"`
+	Provider                string `json:"provider,omitempty"`
+	Model                   string `json:"model,omitempty"`
+	AutoApprove             bool   `json:"autoApprove,omitempty"`
+	SystemPrompt            string `json:"systemPrompt,omitempty"`
+	ParentSessionID         string `json:"parentSessionId,omitempty"`
+	RoleTemplate            string `json:"roleTemplate,omitempty"`
+	Ephemeral               bool   `json:"ephemeral,omitempty"`
+	EphemeralTimeoutSeconds *int   `json:"ephemeralTimeoutSeconds,omitempty"`
 }
 
 type sendImageData struct {
@@ -292,7 +294,7 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "name and projectPath are required")
 		return
 	}
-	sess, err := s.sessions.Create(req.Name, req.ProjectPath, req.Prompt, req.Worktree, session.CreateOpts{Provider: session.ProviderName(req.Provider), Model: req.Model, FullAuto: req.AutoApprove, SystemPrompt: req.SystemPrompt, ParentSessionID: req.ParentSessionID, RoleTemplate: req.RoleTemplate})
+	sess, err := s.sessions.Create(req.Name, req.ProjectPath, req.Prompt, req.Worktree, session.CreateOpts{Provider: session.ProviderName(req.Provider), Model: req.Model, FullAuto: req.AutoApprove, SystemPrompt: req.SystemPrompt, ParentSessionID: req.ParentSessionID, RoleTemplate: req.RoleTemplate, Ephemeral: req.Ephemeral, EphemeralTimeoutSeconds: req.EphemeralTimeoutSeconds})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -87,6 +87,9 @@ func (m *Manager) ManagedHolderPIDs() []int {
 			pids = append(pids, pid)
 		}
 	}
+	if rows.Err() != nil {
+		return nil
+	}
 	return pids
 }
 
@@ -238,6 +241,9 @@ func (m *Manager) RecoverStreamProcesses() {
 			m.logger.Error("failed to update holder_pid", "sessionId", id, "pid", sp.HolderPID(), "error", err)
 		}
 		m.logger.Info("recovered stream process via new holder", "sessionId", id, "holderPid", sp.HolderPID())
+	}
+	if err := rows.Err(); err != nil {
+		m.logger.Error("recover stream processes: rows iteration error", "error", err)
 	}
 }
 
@@ -409,9 +415,9 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	}
 
 	if _, err := m.db.Exec(
-		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, system_prompt, parent_session_id, role_template, holder_pid, ephemeral_timeout_seconds, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, s.RoleTemplate, sp.HolderPID(), s.EphemeralTimeoutSeconds, s.CreatedAt, s.UpdatedAt,
+		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, system_prompt, parent_session_id, role_template, holder_pid, ephemeral_timeout_seconds, completion_report, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, s.RoleTemplate, sp.HolderPID(), s.EphemeralTimeoutSeconds, s.CompletionReport, s.CreatedAt, s.UpdatedAt,
 	); err != nil {
 		return nil, fmt.Errorf("insert session: %w", err)
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -483,7 +483,8 @@ func (m *Manager) List() ([]Session, error) {
 			s.EphemeralTimeoutSeconds = &v
 		}
 		if completionReport.Valid {
-			s.CompletionReport = &completionReport.String
+			v := completionReport.String
+			s.CompletionReport = &v
 		}
 
 		sessions = append(sessions, s)
@@ -546,7 +547,8 @@ func (m *Manager) Get(id string) (*Session, error) {
 		s.EphemeralTimeoutSeconds = &v
 	}
 	if completionReport.Valid {
-		s.CompletionReport = &completionReport.String
+		v := completionReport.String
+		s.CompletionReport = &v
 	}
 	return &s, nil
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -277,12 +277,14 @@ func (m *Manager) killStaleHolder(sessionID string) {
 
 // CreateOpts contains optional parameters for creating a session.
 type CreateOpts struct {
-	Provider        ProviderName
-	Model           string
-	FullAuto        bool   // enable full-auto mode (bypasses permission prompts for Codex)
-	SystemPrompt    string // per-session custom system prompt (appended to defaultSystemPrompt)
-	ParentSessionID string // parent session ID for sub-session creation
-	RoleTemplate    string // name of the role template used to create this session
+	Provider                ProviderName
+	Model                   string
+	FullAuto                bool   // enable full-auto mode (bypasses permission prompts for Codex)
+	SystemPrompt            string // per-session custom system prompt (appended to defaultSystemPrompt)
+	ParentSessionID         string // parent session ID for sub-session creation
+	RoleTemplate            string // name of the role template used to create this session
+	Ephemeral               bool   // create as ephemeral session
+	EphemeralTimeoutSeconds *int   // timeout in seconds for ephemeral sessions
 }
 
 func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts ...CreateOpts) (*Session, error) {
@@ -292,6 +294,8 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	customSystemPrompt := ""
 	parentSessionID := ""
 	roleTemplate := ""
+	ephemeral := false
+	var ephemeralTimeoutSeconds *int
 	if len(opts) > 0 {
 		if opts[0].Provider != "" {
 			pn = opts[0].Provider
@@ -301,6 +305,8 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		customSystemPrompt = opts[0].SystemPrompt
 		parentSessionID = opts[0].ParentSessionID
 		roleTemplate = opts[0].RoleTemplate
+		ephemeral = opts[0].Ephemeral
+		ephemeralTimeoutSeconds = opts[0].EphemeralTimeoutSeconds
 	}
 
 	// Validate parent session exists when creating a sub-session
@@ -381,26 +387,31 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	m.streamMu.Unlock()
 
 	now := time.Now()
+	sessionType := TypeWorker
+	if ephemeral {
+		sessionType = TypeEphemeral
+	}
 	s := &Session{
-		ID:              id,
-		Name:            name,
-		ProjectPath:     projectPath,
-		InitialPrompt:   prompt,
-		SystemPrompt:    customSystemPrompt,
-		Status:          StatusIdle,
-		Type:            TypeWorker,
-		Provider:        pn,
-		Model:           model,
-		ParentSessionID: parentSessionID,
-		RoleTemplate:    roleTemplate,
-		CreatedAt:       now,
-		UpdatedAt:       now,
+		ID:                      id,
+		Name:                    name,
+		ProjectPath:             projectPath,
+		InitialPrompt:           prompt,
+		SystemPrompt:            customSystemPrompt,
+		Status:                  StatusIdle,
+		Type:                    sessionType,
+		Provider:                pn,
+		Model:                   model,
+		ParentSessionID:         parentSessionID,
+		RoleTemplate:            roleTemplate,
+		EphemeralTimeoutSeconds: ephemeralTimeoutSeconds,
+		CreatedAt:               now,
+		UpdatedAt:               now,
 	}
 
 	if _, err := m.db.Exec(
-		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, system_prompt, parent_session_id, role_template, holder_pid, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, s.RoleTemplate, sp.HolderPID(), s.CreatedAt, s.UpdatedAt,
+		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, system_prompt, parent_session_id, role_template, holder_pid, ephemeral_timeout_seconds, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, s.RoleTemplate, sp.HolderPID(), s.EphemeralTimeoutSeconds, s.CreatedAt, s.UpdatedAt,
 	); err != nil {
 		return nil, fmt.Errorf("insert session: %w", err)
 	}
@@ -410,7 +421,7 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 
 func (m *Manager) List() ([]Session, error) {
 	rows, err := m.db.Query(
-		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, ephemeral_timeout_seconds, completion_report, created_at, updated_at
 		 FROM sessions ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -424,9 +435,10 @@ func (m *Manager) List() ([]Session, error) {
 		var status string
 		var sessionType string
 		var providerStr string
-		var prompt, systemPrompt, parentSessionID, roleTemplate, currentTask, goal, goalsJSON, lastError sql.NullString
+		var prompt, systemPrompt, parentSessionID, roleTemplate, currentTask, goal, goalsJSON, lastError, completionReport sql.NullString
 		var conversationStartedInt int
-		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		var ephemeralTimeoutSeconds sql.NullInt64
+		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &ephemeralTimeoutSeconds, &completionReport, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		s.ConversationStarted = conversationStartedInt != 0
@@ -460,6 +472,13 @@ func (m *Manager) List() ([]Session, error) {
 		if lastError.Valid {
 			s.LastError = lastError.String
 		}
+		if ephemeralTimeoutSeconds.Valid {
+			v := int(ephemeralTimeoutSeconds.Int64)
+			s.EphemeralTimeoutSeconds = &v
+		}
+		if completionReport.Valid {
+			s.CompletionReport = &completionReport.String
+		}
 
 		sessions = append(sessions, s)
 	}
@@ -472,12 +491,13 @@ func (m *Manager) Get(id string) (*Session, error) {
 	var status string
 	var sessionType string
 	var providerStr string
-	var prompt, systemPrompt, parentSessionID, roleTemplate, currentTask, goal, goalsJSON, lastError sql.NullString
+	var prompt, systemPrompt, parentSessionID, roleTemplate, currentTask, goal, goalsJSON, lastError, completionReport sql.NullString
 	var conversationStartedInt int
+	var ephemeralTimeoutSeconds sql.NullInt64
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, ephemeral_timeout_seconds, completion_report, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id,
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &ephemeralTimeoutSeconds, &completionReport, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
@@ -514,6 +534,13 @@ func (m *Manager) Get(id string) (*Session, error) {
 	}
 	if lastError.Valid {
 		s.LastError = lastError.String
+	}
+	if ephemeralTimeoutSeconds.Valid {
+		v := int(ephemeralTimeoutSeconds.Int64)
+		s.EphemeralTimeoutSeconds = &v
+	}
+	if completionReport.Valid {
+		s.CompletionReport = &completionReport.String
 	}
 	return &s, nil
 }

--- a/internal/session/manager_holderPID_test.go
+++ b/internal/session/manager_holderPID_test.go
@@ -40,6 +40,8 @@ func newTestDB(t *testing.T) *sql.DB {
 			goals TEXT NOT NULL DEFAULT '[]',
 			last_error TEXT,
 			conversation_started INTEGER NOT NULL DEFAULT 0,
+			ephemeral_timeout_seconds INTEGER,
+			completion_report TEXT,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -20,6 +20,7 @@ const (
 	StatusPaused       Status = "paused"         // User explicitly stopped the session
 	StatusExited       Status = "exited"         // Process died unexpectedly
 	StatusWaitingInput Status = "waiting_input"  // Waiting for user input (escalation/permission)
+	StatusArchived     Status = "archived"       // Session has been archived
 )
 
 type SessionType string
@@ -28,6 +29,7 @@ const (
 	TypeWorker     SessionType = "worker"
 	TypeController SessionType = "controller"
 	TypeExternal   SessionType = "external"
+	TypeEphemeral  SessionType = "ephemeral"
 )
 
 type Session struct {
@@ -47,11 +49,13 @@ type Session struct {
 	Goal            string       `json:"goal,omitempty"`
 	Goals           GoalStack    `json:"goals,omitempty"`
 	LastError       string       `json:"lastError,omitempty"`
-	HolderPID            int          `json:"holderPid,omitempty"`
-	ClearOffset          int64        `json:"clearOffset"`
-	ConversationStarted  bool         `json:"conversationStarted"`
-	CreatedAt            time.Time    `json:"createdAt"`
-	UpdatedAt            time.Time    `json:"updatedAt"`
+	HolderPID                int          `json:"holderPid,omitempty"`
+	ClearOffset              int64        `json:"clearOffset"`
+	ConversationStarted      bool         `json:"conversationStarted"`
+	EphemeralTimeoutSeconds  *int         `json:"ephemeralTimeoutSeconds,omitempty"`
+	CompletionReport         *string      `json:"completionReport,omitempty"`
+	CreatedAt                time.Time    `json:"createdAt"`
+	UpdatedAt                time.Time    `json:"updatedAt"`
 }
 
 type GoalEntry struct {


### PR DESCRIPTION
## Summary
- `TypeEphemeral` SessionType と `StatusArchived` Status を追加
- `Session` 構造体に `EphemeralTimeoutSeconds`, `CompletionReport` フィールドを追加
- SQLite マイグレーションで `ephemeral_timeout_seconds`, `completion_report` カラムを追加
- `CreateOpts` に `Ephemeral`, `EphemeralTimeoutSeconds` を追加し、Create/List/Get を対応
- `createSessionRequest` に `ephemeral`, `ephemeralTimeoutSeconds` フィールドを追加

## Test plan
- [x] `make build` 通過
- [x] `make test` 通過（テスト用DBスキーマも更新済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)