### PR TITLE
feat: complete_goal拡張 - レポート保存・自動アーカイブ・親通知 (re-apply #619)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -168,11 +168,15 @@ func (s *Server) handleMethod(method string, params json.RawMessage) (interface{
 				},
 				map[string]interface{}{
 					"name":        "complete_goal",
-					"description": "現在のゴールを達成済みとしてポップします。親ゴールがあればそれがアクティブになります。",
+					"description": "現在のゴールを達成済みとしてポップします。親ゴールがあればそれがアクティブになります。reportを指定すると完了レポートとして保存されます。",
 					"inputSchema": map[string]interface{}{
 						"type": "object",
 						"properties": map[string]interface{}{
 							"session_id": sessionIDProperty,
+							"report": map[string]interface{}{
+								"type":        "string",
+								"description": "完了時のレポート文字列（任意）",
+							},
 						},
 					},
 				},
@@ -351,7 +355,12 @@ func (s *Server) handleCompleteGoal(args json.RawMessage) (interface{}, *jsonRPC
 		return nil, rpcErr
 	}
 
-	parentGoal, err := s.apiCompleteGoal(sessionID)
+	var input struct {
+		Report string `json:"report"`
+	}
+	_ = json.Unmarshal(args, &input) // report is optional; ignore error (defaults to empty string)
+
+	parentGoal, err := s.apiCompleteGoal(sessionID, input.Report)
 	if err != nil {
 		return toolResult(fmt.Sprintf("Error: %v", err), true), nil
 	}
@@ -613,12 +622,21 @@ func (s *Server) apiCreateGoal(sessionID string, currentTask, goal string, subgo
 	return nil
 }
 
