### PR TITLE
feat: ephemeral session timeout monitoring

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -300,7 +300,7 @@ func (m *Manager) recoverEphemeralTimeouts() {
 					"sessionId", id, "error", err)
 			}
 			if parentID != "" {
-				msg := fmt.Sprintf("[system] Ephemeral session %s has been archived due to timeout (%ds).", id, timeoutSeconds)
+				msg := fmt.Sprintf("[system] Ephemeral session %s has been archived due to timeout (%s).", id, time.Duration(timeoutSeconds)*time.Second)
 				if err := m.SendKeys(parentID, msg); err != nil {
 					m.logger.Warn("recover ephemeral timeouts: failed to notify parent",
 						"sessionId", id, "parentSessionId", parentID, "error", err)
@@ -311,6 +311,9 @@ func (m *Manager) recoverEphemeralTimeouts() {
 				"sessionId", id, "remaining", remaining)
 			m.startEphemeralTimeout(id, parentID, remaining)
 		}
+	}
+	if err := rows.Err(); err != nil {
+		m.logger.Error("recover ephemeral timeouts: rows iteration error", "error", err)
 	}
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -246,6 +246,72 @@ func (m *Manager) RecoverStreamProcesses() {
 	if err := rows.Err(); err != nil {
 		m.logger.Error("recover stream processes: rows iteration error", "error", err)
 	}
+
+	// Recover ephemeral timeout goroutines for active ephemeral sessions
+	m.recoverEphemeralTimeouts()
+}
+
+// recoverEphemeralTimeouts scans ephemeral sessions with a timeout that are still
+// in an active state (working/idle) and restarts their timeout goroutines with
+// the remaining time based on created_at + timeout - now.
+func (m *Manager) recoverEphemeralTimeouts() {
+	rows, err := m.db.Query(
+		`SELECT id, parent_session_id, ephemeral_timeout_seconds, created_at
+		 FROM sessions
+		 WHERE type = ? AND ephemeral_timeout_seconds IS NOT NULL AND status IN (?, ?)`,
+		string(TypeEphemeral), string(StatusWorking), string(StatusIdle),
+	)
+	if err != nil {
+		m.logger.Error("recover ephemeral timeouts: query failed", "error", err)
+		return
+	}
+	defer rows.Close()
+
+	now := time.Now()
+	for rows.Next() {
+		var id string
+		var parentSessionID sql.NullString
+		var timeoutSeconds int
+		var createdAt time.Time
+		if err := rows.Scan(&id, &parentSessionID, &timeoutSeconds, &createdAt); err != nil {
+			m.logger.Error("recover ephemeral timeouts: scan failed", "error", err)
+			continue
+		}
+
+		deadline := createdAt.Add(time.Duration(timeoutSeconds) * time.Second)
+		remaining := deadline.Sub(now)
+
+		parentID := ""
+		if parentSessionID.Valid {
+			parentID = parentSessionID.String
+		}
+
+		if remaining <= 0 {
+			// Already expired, archive immediately
+			m.logger.Info("ephemeral session already expired, archiving now",
+				"sessionId", id, "deadline", deadline)
+			m.stopStreamProcess(id)
+			if err := m.UpdateStatus(id, StatusArchived); err != nil {
+				m.logger.Error("recover ephemeral timeouts: failed to archive",
+					"sessionId", id, "error", err)
+			}
+			if _, err := m.db.Exec("UPDATE sessions SET holder_pid = 0, updated_at = ? WHERE id = ?", now, id); err != nil {
+				m.logger.Error("recover ephemeral timeouts: failed to clear holder_pid",
+					"sessionId", id, "error", err)
+			}
+			if parentID != "" {
+				msg := fmt.Sprintf("[system] Ephemeral session %s has been archived due to timeout (%ds).", id, timeoutSeconds)
+				if err := m.SendKeys(parentID, msg); err != nil {
+					m.logger.Warn("recover ephemeral timeouts: failed to notify parent",
+						"sessionId", id, "parentSessionId", parentID, "error", err)
+				}
+			}
+		} else {
+			m.logger.Info("restarting ephemeral timeout goroutine",
+				"sessionId", id, "remaining", remaining)
+			m.startEphemeralTimeout(id, parentID, remaining)
+		}
+	}
 }
 
 // updateHolderPID persists the holder PID to the database.
@@ -429,7 +495,59 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		return nil, fmt.Errorf("insert session: %w", err)
 	}
 
