### PR TITLE
feat: complete_goal拡張 - レポート保存・自動アーカイブ・親通知

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -358,7 +358,7 @@ func (s *Server) handleCompleteGoal(args json.RawMessage) (interface{}, *jsonRPC
 	var input struct {
 		Report string `json:"report"`
 	}
-	_ = json.Unmarshal(args, &input)
+	_ = json.Unmarshal(args, &input) // report is optional; ignore error (defaults to empty string)
 
 	parentGoal, err := s.apiCompleteGoal(sessionID, input.Report)
 	if err != nil {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -168,11 +168,15 @@ func (s *Server) handleMethod(method string, params json.RawMessage) (interface{
 				},
 				map[string]interface{}{
 					"name":        "complete_goal",
-					"description": "現在のゴールを達成済みとしてポップします。親ゴールがあればそれがアクティブになります。",
+					"description": "現在のゴールを達成済みとしてポップします。親ゴールがあればそれがアクティブになります。reportを指定すると完了レポートとして保存されます。",
 					"inputSchema": map[string]interface{}{
 						"type": "object",
 						"properties": map[string]interface{}{
 							"session_id": sessionIDProperty,
+							"report": map[string]interface{}{
+								"type":        "string",
+								"description": "完了時のレポート文字列（任意）",
+							},
 						},
 					},
 				},
@@ -351,7 +355,12 @@ func (s *Server) handleCompleteGoal(args json.RawMessage) (interface{}, *jsonRPC
 		return nil, rpcErr
 	}
 
-	parentGoal, err := s.apiCompleteGoal(sessionID)
+	var input struct {
+		Report string `json:"report"`
+	}
+	_ = json.Unmarshal(args, &input)
+
+	parentGoal, err := s.apiCompleteGoal(sessionID, input.Report)
 	if err != nil {
 		return toolResult(fmt.Sprintf("Error: %v", err), true), nil
 	}
@@ -613,12 +622,21 @@ func (s *Server) apiCreateGoal(sessionID string, currentTask, goal string, subgo
 	return nil
 }
 
-func (s *Server) apiCompleteGoal(sessionID string) (string, error) {
+func (s *Server) apiCompleteGoal(sessionID string, report string) (string, error) {
 	url := fmt.Sprintf("%s/api/sessions/%s/goals/complete", s.apiURL, sessionID)
 
-	req, err := http.NewRequest("POST", url, nil)
+	var bodyReader io.Reader
+	if report != "" {
+		body := fmt.Sprintf(`{"report":%s}`, jsonString(report))
+		bodyReader = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequest("POST", url, bodyReader)
 	if err != nil {
 		return "", err
+	}
+	if bodyReader != nil {
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -572,7 +572,14 @@ func (s *Server) createGoal(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) completeGoal(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	cgResult, err := s.sessions.CompleteGoal(id)
+
+	var req struct {
+		Report string `json:"report"`
+	}
+	// Body is optional; ignore decode errors (e.g. empty body)
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	cgResult, err := s.sessions.CompleteGoal(id, req.Report)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -598,6 +605,28 @@ func (s *Server) completeGoal(w http.ResponseWriter, r *http.Request) {
 				"currentTask": cgResult.CompletedGoal.CurrentTask,
 				"goal":        cgResult.CompletedGoal.Goal,
 				"durationMs":  durationMs,
+			},
+		})
+	}
+
+	// If auto-archived ephemeral session with parent, notify parent
+	if cgResult.AutoArchived && cgResult.ParentSessionID != "" && req.Report != "" {
+		notifyMsg := fmt.Sprintf("[ephemeral session %s completed] %s", cgResult.SessionName, req.Report)
+		s.recordSessionAction(cgResult.ParentSessionID, "agent_notification", notifyMsg)
+		if err := s.saveNotification(cgResult.ParentSessionID, "notification", notifyMsg); err != nil {
+			slog.Error("failed to save completion notification", "error", err)
+		}
+		parentSess, _ := s.sessions.Get(cgResult.ParentSessionID)
+		parentName := ""
+		if parentSess != nil {
+			parentName = parentSess.Name
+		}
+		s.hub.Broadcast(Message{
+			Type: "agent_notification",
+			Data: map[string]interface{}{
+				"sessionId":   cgResult.ParentSessionID,
+				"sessionName": parentName,
+				"message":     notifyMsg,
 			},
 		})
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -609,9 +609,13 @@ func (s *Server) completeGoal(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// If auto-archived ephemeral session with parent, notify parent
-	if cgResult.AutoArchived && cgResult.ParentSessionID != "" && req.Report != "" {
-		notifyMsg := fmt.Sprintf("[ephemeral session %s completed] %s", cgResult.SessionName, req.Report)
+	// If auto-archived ephemeral session with parent, notify parent regardless of whether report is set
+	if cgResult.AutoArchived && cgResult.ParentSessionID != "" {
+		reportPart := req.Report
+		if reportPart == "" {
+			reportPart = "(report なし)"
+		}
+		notifyMsg := fmt.Sprintf("[ephemeral session %s completed] %s", cgResult.SessionName, reportPart)
 		s.recordSessionAction(cgResult.ParentSessionID, "agent_notification", notifyMsg)
 		if err := s.saveNotification(cgResult.ParentSessionID, "notification", notifyMsg); err != nil {
 			slog.Error("failed to save completion notification", "error", err)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1376,7 +1376,17 @@ func (m *Manager) CompleteGoal(id string, report string) (*CompleteGoalResult, e
 		goal = top.Goal
 	}
 
-	_, err = m.db.Exec(
+	tx, err := m.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	_, err = tx.Exec(
 		"UPDATE sessions SET current_task = ?, goal = ?, goals = ?, updated_at = ? WHERE id = ?",
 		currentTask, goal, newGoals.ToJSON(), time.Now(), id,
 	)
@@ -1396,12 +1406,12 @@ func (m *Manager) CompleteGoal(id string, report string) (*CompleteGoalResult, e
 	// When goal stack is empty and session is ephemeral, auto-archive and save report
 	if newGoals.Top() == nil && s.Type == TypeEphemeral {
 		if report != "" {
-			_, err = m.db.Exec(
+			_, err = tx.Exec(
 				"UPDATE sessions SET completion_report = ?, status = ?, updated_at = ? WHERE id = ?",
 				report, string(StatusArchived), time.Now(), id,
 			)
 		} else {
-			_, err = m.db.Exec(
+			_, err = tx.Exec(
 				"UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?",
 				string(StatusArchived), time.Now(), id,
 			)
@@ -1414,13 +1424,17 @@ func (m *Manager) CompleteGoal(id string, report string) (*CompleteGoalResult, e
 		result.SessionName = s.Name
 	} else if report != "" {
 		// Save completion report even if not auto-archiving
-		_, err = m.db.Exec(
+		_, err = tx.Exec(
 			"UPDATE sessions SET completion_report = ?, updated_at = ? WHERE id = ?",
 			report, time.Now(), id,
 		)
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
 	}
 
 	return result, nil

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1354,11 +1354,14 @@ func (m *Manager) CreateGoal(id string, currentTask, goal string, subgoal bool) 
 
 // CompleteGoalResult contains the result of completing a goal.
 type CompleteGoalResult struct {
-	CompletedGoal *GoalEntry // the goal that was just completed
-	ParentGoal    *GoalEntry // the new top of stack (nil if empty)
+	CompletedGoal   *GoalEntry // the goal that was just completed
+	ParentGoal      *GoalEntry // the new top of stack (nil if empty)
+	AutoArchived    bool       // true if session was auto-archived (ephemeral with empty goal stack)
+	ParentSessionID string     // parent session ID for notification (set when auto-archived)
+	SessionName     string     // name of the completed session
 }
 
-func (m *Manager) CompleteGoal(id string) (*CompleteGoalResult, error) {
+func (m *Manager) CompleteGoal(id string, report string) (*CompleteGoalResult, error) {
 	s, err := m.Get(id)
 	if err != nil {
 		return nil, err
@@ -1389,6 +1392,37 @@ func (m *Manager) CompleteGoal(id string) (*CompleteGoalResult, error) {
 	if top := newGoals.Top(); top != nil {
 		result.ParentGoal = top
 	}
+
+	// When goal stack is empty and session is ephemeral, auto-archive and save report
+	if newGoals.Top() == nil && s.Type == TypeEphemeral {
+		if report != "" {
+			_, err = m.db.Exec(
+				"UPDATE sessions SET completion_report = ?, status = ?, updated_at = ? WHERE id = ?",
+				report, string(StatusArchived), time.Now(), id,
+			)
+		} else {
+			_, err = m.db.Exec(
+				"UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?",
+				string(StatusArchived), time.Now(), id,
+			)
+		}
+		if err != nil {
+			return nil, err
+		}
+		result.AutoArchived = true
+		result.ParentSessionID = s.ParentSessionID
+		result.SessionName = s.Name
+	} else if report != "" {
+		// Save completion report even if not auto-archiving
+		_, err = m.db.Exec(
+			"UPDATE sessions SET completion_report = ?, updated_at = ? WHERE id = ?",
+			report, time.Now(), id,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return result, nil
 }
 

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -40,7 +40,8 @@ type SessionService interface {
 	// CreateGoal creates a new goal for a session.
 	CreateGoal(id string, currentTask, goal string, subgoal bool) error
 	// CompleteGoal completes the current goal and returns the result.
-	CompleteGoal(id string) (*CompleteGoalResult, error)
+	// report is an optional completion report string.
+	CompleteGoal(id string, report string) (*CompleteGoalResult, error)
 
 	// GetStreamLines returns stream lines for a session.
 	GetStreamLines(id string, limit int) ([]string, int, error)


### PR DESCRIPTION
## Summary
- MCP `complete_goal` ツールに `report` パラメータを追加（任意）
- `completion_report` を DB に保存
- ephemeral セッションでゴールスタックが空になった場合、自動で `archived` ステータスに変更
- `parent_session_id` がある場合、親セッションに `send_notification` で完了レポートを通知

## Test plan
- [x] `make build` 通過
- [x] `make test` 通過
- [ ] ephemeral セッションで `complete_goal` → ゴール空 → 自動 archived 確認
- [ ] `completion_report` が DB に保存されることを確認
- [ ] 親セッションに通知が届くことを確認

Closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)