-func (s *Server) apiCompleteGoal(sessionID string) (string, error) {
+func (s *Server) apiCompleteGoal(sessionID string, report string) (string, error) {
 	url := fmt.Sprintf("%s/api/sessions/%s/goals/complete", s.apiURL, sessionID)
 
-	req, err := http.NewRequest("POST", url, nil)
+	var bodyReader io.Reader
+	if report != "" {
+		body := fmt.Sprintf(`{"report":%s}`, jsonString(report))
+		bodyReader = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequest("POST", url, bodyReader)
 	if err != nil {
 		return "", err
+	}
+	if bodyReader != nil {
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -573,7 +573,14 @@ func (s *Server) createGoal(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) completeGoal(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	cgResult, err := s.sessions.CompleteGoal(id)
+
+	var req struct {
+		Report string `json:"report"`
+	}
+	// Body is optional; ignore decode errors (e.g. empty body)
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	cgResult, err := s.sessions.CompleteGoal(id, req.Report)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -599,6 +606,32 @@ func (s *Server) completeGoal(w http.ResponseWriter, r *http.Request) {
 				"currentTask": cgResult.CompletedGoal.CurrentTask,
 				"goal":        cgResult.CompletedGoal.Goal,
 				"durationMs":  durationMs,
+			},
+		})
+	}
+
+	// If auto-archived ephemeral session with parent, notify parent regardless of whether report is set
+	if cgResult.AutoArchived && cgResult.ParentSessionID != "" {
+		reportPart := req.Report
+		if reportPart == "" {
+			reportPart = "(report なし)"
+		}
+		notifyMsg := fmt.Sprintf("[ephemeral session %s completed] %s", cgResult.SessionName, reportPart)
+		s.recordSessionAction(cgResult.ParentSessionID, "agent_notification", notifyMsg)
+		if err := s.saveNotification(cgResult.ParentSessionID, "notification", notifyMsg); err != nil {
+			slog.Error("failed to save completion notification", "error", err)
+		}
+		parentSess, _ := s.sessions.Get(cgResult.ParentSessionID)
+		parentName := ""
+		if parentSess != nil {
+			parentName = parentSess.Name
+		}
+		s.hub.Broadcast(Message{
+			Type: "agent_notification",
+			Data: map[string]interface{}{
+				"sessionId":   cgResult.ParentSessionID,
+				"sessionName": parentName,
+				"message":     notifyMsg,
 			},
 		})
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1560,11 +1560,14 @@ func (m *Manager) CreateGoal(id string, currentTask, goal string, subgoal bool) 
 
 // CompleteGoalResult contains the result of completing a goal.
 type CompleteGoalResult struct {
-	CompletedGoal *GoalEntry // the goal that was just completed
-	ParentGoal    *GoalEntry // the new top of stack (nil if empty)
+	CompletedGoal   *GoalEntry // the goal that was just completed
+	ParentGoal      *GoalEntry // the new top of stack (nil if empty)
+	AutoArchived    bool       // true if session was auto-archived (ephemeral with empty goal stack)
+	ParentSessionID string     // parent session ID for notification (set when auto-archived)
+	SessionName     string     // name of the completed session
 }
 
-func (m *Manager) CompleteGoal(id string) (*CompleteGoalResult, error) {
+func (m *Manager) CompleteGoal(id string, report string) (*CompleteGoalResult, error) {
 	s, err := m.Get(id)
 	if err != nil {
 		return nil, err
@@ -1579,7 +1582,17 @@ func (m *Manager) CompleteGoal(id string) (*CompleteGoalResult, error) {
 		goal = top.Goal
 	}
 
-	_, err = m.db.Exec(
+	tx, err := m.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	_, err = tx.Exec(
 		"UPDATE sessions SET current_task = ?, goal = ?, goals = ?, updated_at = ? WHERE id = ?",
 		currentTask, goal, newGoals.ToJSON(), time.Now(), id,
 	)
@@ -1595,6 +1608,41 @@ func (m *Manager) CompleteGoal(id string) (*CompleteGoalResult, error) {
 	if top := newGoals.Top(); top != nil {
 		result.ParentGoal = top
 	}
+
+	// When goal stack is empty and session is ephemeral, auto-archive and save report
+	if newGoals.Top() == nil && s.Type == TypeEphemeral {
+		if report != "" {
+			_, err = tx.Exec(
+				"UPDATE sessions SET completion_report = ?, status = ?, updated_at = ? WHERE id = ?",
+				report, string(StatusArchived), time.Now(), id,
+			)
+		} else {
+			_, err = tx.Exec(
+				"UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?",
+				string(StatusArchived), time.Now(), id,
+			)
+		}
+		if err != nil {
+			return nil, err
+		}
+		result.AutoArchived = true
+		result.ParentSessionID = s.ParentSessionID
+		result.SessionName = s.Name
+	} else if report != "" {
+		// Save completion report even if not auto-archiving
+		_, err = tx.Exec(
+			"UPDATE sessions SET completion_report = ?, updated_at = ? WHERE id = ?",
+			report, time.Now(), id,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+
 	return result, nil
 }
 

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -40,7 +40,8 @@ type SessionService interface {
 	// CreateGoal creates a new goal for a session.
 	CreateGoal(id string, currentTask, goal string, subgoal bool) error
 	// CompleteGoal completes the current goal and returns the result.
-	CompleteGoal(id string) (*CompleteGoalResult, error)
+	// report is an optional completion report string.
+	CompleteGoal(id string, report string) (*CompleteGoalResult, error)
 
 	// GetStreamLines returns stream lines for a session.
 	GetStreamLines(id string, limit int) ([]string, int, error)


### PR DESCRIPTION
## 概要

PR #619 が誤って `feat/606-ephemeral-db-model` ブランチにマージされたため、main に変更が反映されていませんでした。本PRは #619 のコミット `ad20cb5` を main に cherry-pick して再適用したものです。

Closes #607

## 変更内容（#619 と等価）

- `complete_goal` MCP ツールに `report` パラメータを追加
- `completion_report` を DB に保存
- ephemeral セッションでゴールスタックが空になった際に自動 archived
- 親セッションへの完了通知（`send_notification` 経由）
- `CompleteGoal` のDB操作をトランザクション化し、中間失敗時のDB不整合を防止

## 再適用の経緯

- #619 は `feat/606-ephemeral-db-model` をベースブランチとして作成・マージされた
- main には #617 (#606 ephemeral DB実装) と #618 (ephemeral timeout monitoring) が既にマージ済みで、差分に矛盾はなかった
- cherry-pick は競合なしで適用完了、`make build && make test` 全通