+	// Start ephemeral timeout goroutine if applicable
+	if ephemeral && ephemeralTimeoutSeconds != nil && *ephemeralTimeoutSeconds > 0 {
+		m.startEphemeralTimeout(s.ID, s.ParentSessionID, time.Duration(*ephemeralTimeoutSeconds)*time.Second)
+	}
+
 	return s, nil
+}
+
+// startEphemeralTimeout launches a goroutine that waits for the given duration,
+// then checks if the session is still active (working/idle) and archives it if so.
+// If the session has a parent, a notification is sent to the parent via SendKeys.
+func (m *Manager) startEphemeralTimeout(sessionID, parentSessionID string, timeout time.Duration) {
+	go func() {
+		time.Sleep(timeout)
+
+		s, err := m.Get(sessionID)
+		if err != nil {
+			m.logger.Warn("ephemeral timeout: session not found", "sessionId", sessionID, "error", err)
+			return
+		}
+
+		// Only archive if still in an active state
+		if s.Status != StatusWorking && s.Status != StatusIdle {
+			m.logger.Info("ephemeral timeout: session already in terminal state, skipping",
+				"sessionId", sessionID, "status", s.Status)
+			return
+		}
+
+		// Stop the stream process and archive
+		m.stopStreamProcess(sessionID)
+		if err := m.UpdateStatus(sessionID, StatusArchived); err != nil {
+			m.logger.Error("ephemeral timeout: failed to archive session",
+				"sessionId", sessionID, "error", err)
+			return
+		}
+		// Clear holder_pid since process is stopped
+		if _, err := m.db.Exec("UPDATE sessions SET holder_pid = 0, updated_at = ? WHERE id = ?", time.Now(), sessionID); err != nil {
+			m.logger.Error("ephemeral timeout: failed to clear holder_pid",
+				"sessionId", sessionID, "error", err)
+		}
+
+		m.logger.Info("ephemeral session archived due to timeout",
+			"sessionId", sessionID, "timeout", timeout)
+
+		// Notify parent session if exists
+		if parentSessionID != "" {
+			msg := fmt.Sprintf("[system] Ephemeral session %s has been archived due to timeout (%s).", sessionID, timeout)
+			if err := m.SendKeys(parentSessionID, msg); err != nil {
+				m.logger.Warn("ephemeral timeout: failed to notify parent session",
+					"sessionId", sessionID, "parentSessionId", parentSessionID, "error", err)
+			}
+		}
+	}()
 }
 
 func (m *Manager) List() ([]Session, error) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bufio"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -38,7 +39,12 @@ type Manager struct {
 	deletingMu  sync.Mutex
 	// spawnMu prevents concurrent holder spawns for the same session in SendKeysWithImages.
 	spawnMu sync.Mutex
-	logger  *slog.Logger
+	// ephemeralCancels stores cancel functions for active ephemeral timeout goroutines.
+	// When a session is manually stopped/deleted/archived, its cancel func is invoked
+	// so the goroutine exits immediately rather than leaking until the timer fires.
+	ephemeralCancels   map[string]context.CancelFunc
+	ephemeralCancelsMu sync.Mutex
+	logger             *slog.Logger
 	onNewLines     func(sessionID string, newLines []string, total int)
 	onStatusChange func(sessionID string, status Status, lastError string)
 }
@@ -66,9 +72,10 @@ func NewManager(db *sql.DB, claudeCommand string, permissionMode string, apiPort
 		permissionMode:  permissionMode,
 		apiPort:         apiPort,
 		systemPrompt:    systemPrompt,
-		streamProcesses: make(map[string]*HolderStreamProcess),
-		deletingSet:     make(map[string]struct{}),
-		logger:          logger.With("component", "session_manager"),
+		streamProcesses:  make(map[string]*HolderStreamProcess),
+		deletingSet:      make(map[string]struct{}),
+		ephemeralCancels: make(map[string]context.CancelFunc),
+		logger:           logger.With("component", "session_manager"),
 	}
 }
 
@@ -251,6 +258,14 @@ func (m *Manager) RecoverStreamProcesses() {
 	m.recoverEphemeralTimeouts()
 }
 
+// ephemeralTimeoutEntry holds the data scanned from a single row in recoverEphemeralTimeouts.
+type ephemeralTimeoutEntry struct {
+	id             string
+	parentID       string
+	timeoutSeconds int
+	createdAt      time.Time
+}
+
 // recoverEphemeralTimeouts scans ephemeral sessions with a timeout that are still
 // in an active state (working/idle) and restarts their timeout goroutines with
 // the remaining time based on created_at + timeout - now.
@@ -265,9 +280,9 @@ func (m *Manager) recoverEphemeralTimeouts() {
 		m.logger.Error("recover ephemeral timeouts: query failed", "error", err)
 		return
 	}
