### PR TITLE
fix: killStaleHolder で holder のみに SIGTERM を送る

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -266,10 +266,12 @@ func (m *Manager) killStaleHolder(sessionID string) {
 	if !IsHolderAlive(holderPID) {
 		return
 	}
-	// Send SIGTERM to the entire process group so claude CLI also receives the signal
-	// and releases its session lock file before the new holder spawns.
-	syscall.Kill(-holderPID, syscall.SIGTERM)
-	waitForProcessExit(holderPID, 3*time.Second, 100*time.Millisecond)
+	// Send SIGTERM only to the holder process (not the process group).
+	// The holder's SIGTERM handler closes stdin, which triggers claude CLI's
+	// graceful shutdown and session lock release. Sending SIGTERM to the entire
+	// group would kill claude CLI directly (exit 143), leaving the lock file.
+	syscall.Kill(holderPID, syscall.SIGTERM)
+	waitForProcessExit(holderPID, 5*time.Second, 100*time.Millisecond)
 	if !IsHolderAlive(holderPID) {
 		m.logger.Info("killStaleHolder: terminated stale holder via SIGTERM", "sessionId", sessionID, "holderPid", holderPID)
 		return


### PR DESCRIPTION
## Summary
- `killStaleHolder()` で `-holderPID`（プロセスグループ全体）ではなく `holderPID`（holder のみ）に SIGTERM を送るよう修正
- プロセスグループ全体に送ると claude CLI も直接 SIGTERM で即死 (exit 143) し、session lock が解放されない
- holder のみに送ることで stdin.Close() → CLI 正常終了 → lock 解放の graceful shutdown が動く

## Test plan
- [x] `TestKillStaleHolder_*` 全テスト PASS
- [ ] agmux セッション再作成後、2回目以降のメッセージ送信でクラッシュしないことを確認

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)