### PR TITLE
fix: holder再起動時のレースコンディションを解消 (Closes #620)

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -249,8 +249,10 @@ func (m *Manager) updateHolderPID(id string, pid int) {
 }
 
 // killStaleHolder checks the DB for the session's current holder_pid and, if the process
-// is still alive, sends SIGKILL and waits for it to exit. This prevents orphan holder
-// processes when a new holder is about to be spawned.
+// is still alive, sends SIGTERM and waits for graceful shutdown. Falls back to SIGKILL if
+// SIGTERM does not terminate the process within the timeout. This prevents the race where
+// SIGKILL leaves claude CLI holding the session lock file, causing "Session ID is already
+// in use" when the new holder spawns immediately after.
 func (m *Manager) killStaleHolder(sessionID string) {
 	var holderPID int
 	if err := m.db.QueryRow("SELECT holder_pid FROM sessions WHERE id = ?", sessionID).Scan(&holderPID); err != nil {
@@ -263,16 +265,18 @@ func (m *Manager) killStaleHolder(sessionID string) {
 	if !IsHolderAlive(holderPID) {
 		return
 	}
-	proc, err := os.FindProcess(holderPID)
-	if err != nil {
-		return
-	}
-	if err := proc.Signal(syscall.SIGKILL); err != nil {
-		m.logger.Warn("killStaleHolder: failed to kill holder", "sessionId", sessionID, "holderPid", holderPID, "error", err)
-		return
-	}
+	// Send SIGTERM to the entire process group so claude CLI also receives the signal
+	// and releases its session lock file before the new holder spawns.
+	syscall.Kill(-holderPID, syscall.SIGTERM)
 	waitForProcessExit(holderPID, 3*time.Second, 100*time.Millisecond)
-	m.logger.Info("killStaleHolder: killed stale holder before spawning new one", "sessionId", sessionID, "holderPid", holderPID)
+	if !IsHolderAlive(holderPID) {
+		m.logger.Info("killStaleHolder: terminated stale holder via SIGTERM", "sessionId", sessionID, "holderPid", holderPID)
+		return
+	}
+	// Fallback: SIGTERM did not work; kill the entire process group
+	syscall.Kill(-holderPID, syscall.SIGKILL)
+	waitForProcessExit(holderPID, 3*time.Second, 100*time.Millisecond)
+	m.logger.Info("killStaleHolder: killed stale holder via SIGKILL (SIGTERM fallback)", "sessionId", sessionID, "holderPid", holderPID)
 }
 
 // CreateOpts contains optional parameters for creating a session.


### PR DESCRIPTION
## 関連 Issue

Closes #620

## 症状

`agmux session send` で2回目以降のメッセージを送信すると、claude CLI が以下のエラーで即座にクラッシュする:

```
Error: Session ID ca2d1585-... is already in use.
```

## 原因

`SendKeysWithImages()` → `killStaleHolder()` → 新 holder spawn のフローにレースコンディションがあった。

1. `killStaleHolder()` が旧 holder プロセスに SIGKILL を送信
2. SIGKILL は即座に holder を終了させるが、**子プロセスの claude CLI は session lock ファイルを保持したまま残留**
3. 直後に新しい holder が spawn され、同じ session ID で `claude --session-id <uuid>` を実行
4. claude CLI が「Session ID is already in use」で exit code 1

`Delete()` はすでに SIGTERM → SIGKILL フォールバックパターンを使っており、holder 側の graceful shutdown（stdin.Close() → claude CLI 正常終了 → lock 解放）が保証されていた。`killStaleHolder()` だけが SIGKILL のままで同じ保証がなかった。

## 修正内容

`killStaleHolder()` を `Delete()` と同じパターンに統一:

- `syscall.Kill(-holderPID, syscall.SIGTERM)` でプロセスグループ全体に SIGTERM 送信
- `waitForProcessExit()` で最大 3 秒待機（holder が stdin.Close() → claude CLI が終了 → lock 解放）
- タイムアウト後も alive なら SIGKILL にフォールバック

## テスト観点

- `TestKillStaleHolder_LiveProcess`: 実プロセス（`sleep 60`）を起動し、`killStaleHolder()` が終了を確認するまで待つ → PASS
- `TestKillStaleHolder_NoPID`, `TestKillStaleHolder_DeadPID`, `TestKillStaleHolder_MissingSession`: エッジケース → すべて PASS
- `go test ./internal/...` 全体: PASS