### PR TITLE
feat: ephemeral session CLI / Web UI 対応 (Closes #609)

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -377,6 +377,9 @@ func sessionCreateCmd() *cobra.Command {
 				return err
 			}
 			defer database.Close()
+			if !ephemeral && ephemeralTimeout > 0 {
+				return fmt.Errorf("--timeout requires --ephemeral")
+			}
 			var ephemeralTimeoutPtr *int
 			if ephemeral && ephemeralTimeout > 0 {
 				ephemeralTimeoutPtr = &ephemeralTimeout

--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -339,6 +339,8 @@ func sessionCreateCmd() *cobra.Command {
 	var autoApprove bool
 	var parentSessionID string
 	var templateName string
+	var ephemeral bool
+	var ephemeralTimeout int
 
 	cmd := &cobra.Command{
 		Use:   "create <name>",
@@ -375,13 +377,19 @@ func sessionCreateCmd() *cobra.Command {
 				return err
 			}
 			defer database.Close()
+			var ephemeralTimeoutPtr *int
+			if ephemeral && ephemeralTimeout > 0 {
+				ephemeralTimeoutPtr = &ephemeralTimeout
+			}
 			sess, err := mgr.Create(args[0], absPath, prompt, worktree, session.CreateOpts{
-				Provider:        session.ProviderName(provider),
-				Model:           model,
-				FullAuto:        autoApprove,
-				SystemPrompt:    systemPrompt,
-				ParentSessionID: parentSessionID,
-				RoleTemplate:    templateName,
+				Provider:                session.ProviderName(provider),
+				Model:                   model,
+				FullAuto:                autoApprove,
+				SystemPrompt:            systemPrompt,
+				ParentSessionID:         parentSessionID,
+				RoleTemplate:            templateName,
+				Ephemeral:               ephemeral,
+				EphemeralTimeoutSeconds: ephemeralTimeoutPtr,
 			})
 			if err != nil {
 				return err
@@ -399,6 +407,8 @@ func sessionCreateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", true, "Enable full-auto mode (bypass permission prompts for Codex)")
 	cmd.Flags().StringVar(&parentSessionID, "parent", "", "Parent session ID to create a sub-session")
 	cmd.Flags().StringVarP(&templateName, "template", "t", "", "Role template name to apply")
+	cmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "Create an ephemeral session (auto-archived after completion or timeout)")
+	cmd.Flags().IntVar(&ephemeralTimeout, "timeout", 0, "Timeout in seconds for ephemeral session (0 = no timeout)")
 
 	return cmd
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -38,6 +38,8 @@ export const api = {
     systemPrompt?: string;
     parentSessionId?: string;
     roleTemplate?: string;
+    ephemeral?: boolean;
+    ephemeralTimeoutSeconds?: number;
   }) =>
     request<Session>("/sessions", {
       method: "POST",

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -12,6 +12,8 @@ interface Props {
     autoApprove?: boolean;
     systemPrompt?: string;
     roleTemplate?: string;
+    ephemeral?: boolean;
+    ephemeralTimeoutSeconds?: number;
   }) => void;
 }
 
@@ -35,6 +37,8 @@ export function CreateSession({ onClose, onCreate }: Props) {
   const [recentProjects, setRecentProjects] = useState<RecentProject[]>([]);
   const [templates, setTemplates] = useState<RoleTemplate[]>([]);
   const [selectedTemplate, setSelectedTemplate] = useState("");
+  const [ephemeral, setEphemeral] = useState(false);
+  const [ephemeralTimeout, setEphemeralTimeout] = useState("");
 
   useEffect(() => {
     api.getRecentProjects()
@@ -94,6 +98,7 @@ export function CreateSession({ onClose, onCreate }: Props) {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const timeoutSecs = ephemeralTimeout ? parseInt(ephemeralTimeout, 10) : undefined;
     onCreate({
       name,
       projectPath,
@@ -103,6 +108,8 @@ export function CreateSession({ onClose, onCreate }: Props) {
       autoApprove: provider === "codex" && autoApprove ? true : undefined,
       systemPrompt: systemPrompt || undefined,
       roleTemplate: selectedTemplate || undefined,
+      ephemeral: ephemeral || undefined,
+      ephemeralTimeoutSeconds: ephemeral && timeoutSecs && timeoutSecs > 0 ? timeoutSecs : undefined,
     });
   };
 
@@ -269,6 +276,31 @@ export function CreateSession({ onClose, onCreate }: Props) {
                   </option>
                 ))}
               </select>
+            </div>
+          )}
+          <div>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={ephemeral}
+                onChange={(e) => setEphemeral(e.target.checked)}
+              />
+              Ephemeral (auto-archive after completion)
+            </label>
+          </div>
+          {ephemeral && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Timeout (seconds, optional)
+              </label>
+              <input
+                type="number"
+                value={ephemeralTimeout}
+                onChange={(e) => setEphemeralTimeout(e.target.value)}
+                min="0"
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm"
+                placeholder="e.g. 3600"
+              />
             </div>
           )}
           <div className="flex justify-end gap-2">

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -98,7 +98,7 @@ export function CreateSession({ onClose, onCreate }: Props) {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const timeoutSecs = ephemeralTimeout ? parseInt(ephemeralTimeout, 10) : undefined;
+    const timeoutSecs = ephemeralTimeout ? Math.max(1, Math.floor(parseInt(ephemeralTimeout, 10))) : undefined;
     onCreate({
       name,
       projectPath,
@@ -297,7 +297,8 @@ export function CreateSession({ onClose, onCreate }: Props) {
                 type="number"
                 value={ephemeralTimeout}
                 onChange={(e) => setEphemeralTimeout(e.target.value)}
-                min="0"
+                min="1"
+                step="1"
                 className="w-full border border-gray-300 rounded px-3 py-2 text-sm"
                 placeholder="e.g. 3600"
               />

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -119,6 +119,7 @@ export function SessionList({ sessions, onRestartController }: Props) {
               timeAgo={timeAgo(s.createdAt)}
               isSubSession={depth > 0}
               isSelected={s.id === selectedSessionId}
+              completionReport={s.completionReport}
               onClick={() => navigate(`/sessions/${s.id}`, { viewTransition: true } as never)}
               actions={
                 s.type === "controller" && (s.status === "paused" || s.status === "exited") ? (

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -6,6 +6,7 @@ export const statusDots: Record<Session["status"], string> = {
   paused: "bg-yellow-500",
   exited: "bg-gray-400",
   waiting_input: "bg-orange-500",
+  archived: "bg-gray-300",
 };
 
 export function StatusDot({ status }: { status: Session["status"] }) {

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -6,7 +6,7 @@ export const statusDots: Record<Session["status"], string> = {
   paused: "bg-yellow-500",
   exited: "bg-gray-400",
   waiting_input: "bg-orange-500",
-  archived: "bg-gray-300",
+  archived: "bg-slate-400",
 };
 
 export function StatusDot({ status }: { status: Session["status"] }) {

--- a/frontend/src/components/ui/SessionCard.tsx
+++ b/frontend/src/components/ui/SessionCard.tsx
@@ -17,6 +17,7 @@ interface SessionCardProps {
   isSelected?: boolean;
   onClick?: () => void;
   actions?: React.ReactNode;
+  completionReport?: string;
 }
 
 export function SessionCard({
@@ -34,6 +35,7 @@ export function SessionCard({
   isSelected,
   onClick,
   actions,
+  completionReport,
 }: SessionCardProps) {
   const vtn = (suffix: string) => id ? { viewTransitionName: `session-${suffix}-${id}` } : undefined;
   return (
@@ -51,6 +53,9 @@ export function SessionCard({
         </span>
         {type === "controller" && (
           <Chip color="purple">Controller</Chip>
+        )}
+        {type === "ephemeral" && (
+          <Chip color="blue">Ephemeral</Chip>
         )}
         {roleTemplate && (
           <span className="inline-flex items-center" style={vtn("role")}><Chip color="orange">{roleTemplate}</Chip></span>
@@ -70,6 +75,11 @@ export function SessionCard({
       {status === "exited" && lastError && (
         <p className="text-xs text-red-600 truncate mb-0.5" title={lastError}>
           Error: {lastError}
+        </p>
+      )}
+      {status === "archived" && completionReport && (
+        <p className="text-xs text-green-700 truncate mb-0.5" title={completionReport}>
+          {completionReport}
         </p>
       )}
       <p className="text-xs text-gray-500 truncate mb-1">

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -706,6 +706,9 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
             {session.roleTemplate && (
               <span className="inline-flex items-center" style={{ viewTransitionName: `session-role-${session.id}` }}><Chip color="orange">{session.roleTemplate}</Chip></span>
             )}
+            {session.type === "ephemeral" && (
+              <Chip color="blue">Ephemeral</Chip>
+            )}
           </>
         ) : (
           <>
@@ -718,6 +721,11 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
       </div>
       {session?.parentSessionId && (
         <ParentSessionLink parentId={session.parentSessionId} />
+      )}
+      {session?.status === "archived" && session?.completionReport && (
+        <div className="mb-2 px-3 py-2 bg-green-50 border border-green-200 rounded text-xs text-green-800">
+          <span className="font-medium">Completion Report: </span>{session.completionReport}
+        </div>
       )}
       {session ? (
         <div className="flex items-center gap-1.5 mb-2 shrink-0 text-xs sm:text-sm text-gray-500">

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -3,8 +3,8 @@ export interface Session {
   name: string;
   projectPath: string;
   initialPrompt?: string;
-  status: "working" | "idle" | "paused" | "exited" | "waiting_input";
-  type: "worker" | "controller" | "external";
+  status: "working" | "idle" | "paused" | "exited" | "waiting_input" | "archived";
+  type: "worker" | "controller" | "external" | "ephemeral";
   provider: string;
   model?: string;
   parentSessionId?: string;
@@ -14,6 +14,8 @@ export interface Session {
   goals?: { currentTask: string; goal: string }[];
   lastError?: string;
   conversationStarted?: boolean;
+  ephemeralTimeoutSeconds?: number;
+  completionReport?: string;
   createdAt: string;
   updatedAt: string;
   githubUrl?: string;


### PR DESCRIPTION
## Summary

- **CLI**: `agmux session create` に `--ephemeral` フラグと `--timeout <seconds>` フラグを追加
- **Web UI**: セッション作成フォームに「Ephemeral」チェックボックスとタイムアウト入力欄を追加（チェック時のみ表示）
- **セッション一覧**: ephemeral セッションに「Ephemeral」バッジ表示、archived セッションの completion_report を表示
- **セッション詳細**: ephemeral バッジ、archived 時の completion_report バナー表示
- Session 型に `archived` ステータス、`ephemeral` 型、`ephemeralTimeoutSeconds`、`completionReport` フィールドを追加

## Test plan

- [ ] `agmux session create test --ephemeral --timeout 3600 -m "task"` でエフェメラルセッションが作成できる
- [ ] Web UI のフォームで Ephemeral チェックボックスが表示され、チェック時にタイムアウト入力欄が現れる
- [ ] セッション一覧でエフェメラルセ��ションに「Ephemeral」バッジが表示される
- [ ] archived セッションの completion_report がカードおよび詳細ページに表示される
- [ ] `make build && make test` 通過

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)