### PR TITLE
fix: JSONL の session_id から resume を有効にする

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -973,11 +973,10 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			cliSessionID = ReadCLISessionID(s.ID, provider)
 		}
 
-		// Only resume if a full conversation turn has been completed before.
-		// If conversation_started is false, the session was created without an initial
-		// message and Claude has never processed a turn yet. Resuming a non-existent
-		// conversation causes "No conversation found with session ID" errors.
-		canResume := s.ConversationStarted
+		// Resume if the DB flag says a conversation was started, OR if we found
+		// a CLI session ID in the JSONL stream (which proves a conversation exists
+		// even when the DB flag wasn't updated — e.g. session created via CLI).
+		canResume := s.ConversationStarted || cliSessionID != ""
 
 		effectiveSP := m.buildEffectiveSystemPrompt(s.SystemPrompt)
 		if s.Provider == ProviderCodex && cliSessionID != "" && canResume {


### PR DESCRIPTION
## Summary
- CLI 経由で `session create` した場合、DB の `conversation_started` と `cli_session_id` が更新されない
- 2回目のメッセージ送信時に `canResume=false` → 同じ session ID で `--session-id`（新規）起動 → "already in use" エラー
- `ReadCLISessionID()` で JSONL から session_id を取得できた場合は `canResume=true` とする

## Test plan
- [x] `go test ./internal/session/` 全テスト PASS
- [ ] agmux セッション再作成後、2回目以降のメッセージ送信が `--resume` で正常動作することを確認

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)