### PR TITLE
feat: バックグラウンドタスク一覧をバックエンド/DBで管理 (Closes #627)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -187,7 +187,26 @@ export const api = {
       method: "POST",
     }),
 
+  listBackgroundTasks: (sessionId: string) =>
+    request<{ tasks: BackgroundTaskDTO[] }>(
+      `/sessions/${sessionId}/background-tasks`
+    ),
+
 };
+
+// BackgroundTaskDTO mirrors `internal/session.BackgroundTask` (Go).
+export interface BackgroundTaskDTO {
+  taskId: string;
+  taskType: string;
+  agentId?: string;
+  description?: string;
+  startedAt?: string;
+  lastToolName?: string;
+  lastToolInput?: unknown;
+  output?: string;
+  usage?: { inputTokens?: number; outputTokens?: number };
+  toolCallHistory: { toolName: string; description?: string; timestamp?: string }[];
+}
 
 export interface RecentProject {
   projectPath: string;

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -28,8 +28,23 @@ import { GoalPanel } from "../components/ui/GoalPanel";
 import { ConnectionStatusIndicator } from "../components/ui/ConnectionStatus";
 import { PullRequestBadge } from "../components/ui/PullRequestBadge";
 import { AlertBanner } from "../components/ui/AlertBanner";
-import type { StreamEntry } from "../models/stream";
-import { extractActiveTasks } from "../models/stream";
+import type { ActiveTask } from "../models/stream";
+import type { BackgroundTaskDTO } from "../api/client";
+
+function dtoToActiveTask(dto: BackgroundTaskDTO): ActiveTask {
+  return {
+    taskId: dto.taskId,
+    taskType: dto.taskType,
+    agentId: dto.agentId,
+    description: dto.description,
+    startedAt: dto.startedAt,
+    lastToolName: dto.lastToolName,
+    lastToolInput: dto.lastToolInput,
+    output: dto.output,
+    usage: dto.usage,
+    toolCallHistory: dto.toolCallHistory ?? [],
+  };
+}
 
 type DeferredData = {
   streamOutput: { lines: unknown[]; total: number };
@@ -143,13 +158,25 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
   const providerVersion = deferred.providerVersion;
   const streamCursorRef = useRef<number | null>(null);
 
-  // Compute active tasks for fixed display above input
-  const activeTasks = useMemo(() => {
-    const entries = streamLines
-      .map((line) => line as StreamEntry)
-      .filter((e: StreamEntry) => e.type === "user" || e.type === "assistant" || e.type === "system");
-    return extractActiveTasks(entries);
-  }, [streamLines]);
+  // Active tasks (background-running agent / tool calls). Fetched from the
+  // backend so the source of truth is the DB. Refetched when new stream
+  // lines arrive (the backend updates the table on each line).
+  const [activeTasks, setActiveTasks] = useState<ActiveTask[]>([]);
+  useEffect(() => {
+    if (!sessionId) return;
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const resp = await api.listBackgroundTasks(sessionId);
+        if (cancelled) return;
+        setActiveTasks(resp.tasks.map(dtoToActiveTask));
+      } catch {
+        // ignore; UI will show last known state
+      }
+    };
+    refresh();
+    return () => { cancelled = true; };
+  }, [sessionId, streamLines.length]);
 
   // Extract slash_commands from system init messages
   const slashCommands = useMemo(() => {

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -360,6 +360,15 @@ func migrate(db *sql.DB) error {
 	}
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_background_tasks_session ON background_tasks(session_id)`)
 
+	// Migration: add dismissed_at column for logical delete.
+	// Physical delete + UPSERT could resurrect a dismissed task when a delayed
+	// task_progress event arrived. With dismissed_at set, the row stays in the
+	// DB as a tombstone and List/UPSERT skip it.
+	_, err = db.Exec(`ALTER TABLE background_tasks ADD COLUMN dismissed_at DATETIME`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -335,6 +335,31 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: create background_tasks table
+	// Tracks long-running tasks (agent / tool background tasks) detected from JSONL stream.
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS background_tasks (
+			session_id TEXT NOT NULL,
+			task_id TEXT NOT NULL,
+			task_type TEXT NOT NULL DEFAULT 'unknown',
+			agent_id TEXT,
+			description TEXT,
+			started_at TEXT,
+			last_tool_name TEXT,
+			last_tool_input TEXT,
+			output TEXT,
+			usage_input_tokens INTEGER,
+			usage_output_tokens INTEGER,
+			tool_call_history TEXT NOT NULL DEFAULT '[]',
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (session_id, task_id)
+		)
+	`)
+	if err != nil {
+		return err
+	}
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_background_tasks_session ON background_tasks(session_id)`)
+
 	return nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -153,6 +153,8 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/permission", s.createPermission)
 		r.Post("/sessions/{id}/permission/respond", s.respondPermission)
 		r.Post("/sessions/{id}/tasks/{taskId}/dismiss", s.dismissTask)
+		r.Get("/sessions/{id}/background-tasks", s.listBackgroundTasks)
+		r.Delete("/sessions/{id}/background-tasks/{taskId}", s.dismissTask)
 		r.Post("/sessions/{id}/notify", s.sendNotification)
 		r.Post("/sessions/broadcast", s.broadcastToSessions)
 		r.Post("/sessions/controller/restart", s.restartController)
@@ -1918,4 +1920,15 @@ func (s *Server) dismissTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "dismissed"})
+}
+
+// listBackgroundTasks returns the persisted background-task list for the session.
+func (s *Server) listBackgroundTasks(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	tasks, err := s.sessions.ListBackgroundTasks(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"tasks": tasks})
 }

--- a/internal/session/background_task.go
+++ b/internal/session/background_task.go
@@ -1,0 +1,556 @@
+package session
+
+import (
+	"bufio"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/myuon/agmux/internal/db"
+)
+
+// BackgroundTask mirrors the frontend ActiveTask shape and represents
+// a long-running agent / tool task detected from the JSONL stream.
+type BackgroundTask struct {
+	TaskID            string                  `json:"taskId"`
+	TaskType          string                  `json:"taskType"`
+	AgentID           string                  `json:"agentId,omitempty"`
+	Description       string                  `json:"description,omitempty"`
+	StartedAt         string                  `json:"startedAt,omitempty"`
+	LastToolName      string                  `json:"lastToolName,omitempty"`
+	LastToolInput     interface{}             `json:"lastToolInput,omitempty"`
+	Output            string                  `json:"output,omitempty"`
+	Usage             *BackgroundTaskUsage    `json:"usage,omitempty"`
+	ToolCallHistory   []BackgroundTaskToolCall `json:"toolCallHistory"`
+}
+
+// BackgroundTaskUsage tracks token usage reported in task_progress events.
+type BackgroundTaskUsage struct {
+	InputTokens  *int `json:"inputTokens,omitempty"`
+	OutputTokens *int `json:"outputTokens,omitempty"`
+}
+
+// BackgroundTaskToolCall is one entry in the tool call history.
+type BackgroundTaskToolCall struct {
+	ToolName    string `json:"toolName"`
+	Description string `json:"description,omitempty"`
+	Timestamp   string `json:"timestamp,omitempty"`
+}
+
+// BackgroundTaskStore manages background_tasks rows in SQLite.
+// Detection mirrors frontend `extractActiveTasks` in
+// frontend/src/models/stream.ts.
+type BackgroundTaskStore struct {
+	db *sql.DB
+	mu sync.Mutex
+	// pendingToolUseInputs tracks recent tool_use blocks per session by id
+	// so that when a task_started event references a tool_use_id we can
+	// resolve the tool name / input. Keyed by sessionID, then tool_use_id.
+	pendingToolUseInputs map[string]map[string]toolUseRef
+}
+
+type toolUseRef struct {
+	name  string
+	input interface{}
+	at    time.Time
+}
+
+// NewBackgroundTaskStore creates a store backed by the given SQLite DB.
+func NewBackgroundTaskStore(db *sql.DB) *BackgroundTaskStore {
+	return &BackgroundTaskStore{
+		db:                   db,
+		pendingToolUseInputs: make(map[string]map[string]toolUseRef),
+	}
+}
+
+// rawStreamLine is the minimal shape we need from each JSONL line.
+type rawStreamLine struct {
+	Type     string                 `json:"type"`
+	Subtype  string                 `json:"subtype"`
+	TaskID   string                 `json:"task_id"`
+	TaskType string                 `json:"task_type"`
+	AgentID  string                 `json:"agent_id"`
+	ToolUse  string                 `json:"tool_use_id"`
+	Desc     string                 `json:"description"`
+	Status   string                 `json:"status"`
+	Time     string                 `json:"timestamp"`
+	LastTool string                 `json:"last_tool_name"`
+	LastIn   json.RawMessage        `json:"last_tool_input"`
+	Output   string                 `json:"output"`
+	Usage    map[string]json.Number `json:"usage"`
+	Message  *struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+type assistantBlock struct {
+	Type  string          `json:"type"`
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+// ApplyLine inspects one JSONL line for the given session and updates the
+// background_tasks table accordingly. It is a no-op if the line is not
+// task-related. Errors are returned but the caller is expected to log them
+// and continue (the JSONL file remains the source of truth for replay).
+func (s *BackgroundTaskStore) ApplyLine(sessionID string, line []byte) error {
+	if len(line) == 0 || line[0] != '{' {
+		return nil
+	}
+	var ev rawStreamLine
+	if err := json.Unmarshal(line, &ev); err != nil {
+		return nil
+	}
+
+	// 1. Track tool_use inputs from assistant messages so task_started can
+	//    resolve `lastToolName` / `lastToolInput` via tool_use_id.
+	if ev.Type == "assistant" && ev.Message != nil {
+		var blocks []assistantBlock
+		if err := json.Unmarshal(ev.Message.Content, &blocks); err == nil {
+			for _, b := range blocks {
+				if b.Type == "tool_use" && b.ID != "" {
+					var input interface{}
+					if len(b.Input) > 0 {
+						_ = json.Unmarshal(b.Input, &input)
+					}
+					s.rememberToolUse(sessionID, b.ID, b.Name, input)
+					// TaskStop tool calls explicitly remove tasks
+					if b.Name == "TaskStop" && len(b.Input) > 0 {
+						var stop struct {
+							TaskID string `json:"task_id"`
+						}
+						if err := json.Unmarshal(b.Input, &stop); err == nil && stop.TaskID != "" {
+							_ = s.deleteTask(sessionID, stop.TaskID)
+						}
+					}
+				}
+			}
+		}
+		return nil
+	}
+
+	if ev.Type != "system" {
+		return nil
+	}
+
+	switch ev.Subtype {
+	case "task_started":
+		if ev.TaskID == "" {
+			return nil
+		}
+		taskType := ev.TaskType
+		if taskType == "" {
+			taskType = "unknown"
+		}
+		task := BackgroundTask{
+			TaskID:          ev.TaskID,
+			TaskType:        taskType,
+			AgentID:         ev.AgentID,
+			Description:     ev.Desc,
+			StartedAt:       ev.Time,
+			ToolCallHistory: []BackgroundTaskToolCall{},
+		}
+		if ev.ToolUse != "" {
+			if name, input, ok := s.lookupToolUse(sessionID, ev.ToolUse); ok {
+				task.LastToolName = name
+				task.LastToolInput = input
+			}
+		}
+		return s.upsertTask(sessionID, task)
+
+	case "task_progress":
+		if ev.TaskID == "" {
+			return nil
+		}
+		existing, err := s.getTask(sessionID, ev.TaskID)
+		if err != nil {
+			return err
+		}
+		if existing == nil {
+			taskType := ev.TaskType
+			if taskType == "" {
+				taskType = "unknown"
+			}
+			existing = &BackgroundTask{
+				TaskID:          ev.TaskID,
+				TaskType:        taskType,
+				AgentID:         ev.AgentID,
+				ToolCallHistory: []BackgroundTaskToolCall{},
+			}
+		}
+		if ev.Desc != "" {
+			existing.Description = ev.Desc
+		}
+		if ev.LastTool != "" {
+			last := lastToolCall(existing.ToolCallHistory)
+			if last == nil || last.ToolName != ev.LastTool || last.Description != ev.Desc {
+				existing.ToolCallHistory = append(existing.ToolCallHistory, BackgroundTaskToolCall{
+					ToolName:    ev.LastTool,
+					Description: ev.Desc,
+					Timestamp:   ev.Time,
+				})
+			}
+			existing.LastToolName = ev.LastTool
+		}
+		if len(ev.LastIn) > 0 {
+			var input interface{}
+			if err := json.Unmarshal(ev.LastIn, &input); err == nil {
+				existing.LastToolInput = input
+			}
+		}
+		if ev.Output != "" {
+			existing.Output = ev.Output
+		}
+		if len(ev.Usage) > 0 {
+			usage := &BackgroundTaskUsage{}
+			if v, ok := ev.Usage["input_tokens"]; ok {
+				if n, err := v.Int64(); err == nil {
+					i := int(n)
+					usage.InputTokens = &i
+				}
+			}
+			if v, ok := ev.Usage["output_tokens"]; ok {
+				if n, err := v.Int64(); err == nil {
+					i := int(n)
+					usage.OutputTokens = &i
+				}
+			}
+			existing.Usage = usage
+		}
+		return s.upsertTask(sessionID, *existing)
+
+	case "task_notification":
+		if ev.TaskID == "" {
+			return nil
+		}
+		return s.deleteTask(sessionID, ev.TaskID)
+	}
+
+	return nil
+}
+
+func lastToolCall(h []BackgroundTaskToolCall) *BackgroundTaskToolCall {
+	if len(h) == 0 {
+		return nil
+	}
+	return &h[len(h)-1]
+}
+
+// List returns the current background tasks for the given session, ordered
+// by started_at ascending (oldest first), to match frontend insertion order.
+func (s *BackgroundTaskStore) List(sessionID string) ([]BackgroundTask, error) {
+	rows, err := s.db.Query(
+		`SELECT task_id, task_type, agent_id, description, started_at,
+		        last_tool_name, last_tool_input, output,
+		        usage_input_tokens, usage_output_tokens,
+		        tool_call_history
+		 FROM background_tasks WHERE session_id = ?
+		 ORDER BY started_at ASC, task_id ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list background tasks: %w", err)
+	}
+	defer rows.Close()
+
+	var tasks []BackgroundTask
+	for rows.Next() {
+		var t BackgroundTask
+		var agentID, desc, startedAt, lastToolName, lastToolInput, output sql.NullString
+		var inTok, outTok sql.NullInt64
+		var history string
+		if err := rows.Scan(
+			&t.TaskID, &t.TaskType, &agentID, &desc, &startedAt,
+			&lastToolName, &lastToolInput, &output,
+			&inTok, &outTok,
+			&history,
+		); err != nil {
+			return nil, fmt.Errorf("scan background task: %w", err)
+		}
+		if agentID.Valid {
+			t.AgentID = agentID.String
+		}
+		if desc.Valid {
+			t.Description = desc.String
+		}
+		if startedAt.Valid {
+			t.StartedAt = startedAt.String
+		}
+		if lastToolName.Valid {
+			t.LastToolName = lastToolName.String
+		}
+		if lastToolInput.Valid && lastToolInput.String != "" {
+			var v interface{}
+			if err := json.Unmarshal([]byte(lastToolInput.String), &v); err == nil {
+				t.LastToolInput = v
+			}
+		}
+		if output.Valid {
+			t.Output = output.String
+		}
+		if inTok.Valid || outTok.Valid {
+			u := &BackgroundTaskUsage{}
+			if inTok.Valid {
+				v := int(inTok.Int64)
+				u.InputTokens = &v
+			}
+			if outTok.Valid {
+				v := int(outTok.Int64)
+				u.OutputTokens = &v
+			}
+			t.Usage = u
+		}
+		if history != "" {
+			_ = json.Unmarshal([]byte(history), &t.ToolCallHistory)
+		}
+		if t.ToolCallHistory == nil {
+			t.ToolCallHistory = []BackgroundTaskToolCall{}
+		}
+		tasks = append(tasks, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if tasks == nil {
+		tasks = []BackgroundTask{}
+	}
+	return tasks, nil
+}
+
+// Dismiss removes a task row.
+func (s *BackgroundTaskStore) Dismiss(sessionID, taskID string) error {
+	return s.deleteTask(sessionID, taskID)
+}
+
+// RebuildFromJSONL clears the existing rows for the session and replays all
+// JSONL lines after `clearOffset`. Used after server start / holder reconnect
+// so the DB reflects the current state of background tasks even before any
+// new live lines arrive.
+func (s *BackgroundTaskStore) RebuildFromJSONL(sessionID string, clearOffset int64) error {
+	if err := s.ClearSession(sessionID); err != nil {
+		return err
+	}
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(streamsDir, sessionID+".jsonl")
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+	if clearOffset > 0 {
+		if _, err := f.Seek(clearOffset, 0); err != nil {
+			return err
+		}
+	}
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		_ = s.ApplyLine(sessionID, line)
+	}
+	return scanner.Err()
+}
+
+// ClearSession removes all background task rows for the session, used on
+// session clear / restart.
+func (s *BackgroundTaskStore) ClearSession(sessionID string) error {
+	_, err := s.db.Exec(`DELETE FROM background_tasks WHERE session_id = ?`, sessionID)
+	if err != nil {
+		return fmt.Errorf("clear background tasks: %w", err)
+	}
+	s.mu.Lock()
+	delete(s.pendingToolUseInputs, sessionID)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *BackgroundTaskStore) rememberToolUse(sessionID, id, name string, input interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, ok := s.pendingToolUseInputs[sessionID]
+	if !ok {
+		m = make(map[string]toolUseRef)
+		s.pendingToolUseInputs[sessionID] = m
+	}
+	m[id] = toolUseRef{name: name, input: input, at: time.Now()}
+	// Cap memory growth: if we exceed 256 entries, trim the oldest.
+	if len(m) > 256 {
+		var oldestID string
+		var oldestAt time.Time
+		for k, v := range m {
+			if oldestID == "" || v.at.Before(oldestAt) {
+				oldestID = k
+				oldestAt = v.at
+			}
+		}
+		delete(m, oldestID)
+	}
+}
+
+func (s *BackgroundTaskStore) lookupToolUse(sessionID, id string) (string, interface{}, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, ok := s.pendingToolUseInputs[sessionID]
+	if !ok {
+		return "", nil, false
+	}
+	ref, ok := m[id]
+	if !ok {
+		return "", nil, false
+	}
+	return ref.name, ref.input, true
+}
+
+func (s *BackgroundTaskStore) getTask(sessionID, taskID string) (*BackgroundTask, error) {
+	row := s.db.QueryRow(
+		`SELECT task_id, task_type, agent_id, description, started_at,
+		        last_tool_name, last_tool_input, output,
+		        usage_input_tokens, usage_output_tokens,
+		        tool_call_history
+		 FROM background_tasks WHERE session_id = ? AND task_id = ?`,
+		sessionID, taskID,
+	)
+	var t BackgroundTask
+	var agentID, desc, startedAt, lastToolName, lastToolInput, output sql.NullString
+	var inTok, outTok sql.NullInt64
+	var history string
+	err := row.Scan(
+		&t.TaskID, &t.TaskType, &agentID, &desc, &startedAt,
+		&lastToolName, &lastToolInput, &output,
+		&inTok, &outTok,
+		&history,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if agentID.Valid {
+		t.AgentID = agentID.String
+	}
+	if desc.Valid {
+		t.Description = desc.String
+	}
+	if startedAt.Valid {
+		t.StartedAt = startedAt.String
+	}
+	if lastToolName.Valid {
+		t.LastToolName = lastToolName.String
+	}
+	if lastToolInput.Valid && lastToolInput.String != "" {
+		var v interface{}
+		if err := json.Unmarshal([]byte(lastToolInput.String), &v); err == nil {
+			t.LastToolInput = v
+		}
+	}
+	if output.Valid {
+		t.Output = output.String
+	}
+	if inTok.Valid || outTok.Valid {
+		u := &BackgroundTaskUsage{}
+		if inTok.Valid {
+			v := int(inTok.Int64)
+			u.InputTokens = &v
+		}
+		if outTok.Valid {
+			v := int(outTok.Int64)
+			u.OutputTokens = &v
+		}
+		t.Usage = u
+	}
+	if history != "" {
+		_ = json.Unmarshal([]byte(history), &t.ToolCallHistory)
+	}
+	if t.ToolCallHistory == nil {
+		t.ToolCallHistory = []BackgroundTaskToolCall{}
+	}
+	return &t, nil
+}
+
+func (s *BackgroundTaskStore) upsertTask(sessionID string, t BackgroundTask) error {
+	if t.ToolCallHistory == nil {
+		t.ToolCallHistory = []BackgroundTaskToolCall{}
+	}
+	historyJSON, err := json.Marshal(t.ToolCallHistory)
+	if err != nil {
+		return fmt.Errorf("marshal history: %w", err)
+	}
+	var lastInputJSON sql.NullString
+	if t.LastToolInput != nil {
+		b, err := json.Marshal(t.LastToolInput)
+		if err == nil {
+			lastInputJSON = sql.NullString{String: string(b), Valid: true}
+		}
+	}
+	var inTok, outTok sql.NullInt64
+	if t.Usage != nil {
+		if t.Usage.InputTokens != nil {
+			inTok = sql.NullInt64{Int64: int64(*t.Usage.InputTokens), Valid: true}
+		}
+		if t.Usage.OutputTokens != nil {
+			outTok = sql.NullInt64{Int64: int64(*t.Usage.OutputTokens), Valid: true}
+		}
+	}
+	_, err = s.db.Exec(
+		`INSERT INTO background_tasks (
+			session_id, task_id, task_type, agent_id, description, started_at,
+			last_tool_name, last_tool_input, output,
+			usage_input_tokens, usage_output_tokens, tool_call_history,
+			updated_at
+		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(session_id, task_id) DO UPDATE SET
+			task_type = excluded.task_type,
+			agent_id = excluded.agent_id,
+			description = excluded.description,
+			started_at = COALESCE(NULLIF(excluded.started_at, ''), background_tasks.started_at),
+			last_tool_name = excluded.last_tool_name,
+			last_tool_input = excluded.last_tool_input,
+			output = excluded.output,
+			usage_input_tokens = excluded.usage_input_tokens,
+			usage_output_tokens = excluded.usage_output_tokens,
+			tool_call_history = excluded.tool_call_history,
+			updated_at = CURRENT_TIMESTAMP`,
+		sessionID, t.TaskID, t.TaskType,
+		nullableString(t.AgentID), nullableString(t.Description), nullableString(t.StartedAt),
+		nullableString(t.LastToolName), lastInputJSON, nullableString(t.Output),
+		inTok, outTok, string(historyJSON),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert background task: %w", err)
+	}
+	return nil
+}
+
+func (s *BackgroundTaskStore) deleteTask(sessionID, taskID string) error {
+	_, err := s.db.Exec(
+		`DELETE FROM background_tasks WHERE session_id = ? AND task_id = ?`,
+		sessionID, taskID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete background task: %w", err)
+	}
+	return nil
+}
+
+func nullableString(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: s, Valid: true}
+}