-	defer rows.Close()
 
-	now := time.Now()
+	// Collect all rows before closing so subsequent DB writes don't compete for the connection.
+	var entries []ephemeralTimeoutEntry
 	for rows.Next() {
 		var id string
 		var parentSessionID sql.NullString
@@ -277,39 +292,49 @@ func (m *Manager) recoverEphemeralTimeouts() {
 			m.logger.Error("recover ephemeral timeouts: scan failed", "error", err)
 			continue
 		}
-
-		deadline := createdAt.Add(time.Duration(timeoutSeconds) * time.Second)
-		remaining := deadline.Sub(now)
-
 		parentID := ""
 		if parentSessionID.Valid {
 			parentID = parentSessionID.String
 		}
+		entries = append(entries, ephemeralTimeoutEntry{
+			id:             id,
+			parentID:       parentID,
+			timeoutSeconds: timeoutSeconds,
+			createdAt:      createdAt,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		m.logger.Error("recover ephemeral timeouts: rows iteration error", "error", err)
+	}
+	rows.Close()
+
+	now := time.Now()
+	for _, e := range entries {
+		deadline := e.createdAt.Add(time.Duration(e.timeoutSeconds) * time.Second)
+		remaining := deadline.Sub(now)
 
 		if remaining <= 0 {
 			// Already expired, archive immediately
 			m.logger.Info("ephemeral session already expired, archiving now",
-				"sessionId", id, "deadline", deadline)
-			m.stopStreamProcess(id)
-			if err := m.UpdateStatus(id, StatusArchived); err != nil {
+				"sessionId", e.id, "deadline", deadline)
+			m.stopStreamProcess(e.id)
+			// Atomically update status and clear holder_pid in one query
+			if err := m.UpdateStatusWithHolderPIDClear(e.id, StatusArchived); err != nil {
 				m.logger.Error("recover ephemeral timeouts: failed to archive",
-					"sessionId", id, "error", err)
+					"sessionId", e.id, "error", err)
 			}
-			if _, err := m.db.Exec("UPDATE sessions SET holder_pid = 0, updated_at = ? WHERE id = ?", now, id); err != nil {
-				m.logger.Error("recover ephemeral timeouts: failed to clear holder_pid",
-					"sessionId", id, "error", err)
-			}
-			if parentID != "" {
-				msg := fmt.Sprintf("[system] Ephemeral session %s has been archived due to timeout (%s).", id, time.Duration(timeoutSeconds)*time.Second)
-				if err := m.SendKeys(parentID, msg); err != nil {
+			if e.parentID != "" {
+				timeout := time.Duration(e.timeoutSeconds) * time.Second
+				msg := fmt.Sprintf("[system] Ephemeral session %s has been archived due to timeout (%s).", e.id, timeout)
+				if err := m.SendKeys(e.parentID, msg); err != nil {
 					m.logger.Warn("recover ephemeral timeouts: failed to notify parent",
-						"sessionId", id, "parentSessionId", parentID, "error", err)
+						"sessionId", e.id, "parentSessionId", e.parentID, "error", err)
 				}
 			}
 		} else {
 			m.logger.Info("restarting ephemeral timeout goroutine",
-				"sessionId", id, "remaining", remaining)
-			m.startEphemeralTimeout(id, parentID, remaining)
+				"sessionId", e.id, "remaining", remaining)
+			m.startEphemeralTimeout(e.id, e.parentID, remaining)
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -509,9 +534,34 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 // startEphemeralTimeout launches a goroutine that waits for the given duration,
 // then checks if the session is still active (working/idle) and archives it if so.
 // If the session has a parent, a notification is sent to the parent via SendKeys.
+// The returned cancel func (also stored in m.ephemeralCancels) can be used to
+// terminate the goroutine early when the session is manually stopped/deleted.
 func (m *Manager) startEphemeralTimeout(sessionID, parentSessionID string, timeout time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	m.ephemeralCancelsMu.Lock()
+	m.ephemeralCancels[sessionID] = cancel
+	m.ephemeralCancelsMu.Unlock()
+
 	go func() {
-		time.Sleep(timeout)
+		defer func() {
+			cancel()
+			m.ephemeralCancelsMu.Lock()
+			delete(m.ephemeralCancels, sessionID)
+			m.ephemeralCancelsMu.Unlock()
+		}()
+
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				// Timer fired normally — proceed to archive
+			} else {
+				// Cancelled externally (manual stop/delete/archive)
+				m.logger.Info("ephemeral timeout goroutine cancelled",
+					"sessionId", sessionID)
+				return
+			}
+		}
 
 		s, err := m.Get(sessionID)
 		if err != nil {
@@ -526,17 +576,12 @@ func (m *Manager) startEphemeralTimeout(sessionID, parentSessionID string, timeo
 			return
 		}
 
-		// Stop the stream process and archive
+		// Stop the stream process and archive (atomically update status + holder_pid in one query)
 		m.stopStreamProcess(sessionID)
-		if err := m.UpdateStatus(sessionID, StatusArchived); err != nil {
+		if err := m.UpdateStatusWithHolderPIDClear(sessionID, StatusArchived); err != nil {
 			m.logger.Error("ephemeral timeout: failed to archive session",
 				"sessionId", sessionID, "error", err)
 			return
-		}
-		// Clear holder_pid since process is stopped
-		if _, err := m.db.Exec("UPDATE sessions SET holder_pid = 0, updated_at = ? WHERE id = ?", time.Now(), sessionID); err != nil {
-			m.logger.Error("ephemeral timeout: failed to clear holder_pid",
-				"sessionId", sessionID, "error", err)
 		}
 
 		m.logger.Info("ephemeral session archived due to timeout",
@@ -551,6 +596,26 @@ func (m *Manager) startEphemeralTimeout(sessionID, parentSessionID string, timeo
 			}
 		}
 	}()
+}
+
+// cancelEphemeralTimeout cancels the ephemeral timeout goroutine for the given session,
+// if one is active. This should be called when a session is manually stopped or deleted.
+func (m *Manager) cancelEphemeralTimeout(sessionID string) {
+	m.ephemeralCancelsMu.Lock()
+	cancel, ok := m.ephemeralCancels[sessionID]
+	m.ephemeralCancelsMu.Unlock()
+	if ok {
+		cancel()
+	}
+}
+
+// UpdateStatusWithHolderPIDClear updates the session status and clears holder_pid atomically.
+func (m *Manager) UpdateStatusWithHolderPIDClear(id string, status Status) error {
+	_, err := m.db.Exec("UPDATE sessions SET status = ?, holder_pid = 0, updated_at = ? WHERE id = ?", string(status), time.Now(), id)
+	if err == nil && m.onStatusChange != nil {
+		m.onStatusChange(id, status, "")
+	}
+	return err
 }
 
 func (m *Manager) List() ([]Session, error) {
@@ -847,6 +912,9 @@ func (m *Manager) Stop(id string) error {
 		return err
 	}
 
+	// Cancel ephemeral timeout goroutine if active
+	m.cancelEphemeralTimeout(id)
+
 	// Stop stream process if exists
 	m.stopStreamProcess(id)
 
@@ -871,6 +939,9 @@ func (m *Manager) Delete(id string) error {
 		delete(m.deletingSet, id)
 		m.deletingMu.Unlock()
 	}()
+
+	// Cancel ephemeral timeout goroutine if active
+	m.cancelEphemeralTimeout(id)
 
 	// Stop stream process if exists
 	m.stopStreamProcess(id)

--- a/internal/session/manager_ephemeral_test.go
+++ b/internal/session/manager_ephemeral_test.go
@@ -1,0 +1,129 @@
+package session
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// newTestManagerFull creates a Manager (with all fields initialised) backed by
+// an in-memory SQLite DB.  Unlike the newTestManager helper in manager_holderPID_test.go
+// which only sets db/logger, this version uses NewManager so that maps like
+// ephemeralCancels are properly initialised.
+//
+// MaxOpenConns is set to 1 so that all queries share a single connection and
+// therefore see the same :memory: SQLite database instance.
+func newTestManagerFull(t *testing.T) *Manager {
+	t.Helper()
+	db := newTestDB(t)
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+	return NewManager(db, "claude", "default", 0, slog.Default(), "")
+}
+
+// insertEphemeralSession inserts a minimal ephemeral session row directly into
+// the DB so that recoverEphemeralTimeouts / startEphemeralTimeout can operate
+// on it without requiring a running holder process.
+func insertEphemeralSession(t *testing.T, m *Manager, id string, timeoutSeconds int, createdAt time.Time) {
+	t.Helper()
+	_, err := m.db.Exec(
+		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, holder_pid, ephemeral_timeout_seconds, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, "test", "/tmp", "", "", string(StatusIdle), string(TypeEphemeral), "stream", "claude", "", 0,
+		timeoutSeconds, createdAt, createdAt,
+	)
+	if err != nil {
+		t.Fatalf("insertEphemeralSession: %v", err)
+	}
+}
+
+// TestRecoverEphemeralTimeouts_AlreadyExpired verifies that recoverEphemeralTimeouts
+// immediately archives a session whose deadline has already passed.
+func TestRecoverEphemeralTimeouts_AlreadyExpired(t *testing.T) {
+	m := newTestManagerFull(t)
+
+	id := "expire-now"
+	// created 10 minutes ago with a 5-minute timeout → already expired
+	createdAt := time.Now().Add(-10 * time.Minute)
+	insertEphemeralSession(t, m, id, 300 /* 5 min */, createdAt)
+
+	m.recoverEphemeralTimeouts()
+
+	var status string
+	var holderPID int
+	if err := m.db.QueryRow("SELECT status, holder_pid FROM sessions WHERE id = ?", id).Scan(&status, &holderPID); err != nil {
+		t.Fatalf("query session: %v", err)
+	}
+	if status != string(StatusArchived) {
+		t.Errorf("status = %q, want %q", status, StatusArchived)
+	}
+	if holderPID != 0 {
+		t.Errorf("holder_pid = %d, want 0", holderPID)
+	}
+}
+
+// TestRecoverEphemeralTimeouts_NotYetExpired verifies that recoverEphemeralTimeouts
+// launches a goroutine (and doesn't immediately archive) for a session that still
+// has time remaining, and that the goroutine archives it after the remaining time elapses.
+func TestRecoverEphemeralTimeouts_NotYetExpired(t *testing.T) {
+	m := newTestManagerFull(t)
+
+	id := "expire-soon"
+	// created 1 second ago with a 2-second timeout → ~1 second remaining
+	createdAt := time.Now().Add(-1 * time.Second)
+	insertEphemeralSession(t, m, id, 2 /* 2 sec */, createdAt)
+
+	m.recoverEphemeralTimeouts()
+
+	// Immediately after recovery the session should still be idle
+	var status string
+	if err := m.db.QueryRow("SELECT status FROM sessions WHERE id = ?", id).Scan(&status); err != nil {
+		t.Fatalf("query session: %v", err)
+	}
+	if status != string(StatusIdle) {
+		t.Errorf("status immediately after recover = %q, want %q", status, StatusIdle)
+	}
+
+	// Wait for the goroutine to fire (remaining ≈ 1s; allow 3s for CI slack)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(100 * time.Millisecond)
+		if err := m.db.QueryRow("SELECT status FROM sessions WHERE id = ?", id).Scan(&status); err != nil {
+			t.Fatalf("query session: %v", err)
+		}
+		if status == string(StatusArchived) {
+			break
+		}
+	}
+	if status != string(StatusArchived) {
+		t.Errorf("status after timeout = %q, want %q", status, StatusArchived)
+	}
+}
+
+// TestCancelEphemeralTimeout verifies that cancelling an ephemeral timeout goroutine
+// prevents it from archiving the session.
+func TestCancelEphemeralTimeout(t *testing.T) {
+	m := newTestManagerFull(t)
+
+	id := "cancel-me"
+	createdAt := time.Now()
+	insertEphemeralSession(t, m, id, 3600 /* 1h */, createdAt)
+
+	// Start a goroutine that would fire in 200ms (short for test speed)
+	m.startEphemeralTimeout(id, "", 200*time.Millisecond)
+
+	// Cancel it immediately
+	m.cancelEphemeralTimeout(id)
+
+	// Wait slightly longer than 200ms to give the goroutine time to (not) run
+	time.Sleep(400 * time.Millisecond)
+
+	var status string
+	if err := m.db.QueryRow("SELECT status FROM sessions WHERE id = ?", id).Scan(&status); err != nil {
+		t.Fatalf("query session: %v", err)
+	}
+	// Session should remain idle because the goroutine was cancelled
+	if status != string(StatusIdle) {
+		t.Errorf("status = %q after cancel, want %q (goroutine should have been cancelled)", status, StatusIdle)
+	}
+}


### PR DESCRIPTION
## Summary
- In `Create()`: starts a goroutine when ephemeral + timeout is set that waits for the duration, checks if the session is still working/idle, and archives it
- On server recovery (`RecoverStreamProcesses`): scans ephemeral+active sessions and restarts timeout goroutines with remaining time, or archives immediately if already expired
- Parent session is notified via `SendKeys` when a child ephemeral session is archived due to timeout

Closes #608

## Test plan
- [x] `make build && make test` passes
- [ ] Create an ephemeral session with a short timeout and verify it gets archived
- [ ] Restart the server while an ephemeral session is active and verify timeout resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)