### PR TITLE
fix: プロジェクトパス長文時のオーバーフロー修正

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -685,7 +685,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
           <>
             <span className="inline-flex shrink-0" style={{ viewTransitionName: `session-dot-${session.id}` }}><StatusDot status={session.status} /></span>
             <h2
-              className="text-xl sm:text-2xl font-bold hover:text-indigo-600 transition-colors cursor-pointer"
+              className="text-xl sm:text-2xl font-bold hover:text-indigo-600 transition-colors cursor-pointer truncate min-w-0 max-w-full"
               style={{ viewTransitionName: `session-name-${session.id}` }}
               onClick={() => {
                 navigator.clipboard.writeText(session.name).then(() => {
@@ -755,8 +755,8 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
         </div>
       )}
       {session ? (
-        <div className="flex items-center gap-1.5 mb-2 shrink-0 text-xs sm:text-sm text-gray-500">
-          <IconText icon={<FolderOpen className="w-3.5 h-3.5" />} className="text-xs sm:text-sm">
+        <div className="flex items-center gap-1.5 mb-2 shrink-0 text-xs sm:text-sm text-gray-500 min-w-0">
+          <IconText icon={<FolderOpen className="w-3.5 h-3.5" />} className="text-xs sm:text-sm min-w-0 flex-1">
             <span className="truncate" title={session.projectPath}>{session.projectPath}</span>
           </IconText>
         {session.githubUrl && (


### PR DESCRIPTION
## Summary

- セッションページ (`frontend/src/pages/SessionPage.tsx`) のヘッダーで、長いプロジェクトパスやセッション名がレイアウトをはみ出す問題を修正
- プロジェクトパス表示の親 flex item に `min-w-0 flex-1` を付与し、内側の `<span className="truncate">` が機能するようにレイアウトを調整
- セッション名 `<h2>` にも `truncate min-w-0 max-w-full` を付与して、長いセッション名も省略表示されるように

## Changes

- `frontend/src/pages/SessionPage.tsx`
  - プロジェクトパス行: 親 `<div>` に `min-w-0`、`IconText` に `min-w-0 flex-1` を追加
  - セッション名 `<h2>`: `truncate min-w-0 max-w-full` を追加

## Test plan

- [x] `npm run build` (frontend) が通る
- [x] 長いプロジェクトパス (`/Users/.../matsuri-data-warehouse` 等) でセッション画面が横にはみ出さない (モバイル幅含む) -- agent-browser で 390x844 にて確認 ([コメント](https://github.com/myuon/agmux/pull/633#issuecomment-4420635539))
- [x] 既存セッション (短いパス) の見た目に違和感がない -- `zoutou` セッションで確認
- [x] パスにマウスを乗せると `title` 属性で full path がツールチップ表示される -- DOM の `title` 属性に full path が保持されていることを確認

Closes #632