--- a/internal/session/background_task.go
+++ b/internal/session/background_task.go
@@ -46,7 +46,14 @@ type BackgroundTaskToolCall struct {
 // frontend/src/models/stream.ts.
 type BackgroundTaskStore struct {
 	db *sql.DB
+	// mu guards the in-memory pendingToolUseInputs map.
 	mu sync.Mutex
+	// applyMu serializes ApplyLine to make read-modify-write
+	// (`getTask` -> append history -> `upsertTask`) safe across goroutines.
+	// Holding this around the SQL calls is acceptable: lines arrive from a
+	// single holder reader in the common case, and concurrent rebuild +
+	// live-update paths are rare and per-session.
+	applyMu sync.Mutex
 	// pendingToolUseInputs tracks recent tool_use blocks per session by id
 	// so that when a task_started event references a tool_use_id we can
 	// resolve the tool name / input. Keyed by sessionID, then tool_use_id.
@@ -108,6 +115,12 @@ func (s *BackgroundTaskStore) ApplyLine(sessionID string, line []byte) error {
 		return nil
 	}
 
+	// Serialize to make read-modify-write of tool_call_history race-free when
+	// multiple goroutines feed lines for the same session (e.g. RebuildFromJSONL
+	// vs live `onNewLines`).
+	s.applyMu.Lock()
+	defer s.applyMu.Unlock()
+
 	// 1. Track tool_use inputs from assistant messages so task_started can
 	//    resolve `lastToolName` / `lastToolInput` via tool_use_id.
 	if ev.Type == "assistant" && ev.Message != nil {
@@ -115,11 +128,14 @@ func (s *BackgroundTaskStore) ApplyLine(sessionID string, line []byte) error {
 		if err := json.Unmarshal(ev.Message.Content, &blocks); err == nil {
 			for _, b := range blocks {
 				if b.Type == "tool_use" && b.ID != "" {
-					var input interface{}
-					if len(b.Input) > 0 {
-						_ = json.Unmarshal(b.Input, &input)
+					// Mirror frontend: skip tool_use blocks with null/missing input
+					// when remembering inputs so task_started doesn't resolve to nil.
+					if !isJSONNullOrEmpty(b.Input) {
+						var input interface{}
+						if err := json.Unmarshal(b.Input, &input); err == nil {
+							s.rememberToolUse(sessionID, b.ID, b.Name, input)
+						}
 					}
-					s.rememberToolUse(sessionID, b.ID, b.Name, input)
 					// TaskStop tool calls explicitly remove tasks
 					if b.Name == "TaskStop" && len(b.Input) > 0 {
 						var stop struct {
@@ -242,15 +258,39 @@ func lastToolCall(h []BackgroundTaskToolCall) *BackgroundTaskToolCall {
 	return &h[len(h)-1]
 }
 
+// isJSONNullOrEmpty reports whether the raw JSON value is empty or the
+// literal `null`. Used to mirror the frontend's `b.input != null` guard.
+func isJSONNullOrEmpty(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return true
+	}
+	// Trim whitespace by hand: rawStreamLine fields are well-formed JSON values
+	// emitted by encoding/json, so a trimmed comparison is enough.
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			continue
+		}
+		// Compare the next 4 bytes to "null".
+		if c == 'n' && len(raw)-i >= 4 && string(raw[i:i+4]) == "null" {
+			return true
+		}
+		return false
+	}
+	return true
+}
+
 // List returns the current background tasks for the given session, ordered
 // by started_at ascending (oldest first), to match frontend insertion order.
+// Dismissed tasks (logical delete) are excluded.
 func (s *BackgroundTaskStore) List(sessionID string) ([]BackgroundTask, error) {
 	rows, err := s.db.Query(
 		`SELECT task_id, task_type, agent_id, description, started_at,
 		        last_tool_name, last_tool_input, output,
 		        usage_input_tokens, usage_output_tokens,
 		        tool_call_history
-		 FROM background_tasks WHERE session_id = ?
+		 FROM background_tasks
+		 WHERE session_id = ? AND dismissed_at IS NULL
 		 ORDER BY started_at ASC, task_id ASC`,
 		sessionID,
 	)
@@ -323,9 +363,34 @@ func (s *BackgroundTaskStore) List(sessionID string) ([]BackgroundTask, error) {
 	return tasks, nil
 }
 
-// Dismiss removes a task row.
+// Dismiss marks a task row as dismissed (logical delete). The row is kept
+// in the DB as a tombstone so that a delayed task_progress event for the
+// same task_id cannot resurrect it via UPSERT.
 func (s *BackgroundTaskStore) Dismiss(sessionID, taskID string) error {
-	return s.deleteTask(sessionID, taskID)
+	res, err := s.db.Exec(
+		`UPDATE background_tasks
+		 SET dismissed_at = CURRENT_TIMESTAMP
+		 WHERE session_id = ? AND task_id = ? AND dismissed_at IS NULL`,
+		sessionID, taskID,
+	)
+	if err != nil {
+		return fmt.Errorf("dismiss background task: %w", err)
+	}
+	rows, _ := res.RowsAffected()
+	if rows == 0 {
+		// No existing row: insert a tombstone so a later delayed task_progress
+		// event cannot recreate the task.
+		_, err = s.db.Exec(
+			`INSERT OR IGNORE INTO background_tasks (
+				session_id, task_id, task_type, dismissed_at, updated_at
+			 ) VALUES (?, ?, 'unknown', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			sessionID, taskID,
+		)
+		if err != nil {
+			return fmt.Errorf("insert dismiss tombstone: %w", err)
+		}
+	}
+	return nil
 }
 
 // RebuildFromJSONL clears the existing rows for the session and replays all
@@ -422,7 +487,8 @@ func (s *BackgroundTaskStore) getTask(sessionID, taskID string) (*BackgroundTask
 		        last_tool_name, last_tool_input, output,
 		        usage_input_tokens, usage_output_tokens,
 		        tool_call_history
-		 FROM background_tasks WHERE session_id = ? AND task_id = ?`,
+		 FROM background_tasks
+		 WHERE session_id = ? AND task_id = ? AND dismissed_at IS NULL`,
 		sessionID, taskID,
 	)
 	var t BackgroundTask
@@ -507,6 +573,8 @@ func (s *BackgroundTaskStore) upsertTask(sessionID string, t BackgroundTask) err
 			outTok = sql.NullInt64{Int64: int64(*t.Usage.OutputTokens), Valid: true}
 		}
 	}
+	// Skip if the task has been dismissed (tombstone present) so a delayed
+	// task_progress event cannot resurrect a dismissed row.
 	_, err = s.db.Exec(
 		`INSERT INTO background_tasks (
 			session_id, task_id, task_type, agent_id, description, started_at,
@@ -525,7 +593,8 @@ func (s *BackgroundTaskStore) upsertTask(sessionID string, t BackgroundTask) err
 			usage_input_tokens = excluded.usage_input_tokens,
 			usage_output_tokens = excluded.usage_output_tokens,
 			tool_call_history = excluded.tool_call_history,
-			updated_at = CURRENT_TIMESTAMP`,
+			updated_at = CURRENT_TIMESTAMP
+		 WHERE background_tasks.dismissed_at IS NULL`,
 		sessionID, t.TaskID, t.TaskType,
 		nullableString(t.AgentID), nullableString(t.Description), nullableString(t.StartedAt),
 		nullableString(t.LastToolName), lastInputJSON, nullableString(t.Output),

--- a/internal/session/background_task_test.go
+++ b/internal/session/background_task_test.go
@@ -1,7 +1,10 @@
 package session
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/myuon/agmux/internal/db"
@@ -177,4 +180,163 @@ func TestBackgroundTaskStore_NonTaskLinesAreIgnored(t *testing.T) {
 	tasks, err := store.List("s")
 	require.NoError(t, err)
 	assert.Len(t, tasks, 0)
+}
+
+// TestBackgroundTaskStore_DismissedTaskIsNotResurrected verifies that a
+// delayed task_progress event for a dismissed task does not bring the row
+// back. The frontend / API List() must continue to hide the task.
+func TestBackgroundTaskStore_DismissedTaskIsNotResurrected(t *testing.T) {
+	store := newTestBgStore(t)
+
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t","task_type":"local_agent"}`)))
+	require.NoError(t, store.Dismiss("s", "t"))
+
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	require.Len(t, tasks, 0)
+
+	// Late-arriving task_progress event for the same task_id must not
+	// resurrect the dismissed row.
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_progress","task_id":"t","description":"late","last_tool_name":"Bash"}`)))
+	tasks, err = store.List("s")
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0, "dismissed task must not be resurrected by late task_progress")
+
+	// And a fresh task_started for the same id is also blocked (tombstone).
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t","task_type":"local_agent"}`)))
+	tasks, err = store.List("s")
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0, "dismissed task must stay hidden even when re-started")
+}
+
+// TestBackgroundTaskStore_DismissBeforeAnyTaskStarted creates a tombstone
+// for an unknown task_id and verifies that a subsequent task_started /
+// task_progress for that id is still suppressed.
+func TestBackgroundTaskStore_DismissBeforeAnyTaskStarted(t *testing.T) {
+	store := newTestBgStore(t)
+
+	require.NoError(t, store.Dismiss("s", "t"))
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t","task_type":"local_agent"}`)))
+
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0)
+}
+
+// TestBackgroundTaskStore_ConcurrentApplyLine simulates two goroutines
+// (e.g. RebuildFromJSONL and a live onNewLines callback) appending
+// task_progress entries concurrently. Without serialization the
+// tool_call_history would lose entries via read-modify-write race.
+func TestBackgroundTaskStore_ConcurrentApplyLine(t *testing.T) {
+	store := newTestBgStore(t)
+
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t","task_type":"local_agent"}`)))
+
+	const N = 50
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < N; i++ {
+			line := fmt.Sprintf(`{"type":"system","subtype":"task_progress","task_id":"t","last_tool_name":"A%d","description":"d"}`, i)
+			_ = store.ApplyLine("s", []byte(line))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < N; i++ {
+			line := fmt.Sprintf(`{"type":"system","subtype":"task_progress","task_id":"t","last_tool_name":"B%d","description":"d"}`, i)
+			_ = store.ApplyLine("s", []byte(line))
+		}
+	}()
+	wg.Wait()
+
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	// Expect exactly 2*N appended history entries (every line has a unique
+	// last_tool_name so dedup never drops anything). Without the mutex this
+	// would frequently come out short.
+	assert.Equal(t, 2*N, len(tasks[0].ToolCallHistory),
+		"expected %d history entries, got %d", 2*N, len(tasks[0].ToolCallHistory))
+}
+
+// TestBackgroundTaskStore_RebuildFromJSONL writes a JSONL file with
+// task events, runs RebuildFromJSONL with various clearOffset values,
+// and asserts the resulting DB state matches the replayed segment.
+func TestBackgroundTaskStore_RebuildFromJSONL(t *testing.T) {
+	store := newTestBgStore(t)
+
+	// RebuildFromJSONL reads from db.StreamsDir(), so point HOME at the
+	// test temp dir to isolate file IO.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	streamsDir, err := db.StreamsDir()
+	require.NoError(t, err)
+	jsonlPath := filepath.Join(streamsDir, "sess.jsonl")
+
+	earlyLine := `{"type":"system","subtype":"task_started","task_id":"t-early","task_type":"local_agent","description":"early"}` + "\n"
+	lateStarted := `{"type":"system","subtype":"task_started","task_id":"t-late","task_type":"local_agent","description":"late"}` + "\n"
+	lateProgress := `{"type":"system","subtype":"task_progress","task_id":"t-late","last_tool_name":"Bash","description":"step"}` + "\n"
+
+	contents := []byte(earlyLine + lateStarted + lateProgress)
+	require.NoError(t, os.WriteFile(jsonlPath, contents, 0o644))
+
+	// Full replay (offset 0) should yield two tasks.
+	require.NoError(t, store.RebuildFromJSONL("sess", 0))
+	tasks, err := store.List("sess")
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+
+	// Replay starting from after the early line should yield only the late task.
+	offset := int64(len(earlyLine))
+	require.NoError(t, store.RebuildFromJSONL("sess", offset))
+	tasks, err = store.List("sess")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "t-late", tasks[0].TaskID)
+	require.Len(t, tasks[0].ToolCallHistory, 1)
+	assert.Equal(t, "Bash", tasks[0].ToolCallHistory[0].ToolName)
+
+	// Missing JSONL file must not error.
+	require.NoError(t, os.Remove(jsonlPath))
+	require.NoError(t, store.RebuildFromJSONL("sess", 0))
+	tasks, err = store.List("sess")
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0)
+}
+
+// TestBackgroundTaskStore_PendingToolUseInputsCap verifies the 256-entry
+// cap on the pendingToolUseInputs map keeps the oldest entries from
+// growing unbounded.
+func TestBackgroundTaskStore_PendingToolUseInputsCap(t *testing.T) {
+	store := newTestBgStore(t)
+
+	for i := 0; i < 300; i++ {
+		line := fmt.Sprintf(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"id-%d","name":"Tool","input":{"k":%d}}]}}`, i, i)
+		require.NoError(t, store.ApplyLine("s", []byte(line)))
+	}
+
+	store.mu.Lock()
+	got := len(store.pendingToolUseInputs["s"])
+	store.mu.Unlock()
+	assert.LessOrEqual(t, got, 256, "pending tool_use map must be capped to 256 entries")
+	assert.Greater(t, got, 0)
+}
+
+// TestBackgroundTaskStore_NullToolUseInputIsIgnored mirrors the frontend
+// behavior of skipping tool_use blocks whose input is null.
+func TestBackgroundTaskStore_NullToolUseInputIsIgnored(t *testing.T) {
+	store := newTestBgStore(t)
+
+	// tool_use with input: null should not register a pending input.
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu","name":"Agent","input":null}]}}`)))
+
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t","task_type":"local_agent","tool_use_id":"tu"}`)))
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Empty(t, tasks[0].LastToolName, "null input must not resolve to a lastToolName")
+	assert.Nil(t, tasks[0].LastToolInput)
 }

--- a/internal/session/background_task_test.go
+++ b/internal/session/background_task_test.go
@@ -1,0 +1,180 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/myuon/agmux/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestBgStore(t *testing.T) *BackgroundTaskStore {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	sqlDB, err := db.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return NewBackgroundTaskStore(sqlDB)
+}
+
+func TestBackgroundTaskStore_TaskStartedAddsTask(t *testing.T) {
+	store := newTestBgStore(t)
+
+	// task_started system event
+	line := `{"type":"system","subtype":"task_started","task_id":"t1","task_type":"local_agent","agent_id":"a1","description":"do thing","timestamp":"2025-01-01T00:00:00Z"}`
+	require.NoError(t, store.ApplyLine("sess-1", []byte(line)))
+
+	tasks, err := store.List("sess-1")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "t1", tasks[0].TaskID)
+	assert.Equal(t, "local_agent", tasks[0].TaskType)
+	assert.Equal(t, "a1", tasks[0].AgentID)
+	assert.Equal(t, "do thing", tasks[0].Description)
+	assert.Equal(t, "2025-01-01T00:00:00Z", tasks[0].StartedAt)
+}
+
+func TestBackgroundTaskStore_TaskNotificationRemovesTask(t *testing.T) {
+	store := newTestBgStore(t)
+
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t1","task_type":"local_bash"}`)))
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_notification","task_id":"t1","status":"completed"}`)))
+	tasks, err = store.List("s")
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0)
+}
+
+func TestBackgroundTaskStore_TaskProgressUpdatesFields(t *testing.T) {
+	store := newTestBgStore(t)
+
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t","task_type":"local_agent","timestamp":"2025-01-01T00:00:00Z"}`)))
+
+	progress := `{"type":"system","subtype":"task_progress","task_id":"t","description":"phase 2","last_tool_name":"Bash","last_tool_input":{"command":"ls"},"output":"some","usage":{"input_tokens":100,"output_tokens":50},"timestamp":"2025-01-01T00:01:00Z"}`
+	require.NoError(t, store.ApplyLine("s", []byte(progress)))
+
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	task := tasks[0]
+	assert.Equal(t, "phase 2", task.Description)
+	assert.Equal(t, "Bash", task.LastToolName)
+	assert.Equal(t, "some", task.Output)
+	require.NotNil(t, task.Usage)
+	require.NotNil(t, task.Usage.InputTokens)
+	assert.Equal(t, 100, *task.Usage.InputTokens)
+	require.NotNil(t, task.Usage.OutputTokens)
+	assert.Equal(t, 50, *task.Usage.OutputTokens)
+	require.Len(t, task.ToolCallHistory, 1)
+	assert.Equal(t, "Bash", task.ToolCallHistory[0].ToolName)
+}
+
+func TestBackgroundTaskStore_TaskProgressDeduplicatesHistory(t *testing.T) {
+	store := newTestBgStore(t)
+
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t","task_type":"local_agent"}`)))
+
+	// Same tool name and description -> no new history entry
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_progress","task_id":"t","last_tool_name":"Read","description":"d1"}`)))
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_progress","task_id":"t","last_tool_name":"Read","description":"d1"}`)))
+	// Same tool name but different description -> new entry
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_progress","task_id":"t","last_tool_name":"Read","description":"d2"}`)))
+	// Different tool name -> new entry
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_progress","task_id":"t","last_tool_name":"Bash"}`)))
+
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, []BackgroundTaskToolCall{
+		{ToolName: "Read", Description: "d1"},
+		{ToolName: "Read", Description: "d2"},
+		{ToolName: "Bash"},
+	}, tasks[0].ToolCallHistory)
+}
+
+func TestBackgroundTaskStore_TaskStartedResolvesToolUseInput(t *testing.T) {
+	store := newTestBgStore(t)
+
+	// First an assistant message with a tool_use of name "Agent"
+	assistant := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"Agent","input":{"prompt":"hi"}}]}}`
+	require.NoError(t, store.ApplyLine("s", []byte(assistant)))
+
+	// Then a task_started referring to that tool_use_id
+	started := `{"type":"system","subtype":"task_started","task_id":"t","task_type":"local_agent","tool_use_id":"tu1"}`
+	require.NoError(t, store.ApplyLine("s", []byte(started)))
+
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "Agent", tasks[0].LastToolName)
+	require.NotNil(t, tasks[0].LastToolInput)
+}
+
+func TestBackgroundTaskStore_TaskStopRemovesTask(t *testing.T) {
+	store := newTestBgStore(t)
+
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t","task_type":"local_agent"}`)))
+
+	// Assistant calls TaskStop tool
+	stop := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu","name":"TaskStop","input":{"task_id":"t"}}]}}`
+	require.NoError(t, store.ApplyLine("s", []byte(stop)))
+
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0)
+}
+
+func TestBackgroundTaskStore_DismissRemovesTask(t *testing.T) {
+	store := newTestBgStore(t)
+
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t","task_type":"local_agent"}`)))
+	require.NoError(t, store.Dismiss("s", "t"))
+
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0)
+}
+
+func TestBackgroundTaskStore_ListIsEmptyForUnknownSession(t *testing.T) {
+	store := newTestBgStore(t)
+	tasks, err := store.List("missing")
+	require.NoError(t, err)
+	assert.NotNil(t, tasks)
+	assert.Len(t, tasks, 0)
+}
+
+func TestBackgroundTaskStore_ClearSessionDropsAllTasks(t *testing.T) {
+	store := newTestBgStore(t)
+
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t1","task_type":"local_agent"}`)))
+	require.NoError(t, store.ApplyLine("s", []byte(`{"type":"system","subtype":"task_started","task_id":"t2","task_type":"local_agent"}`)))
+
+	require.NoError(t, store.ClearSession("s"))
+
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0)
+}
+
+func TestBackgroundTaskStore_NonTaskLinesAreIgnored(t *testing.T) {
+	store := newTestBgStore(t)
+
+	// Various non-task lines should not error and not produce rows.
+	for _, line := range []string{
+		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}`,
+		`{"type":"system","subtype":"init"}`,
+		`{"type":"result","subtype":"success"}`,
+		`not json`,
+		``,
+	} {
+		require.NoError(t, store.ApplyLine("s", []byte(line)))
+	}
+	tasks, err := store.List("s")
+	require.NoError(t, err)
+	assert.Len(t, tasks, 0)
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1052,7 +1052,9 @@ func (m *Manager) wireSessionIDCallback(sessionID string, sp *HolderStreamProces
 		}
 	})
 	if upstream == nil {
-		m.logger.Warn("onNewLines callback is nil, WebSocket updates will not work", "sessionId", sessionID)
+		// Background task DB updates still run via the wrapper above; only the
+		// upstream broadcast (e.g. WebSocket relay) is missing.
+		m.logger.Info("onNewLines upstream is nil; background task DB updates will still run, but no upstream broadcast is wired", "sessionId", sessionID)
 	} else {
 		m.logger.Info("onNewLines callback set for session", "sessionId", sessionID)
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -47,6 +47,7 @@ type Manager struct {
 	logger             *slog.Logger
 	onNewLines     func(sessionID string, newLines []string, total int)
 	onStatusChange func(sessionID string, status Status, lastError string)
+	backgroundTasks *BackgroundTaskStore
 }
 
 const nanoidAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
@@ -76,7 +77,21 @@ func NewManager(db *sql.DB, claudeCommand string, permissionMode string, apiPort
 		deletingSet:      make(map[string]struct{}),
 		ephemeralCancels: make(map[string]context.CancelFunc),
 		logger:           logger.With("component", "session_manager"),
+		backgroundTasks:  NewBackgroundTaskStore(db),
 	}
+}
+
+// BackgroundTasks returns the manager's background task store.
+func (m *Manager) BackgroundTasks() *BackgroundTaskStore {
+	return m.backgroundTasks
+}
+
+// ListBackgroundTasks returns the persisted background tasks for the session.
+func (m *Manager) ListBackgroundTasks(sessionID string) ([]BackgroundTask, error) {
+	if m.backgroundTasks == nil {
+		return []BackgroundTask{}, nil
+	}
+	return m.backgroundTasks.List(sessionID)
 }
 
 // ManagedHolderPIDs returns the PIDs of all holder processes currently managed by this Manager.
@@ -216,6 +231,14 @@ func (m *Manager) RecoverStreamProcesses() {
 			Model:         dbModel,
 			APIPort:       m.apiPort,
 			ClearOffset:   clearOffset,
+		}
+
+		// Rebuild background_tasks DB from the JSONL so the API reflects
+		// the current task list before any new live lines arrive.
+		if m.backgroundTasks != nil {
+			if err := m.backgroundTasks.RebuildFromJSONL(id, clearOffset); err != nil {
+				m.logger.Warn("failed to rebuild background tasks from JSONL", "sessionId", id, "error", err)
+			}
 		}
 
 		// Try to reconnect to existing holder first
@@ -984,7 +1007,16 @@ func (m *Manager) Delete(id string) error {
 	}
 
 	_, err = m.db.Exec("DELETE FROM sessions WHERE id = ?", id)
-	return err
+	if err != nil {
+		return err
+	}
+	// Drop background task rows for the deleted session.
+	if m.backgroundTasks != nil {
+		if err := m.backgroundTasks.ClearSession(id); err != nil {
+			m.logger.Warn("failed to clear background tasks on delete", "sessionId", id, "error", err)
+		}
+	}
+	return nil
 }
 
 // wireSessionIDCallback sets up the onSessionID callback on a stream process
@@ -1004,11 +1036,25 @@ func (m *Manager) wireSessionIDCallback(sessionID string, sp *HolderStreamProces
 			m.logger.Info("model name captured from stream", "sessionId", sessionID, "model", model)
 		}
 	})
-	if m.onNewLines != nil {
-		sp.SetOnNewLines(m.onNewLines)
-		m.logger.Info("onNewLines callback set for session", "sessionId", sessionID)
-	} else {
+	// Wrap onNewLines so we can update the background_tasks DB table per line.
+	bgStore := m.backgroundTasks
+	upstream := m.onNewLines
+	sp.SetOnNewLines(func(sid string, newLines []string, total int) {
+		if bgStore != nil {
+			for _, line := range newLines {
+				if err := bgStore.ApplyLine(sid, []byte(line)); err != nil {
+					m.logger.Warn("background task apply line failed", "sessionId", sid, "error", err)
+				}
+			}
+		}
+		if upstream != nil {
+			upstream(sid, newLines, total)
+		}
+	})
+	if upstream == nil {
 		m.logger.Warn("onNewLines callback is nil, WebSocket updates will not work", "sessionId", sessionID)
+	} else {
+		m.logger.Info("onNewLines callback set for session", "sessionId", sessionID)
 	}
 	sp.SetOnTurnComplete(func(sid string) {
 		m.logger.Info("turn completed (result event detected), setting status to idle",
@@ -1151,7 +1197,16 @@ func (m *Manager) Clear(id string) error {
 
 	// Store clear_offset and reset task/goal but keep the existing process and CLI session running.
 	_, err = m.db.Exec("UPDATE sessions SET last_error = NULL, current_task = NULL, goal = NULL, goals = '[]', clear_offset = ?, updated_at = ? WHERE id = ?", clearOffset, time.Now(), id)
-	return err
+	if err != nil {
+		return err
+	}
+	// Drop background task rows tied to the cleared portion of the stream.
+	if m.backgroundTasks != nil {
+		if err := m.backgroundTasks.ClearSession(id); err != nil {
+			m.logger.Warn("failed to clear background tasks", "sessionId", id, "error", err)
+		}
+	}
+	return nil
 }
 
 func (m *Manager) SendKeys(id string, text string) error {
@@ -1854,6 +1909,13 @@ func (m *Manager) DismissTask(sessionID, taskID string) error {
 	m.streamMu.Unlock()
 	if ok {
 		sp.DecrementRunningTasks()
+	}
+
+	// Remove DB row so the background task list endpoint stops returning it.
+	if m.backgroundTasks != nil {
+		if err := m.backgroundTasks.Dismiss(sessionID, taskID); err != nil {
+			m.logger.Warn("failed to dismiss background task in DB", "sessionId", sessionID, "taskId", taskID, "error", err)
+		}
 	}
 
 	return nil

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -78,6 +78,9 @@ type SessionService interface {
 
 	// DismissTask writes a dismissed event to the JSONL stream for the given task.
 	DismissTask(sessionID, taskID string) error
+
+	// ListBackgroundTasks returns the persisted background tasks for the session.
+	ListBackgroundTasks(sessionID string) ([]BackgroundTask, error)
 }
 
 // Verify Manager implements SessionService at compile time.


### PR DESCRIPTION
## Summary

- 新テーブル `background_tasks` を追加し、フロントの `extractActiveTasks` と同等のタスク検知ロジックを Go 側 (`BackgroundTaskStore`) に移植
- 新 API: `GET /api/sessions/:id/background-tasks` (一覧) / `DELETE /api/sessions/:id/background-tasks/:taskId` (dismiss)。既存の `POST /sessions/:id/tasks/:taskId/dismiss` も DB 行を削除するよう拡張
- フロント (`SessionPage.tsx`) は新 API を fetch し、自前検知ロジックを削除。WebSocket 経由で stream lines が更新されるたびに refetch
- セッション復帰時に JSONL から DB を再構築 (`RebuildFromJSONL`)
- 単体テスト 10 件追加

## 動作概要

1. `Manager.wireSessionIDCallback` で `onNewLines` をラップし、各 JSONL 行を `BackgroundTaskStore.ApplyLine` に流す
2. `task_started` で行追加、`task_progress` で description / last_tool / usage / 履歴を更新、`task_notification` または `TaskStop` ツール呼び出しで行削除
3. dismiss / clear / delete は DB 行も削除

## Out of scope (ユーザー確定仕様より別 PR)

- 既存の `working/idle` ステータス判定への統合 (#627 のフォローアップ)
- #568 の追加テスト

## Test plan

- [x] `go test ./...` 全パス (新規 10 ケース含む)
- [x] `make build` 成功 (frontend + go binary)
- [x] `tsc --noEmit` 成功
- [ ] 動作確認: 長時間 Agent タスクを起動し、`GET /api/sessions/:id/background-tasks` で一覧が DB から返ること、完了で消えること

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)