### PR TITLE
fix: 未完了セッションへの初回送信で resume を試みないようにする

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1257,10 +1257,14 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			cliSessionID = ReadCLISessionID(s.ID, provider)
 		}
 
-		// Resume if the DB flag says a conversation was started, OR if we found
-		// a CLI session ID in the JSONL stream (which proves a conversation exists
-		// even when the DB flag wasn't updated — e.g. session created via CLI).
-		canResume := s.ConversationStarted || cliSessionID != ""
+		// Only resume if a conversation turn has actually completed. A CLI
+		// session_id can be written to the JSONL by the SessionStart hook
+		// before the first turn finishes — for sessions created via the CLI
+		// and not yet replied to, the conversation file
+		// (~/.claude/projects/.../<id>.jsonl) does not exist yet, so
+		// `--resume <id>` would fail with "No conversation found with session
+		// ID: <uuid>" and the holder would loop. See issue #629.
+		canResume := s.ConversationStarted
 
 		effectiveSP := m.buildEffectiveSystemPrompt(s.SystemPrompt)
 		if s.Provider == ProviderCodex && cliSessionID != "" && canResume {

--- a/internal/session/manager_holderPID_test.go
+++ b/internal/session/manager_holderPID_test.go
@@ -507,3 +507,80 @@ func TestGetReadsConversationStarted(t *testing.T) {
 		t.Errorf("session id2 ConversationStarted = false, want true")
 	}
 }
+
+// TestSendKeysAutoRecoverResumeFlagDerivation is a regression test for issue #629.
+//
+// Scenario: a session is created via `agmux session create` (CLI). The Claude CLI
+// writes its session_id to the JSONL via the SessionStart hook before the first
+// turn completes, so `cli_session_id` (or the JSONL scan) is non-empty even though
+// `conversation_started` is still false. Previously the SendKeysWithImages
+// auto-recover branch computed `canResume := s.ConversationStarted || cliSessionID != ""`,
+// which caused the resumed holder to call `claude --resume <id>` against a
+// conversation file that did not exist yet, exiting with
+// "No conversation found with session ID: <uuid>" and looping.
+//
+// The fix: canResume must be derived purely from ConversationStarted so that the
+// initial send goes through normal startup (no --resume) and only subsequent
+// sends, after the first turn marks ConversationStarted=true, use --resume.
+//
+// This test mirrors the data shape produced by the bug and asserts the resume
+// flag derivation that SendKeysWithImages uses in its auto-recover path.
+func TestSendKeysAutoRecoverResumeFlagDerivation(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	now := time.Now()
+
+	// CLI-created session: cli_session_id populated (e.g. via JSONL fallback) but
+	// conversation_started still false because no turn has completed yet.
+	idCLICreated := "cli-created-not-started"
+	_, err := db.Exec(
+		`INSERT INTO sessions (id, name, project_path, tmux_session, status, type, output_mode, provider, model, cli_session_id, holder_pid, conversation_started, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		idCLICreated, "cli-created", "/tmp", "", "idle", "worker", "stream", "claude", "", "uuid-from-session-start-hook", 0, 0, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert cli-created session: %v", err)
+	}
+
+	// Same shape but conversation has started; resume must be enabled.
+	idConvStarted := "cli-created-started"
+	_, err = db.Exec(
+		`INSERT INTO sessions (id, name, project_path, tmux_session, status, type, output_mode, provider, model, cli_session_id, holder_pid, conversation_started, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		idConvStarted, "cli-started", "/tmp", "", "idle", "worker", "stream", "claude", "", "uuid-from-session-start-hook", 0, 1, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert cli-started session: %v", err)
+	}
+
+	m := newTestManager(t, db)
+
+	// Reproduce the SendKeysWithImages auto-recover derivation:
+	//   canResume := s.ConversationStarted
+	// (issue #629 fix: cli_session_id MUST NOT make canResume true on its own.)
+	sNotStarted, err := m.Get(idCLICreated)
+	if err != nil {
+		t.Fatalf("Get(cli-created): %v", err)
+	}
+	if sNotStarted.CliSessionID == "" {
+		t.Fatalf("precondition: expected CliSessionID to be non-empty to reproduce the bug")
+	}
+	canResume := sNotStarted.ConversationStarted
+	if canResume {
+		t.Errorf("canResume = true for CLI-created session with no conversation started; "+
+			"SendKeysWithImages would pass Resume: true causing 'No conversation found' (CliSessionID=%q)",
+			sNotStarted.CliSessionID)
+	}
+
+	sStarted, err := m.Get(idConvStarted)
+	if err != nil {
+		t.Fatalf("Get(cli-started): %v", err)
+	}
+	canResume = sStarted.ConversationStarted
+	if !canResume {
+		t.Errorf("canResume = false for CLI-created session after first turn; "+
+			"SendKeysWithImages would lose conversation history (CliSessionID=%q)",
+			sStarted.CliSessionID)
+	}
+}


### PR DESCRIPTION
## Summary

- CLI 作成セッション (`agmux session create`) への初回送信時に `--resume <uuid>` 起動を試みて Claude CLI が "No conversation found with session ID" で exit code 1 で終了し、セッションが詰む不具合を修正。
- `SendKeysWithImages` の auto-recover 経路で `canResume := s.ConversationStarted || cliSessionID != ""` としていた判定を `canResume := s.ConversationStarted` のみに変更。初ターン完了前は `SessionStart` フックが JSONL に書いた session_id を resume 候補として扱わない。
- `Reconnect` / `RecoverStreamProcesses` は既に `ConversationStarted` のみで判定しており、`SendKeysWithImages` だけが取りこぼしていたため、それらと整合させる形になる。
- 回帰テスト `TestSendKeysAutoRecoverResumeFlagDerivation` を追加し、`cli_session_id` だけが入っていて `conversation_started=0` の場合に `canResume=false` となること、`conversation_started=1` 後は `canResume=true` となることを確認。

Closes #629

## Test plan

- [x] `make build`
- [x] `go test ./...`
- [x] 新規回帰テスト `TestSendKeysAutoRecoverResumeFlagDerivation` がパスする
- [x] 既存の `TestReconnectResumeFlagDerivation` / `TestRecoverStreamProcessesResumeFlagDerivation` がパスする (会話開始後の resume 動作が壊れていないこと)