### PR TITLE
feat: バックグラウンドタスク通知のオン/オフ切替

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -133,15 +133,21 @@ func initManager(cfg *config.Config, port int, logger *slog.Logger) (session.Ses
 	mgr.SetDefaultModels(cfg.Session.ClaudeDefaultModel, cfg.Session.CodexDefaultModel)
 
 	// Configure background task notification interval
-	bgNotifyIntervalStr := cfg.Daemon.BackgroundTaskNotificationInterval
-	if bgNotifyIntervalStr == "" {
-		bgNotifyIntervalStr = "30m"
-	}
-	if d, err := time.ParseDuration(bgNotifyIntervalStr); err == nil {
-		mgr.SetNotifyInterval(d)
+	if !cfg.Daemon.IsBackgroundTaskNotificationEnabled() {
+		// Setting interval to 0 disables the periodic notification
+		// (HolderStreamProcess.startPeriodicNotification short-circuits when <= 0).
+		mgr.SetNotifyInterval(0)
 	} else {
-		logger.Warn("invalid background_task_notification_interval, using default 30m", "value", bgNotifyIntervalStr, "error", err)
-		mgr.SetNotifyInterval(30 * time.Minute)
+		bgNotifyIntervalStr := cfg.Daemon.BackgroundTaskNotificationInterval
+		if bgNotifyIntervalStr == "" {
+			bgNotifyIntervalStr = "30m"
+		}
+		if d, err := time.ParseDuration(bgNotifyIntervalStr); err == nil {
+			mgr.SetNotifyInterval(d)
+		} else {
+			logger.Warn("invalid background_task_notification_interval, using default 30m", "value", bgNotifyIntervalStr, "error", err)
+			mgr.SetNotifyInterval(30 * time.Minute)
+		}
 	}
 
 	return mgr, database, nil

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -243,7 +243,11 @@ export interface PromptTemplate {
 
 export interface AppConfig {
   server: { port: number; frontendDir?: string };
-  daemon: { interval: string };
+  daemon: {
+    interval: string;
+    backgroundTaskNotificationInterval?: string;
+    backgroundTaskNotificationEnabled?: boolean;
+  };
   session: { claudeCommand: string; defaultRole?: string; defaultModel?: string; claudeDefaultModel?: string; codexDefaultModel?: string };
   devMode: boolean;
   prompts?: { systemPrompt: string };

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -82,6 +82,26 @@ export function ConfigPage() {
               className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-32 focus:outline-none focus:border-blue-500"
             />
           </Field>
+          <Field label="バックグラウンドタスク通知">
+            <ToggleButton
+              enabled={config.daemon.backgroundTaskNotificationEnabled !== false}
+              onClick={() =>
+                setConfig({
+                  ...config,
+                  daemon: {
+                    ...config.daemon,
+                    backgroundTaskNotificationEnabled:
+                      config.daemon.backgroundTaskNotificationEnabled === false,
+                  },
+                })
+              }
+            >
+              {config.daemon.backgroundTaskNotificationEnabled !== false ? "ON" : "OFF"}
+            </ToggleButton>
+          </Field>
+          <p className="text-xs text-gray-500">
+            有効にするとバックグラウンドタスク実行中、定期的に経過時間を通知します（間隔は config.toml の <code className="font-mono bg-gray-100 px-1 rounded">background_task_notification_interval</code>、default 30m）
+          </p>
         </Section>
 
         <Section title="Session">

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,8 +37,23 @@ type ServerConfig struct {
 }
 
 type DaemonConfig struct {
-	Interval                          string `toml:"interval"`
+	Interval                           string `toml:"interval"`
 	BackgroundTaskNotificationInterval string `toml:"background_task_notification_interval"`
+	// BackgroundTaskNotificationEnabled controls whether the periodic
+	// "バックグラウンドタスク実行中" notification is sent. *bool is used so we
+	// can distinguish "field absent" (treated as enabled for backward compat)
+	// from an explicit "false".
+	BackgroundTaskNotificationEnabled *bool `toml:"background_task_notification_enabled,omitempty"`
+}
+
+// IsBackgroundTaskNotificationEnabled returns true when the periodic
+// background-task notification should fire. Defaults to true when the
+// underlying *bool is nil (backward compatibility with existing config files).
+func (d DaemonConfig) IsBackgroundTaskNotificationEnabled() bool {
+	if d.BackgroundTaskNotificationEnabled == nil {
+		return true
+	}
+	return *d.BackgroundTaskNotificationEnabled
 }
 
 type SessionConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,26 @@
+package config
+
+import "testing"
+
+func TestIsBackgroundTaskNotificationEnabled_DefaultsToTrue(t *testing.T) {
+	d := DaemonConfig{}
+	if !d.IsBackgroundTaskNotificationEnabled() {
+		t.Fatalf("expected default (nil) to be enabled=true")
+	}
+}
+
+func TestIsBackgroundTaskNotificationEnabled_ExplicitFalse(t *testing.T) {
+	v := false
+	d := DaemonConfig{BackgroundTaskNotificationEnabled: &v}
+	if d.IsBackgroundTaskNotificationEnabled() {
+		t.Fatalf("expected explicit false to be enabled=false")
+	}
+}
+
+func TestIsBackgroundTaskNotificationEnabled_ExplicitTrue(t *testing.T) {
+	v := true
+	d := DaemonConfig{BackgroundTaskNotificationEnabled: &v}
+	if !d.IsBackgroundTaskNotificationEnabled() {
+		t.Fatalf("expected explicit true to be enabled=true")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1113,7 +1113,9 @@ type configServerJSON struct {
 	FrontendDir string `json:"frontendDir,omitempty"`
 }
 type configDaemonJSON struct {
-	Interval string `json:"interval"`
+	Interval                           string `json:"interval"`
+	BackgroundTaskNotificationInterval string `json:"backgroundTaskNotificationInterval,omitempty"`
+	BackgroundTaskNotificationEnabled  *bool  `json:"backgroundTaskNotificationEnabled,omitempty"`
 }
 type configSessionJSON struct {
 	ClaudeCommand      string `json:"claudeCommand"`
@@ -1137,9 +1139,14 @@ func configToJSON(cfg *config.Config) configJSON {
 		}
 	}
 	cfgPath, _ := config.ConfigPath()
+	bgEnabled := cfg.Daemon.IsBackgroundTaskNotificationEnabled()
 	return configJSON{
-		Server:          configServerJSON{Port: cfg.Server.Port, FrontendDir: cfg.Server.FrontendDir},
-		Daemon:          configDaemonJSON{Interval: cfg.Daemon.Interval},
+		Server: configServerJSON{Port: cfg.Server.Port, FrontendDir: cfg.Server.FrontendDir},
+		Daemon: configDaemonJSON{
+			Interval:                           cfg.Daemon.Interval,
+			BackgroundTaskNotificationInterval: cfg.Daemon.BackgroundTaskNotificationInterval,
+			BackgroundTaskNotificationEnabled:  &bgEnabled,
+		},
 		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand, DefaultRole: cfg.Session.DefaultRole, DefaultModel: cfg.Session.DefaultModel, ClaudeDefaultModel: cfg.Session.ClaudeDefaultModel, CodexDefaultModel: cfg.Session.CodexDefaultModel},
 		Claude:          configClaudeJSON{PermissionMode: cfg.Claude.ClaudePermissionMode()},
 		DevMode:         cfg.DevMode,
@@ -1160,8 +1167,12 @@ func jsonToConfig(j configJSON) *config.Config {
 		}
 	}
 	return &config.Config{
-		Server:          config.ServerConfig{Port: j.Server.Port},
-		Daemon:          config.DaemonConfig{Interval: j.Daemon.Interval},
+		Server: config.ServerConfig{Port: j.Server.Port},
+		Daemon: config.DaemonConfig{
+			Interval:                           j.Daemon.Interval,
+			BackgroundTaskNotificationInterval: j.Daemon.BackgroundTaskNotificationInterval,
+			BackgroundTaskNotificationEnabled:  j.Daemon.BackgroundTaskNotificationEnabled,
+		},
 		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand, DefaultRole: j.Session.DefaultRole, DefaultModel: j.Session.DefaultModel, ClaudeDefaultModel: j.Session.ClaudeDefaultModel, CodexDefaultModel: j.Session.CodexDefaultModel},
 		Claude:          config.ClaudeConfig{PermissionMode: j.Claude.PermissionMode},
 		DevMode:         j.DevMode,
@@ -1197,6 +1208,11 @@ func (s *Server) updateConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	cfg := jsonToConfig(req)
 	cfg.Server.FrontendDir = current.Server.FrontendDir
+	// Preserve background_task_notification_interval if the request omitted it
+	// (older clients may not send the field).
+	if cfg.Daemon.BackgroundTaskNotificationInterval == "" {
+		cfg.Daemon.BackgroundTaskNotificationInterval = current.Daemon.BackgroundTaskNotificationInterval
+	}
 	if err := config.Save(cfg); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return


### PR DESCRIPTION
## Summary
- `DaemonConfig` に `BackgroundTaskNotificationEnabled *bool` (default true / 後方互換) を追加
- 起動時 enabled=false なら `SetNotifyInterval(0)` を呼んで `startPeriodicNotification` のガードで停止
- `/config` API (configDaemonJSON) に `backgroundTaskNotificationEnabled` / `backgroundTaskNotificationInterval` を露出
- ConfigPage の Daemon セクションに「バックグラウンドタスク通知」ToggleButton を追加

Closes #630

## Test plan
- [x] `make build` がパス
- [x] `go test ./...` がパス (config パッケージに enabled の真偽 / nil case の単体テストを追加)
- [ ] ConfigPage を開き、Daemon セクションに「バックグラウンドタスク通知」ToggleButton が表示される
- [ ] OFF にして保存 → 再起動後、バックグラウンドタスク実行中に定期通知が送られない

🤖 Generated with [Claude Code](https://claude.com/claude-code)