### PR TITLE
feat: Cursor Agent CLI を Provider として追加 (Phase 1)

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -130,7 +130,9 @@ func initManager(cfg *config.Config, port int, logger *slog.Logger) (session.Ses
 	}
 	mgr := session.NewManager(database, cfg.Session.ClaudeCommand, cfg.Claude.ClaudePermissionMode(), cfg.Server.Port, logger, cfg.Session.SystemPrompt)
 	mgr.SetCodexCommand(cfg.Session.CodexCommand)
+	mgr.SetCursorCommand(cfg.Session.CursorCommand)
 	mgr.SetDefaultModels(cfg.Session.ClaudeDefaultModel, cfg.Session.CodexDefaultModel)
+	mgr.SetCursorDefaultModel(cfg.Session.CursorDefaultModel)
 
 	// Configure background task notification interval
 	if !cfg.Daemon.IsBackgroundTaskNotificationEnabled() {
@@ -411,7 +413,7 @@ func sessionCreateCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&projectPath, "path", "p", ".", "Project directory path")
 	cmd.Flags().StringVarP(&prompt, "message", "m", "", "Initial prompt to send")
 	cmd.Flags().BoolVarP(&worktree, "worktree", "w", false, "Create a git worktree for the session")
-	cmd.Flags().StringVar(&provider, "provider", "claude", "Provider: claude or codex")
+	cmd.Flags().StringVar(&provider, "provider", "claude", "Provider: claude, codex, or cursor")
 	cmd.Flags().StringVar(&model, "model", "", "Model to use (e.g. claude-sonnet-4-5, o4-mini)")
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", true, "Enable full-auto mode (bypass permission prompts for Codex)")
 	cmd.Flags().StringVar(&parentSessionID, "parent", "", "Parent session ID to create a sub-session")

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -248,7 +248,7 @@ export interface AppConfig {
     backgroundTaskNotificationInterval?: string;
     backgroundTaskNotificationEnabled?: boolean;
   };
-  session: { claudeCommand: string; defaultRole?: string; defaultModel?: string; claudeDefaultModel?: string; codexDefaultModel?: string };
+  session: { claudeCommand: string; cursorCommand?: string; defaultRole?: string; defaultModel?: string; claudeDefaultModel?: string; codexDefaultModel?: string; cursorDefaultModel?: string };
   devMode: boolean;
   prompts?: { systemPrompt: string };
   templates: RoleTemplate[];

--- a/frontend/src/components/CreateSession.tsx
+++ b/frontend/src/components/CreateSession.tsx
@@ -221,6 +221,7 @@ export function CreateSession({ onClose, onCreate }: Props) {
             >
               <option value="claude">Claude</option>
               <option value="codex">Codex</option>
+              <option value="cursor">Cursor</option>
             </select>
           </div>
           {provider === "codex" && (

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -148,6 +148,28 @@ export function ConfigPage() {
               className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
             />
           </Field>
+          <Field label="Cursor Command">
+            <input
+              type="text"
+              value={config.session.cursorCommand || ""}
+              onChange={(e) =>
+                setConfig({ ...config, session: { ...config.session, cursorCommand: e.target.value || undefined } })
+              }
+              placeholder="agent"
+              className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
+            />
+          </Field>
+          <Field label="Cursor Default Model (optional)">
+            <input
+              type="text"
+              value={config.session.cursorDefaultModel || ""}
+              onChange={(e) =>
+                setConfig({ ...config, session: { ...config.session, cursorDefaultModel: e.target.value || undefined } })
+              }
+              placeholder="e.g. sonnet-4"
+              className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500"
+            />
+          </Field>
         </Section>
 
         <NotificationStatus />
@@ -603,6 +625,7 @@ function TemplateManager({ templates, onUpdate }: { templates: RoleTemplate[]; o
             >
               <option value="claude">Claude</option>
               <option value="codex">Codex</option>
+              <option value="cursor">Cursor</option>
             </select>
           </div>
           <div>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,11 +59,13 @@ func (d DaemonConfig) IsBackgroundTaskNotificationEnabled() bool {
 type SessionConfig struct {
 	ClaudeCommand      string `toml:"claude_command"`
 	CodexCommand       string `toml:"codex_command"`
+	CursorCommand      string `toml:"cursor_command"`
 	SystemPrompt       string `toml:"system_prompt"`
 	DefaultRole        string `toml:"default_role" json:"default_role,omitempty"`
 	DefaultModel       string `toml:"default_model" json:"default_model,omitempty"`       // Deprecated: use ClaudeDefaultModel
 	ClaudeDefaultModel string `toml:"claude_default_model" json:"claude_default_model,omitempty"`
 	CodexDefaultModel  string `toml:"codex_default_model" json:"codex_default_model,omitempty"`
+	CursorDefaultModel string `toml:"cursor_default_model" json:"cursor_default_model,omitempty"`
 }
 
 // DefaultPermissionMode is the default Claude CLI permission mode.
@@ -111,6 +113,7 @@ func Default() *Config {
 		Session: SessionConfig{
 			ClaudeCommand: "claude",
 			CodexCommand:  "codex",
+			CursorCommand: "agent",
 		},
 		Claude: ClaudeConfig{
 			PermissionMode: DefaultPermissionMode,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1119,10 +1119,12 @@ type configDaemonJSON struct {
 }
 type configSessionJSON struct {
 	ClaudeCommand      string `json:"claudeCommand"`
+	CursorCommand      string `json:"cursorCommand,omitempty"`
 	DefaultRole        string `json:"defaultRole,omitempty"`
 	DefaultModel       string `json:"defaultModel,omitempty"` // Deprecated: use ClaudeDefaultModel
 	ClaudeDefaultModel string `json:"claudeDefaultModel,omitempty"`
 	CodexDefaultModel  string `json:"codexDefaultModel,omitempty"`
+	CursorDefaultModel string `json:"cursorDefaultModel,omitempty"`
 }
 type configClaudeJSON struct {
 	PermissionMode string `json:"permissionMode"`
@@ -1147,7 +1149,7 @@ func configToJSON(cfg *config.Config) configJSON {
 			BackgroundTaskNotificationInterval: cfg.Daemon.BackgroundTaskNotificationInterval,
 			BackgroundTaskNotificationEnabled:  &bgEnabled,
 		},
-		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand, DefaultRole: cfg.Session.DefaultRole, DefaultModel: cfg.Session.DefaultModel, ClaudeDefaultModel: cfg.Session.ClaudeDefaultModel, CodexDefaultModel: cfg.Session.CodexDefaultModel},
+		Session:         configSessionJSON{ClaudeCommand: cfg.Session.ClaudeCommand, CursorCommand: cfg.Session.CursorCommand, DefaultRole: cfg.Session.DefaultRole, DefaultModel: cfg.Session.DefaultModel, ClaudeDefaultModel: cfg.Session.ClaudeDefaultModel, CodexDefaultModel: cfg.Session.CodexDefaultModel, CursorDefaultModel: cfg.Session.CursorDefaultModel},
 		Claude:          configClaudeJSON{PermissionMode: cfg.Claude.ClaudePermissionMode()},
 		DevMode:         cfg.DevMode,
 		Templates:       templates,
@@ -1173,7 +1175,7 @@ func jsonToConfig(j configJSON) *config.Config {
 			BackgroundTaskNotificationInterval: j.Daemon.BackgroundTaskNotificationInterval,
 			BackgroundTaskNotificationEnabled:  j.Daemon.BackgroundTaskNotificationEnabled,
 		},
-		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand, DefaultRole: j.Session.DefaultRole, DefaultModel: j.Session.DefaultModel, ClaudeDefaultModel: j.Session.ClaudeDefaultModel, CodexDefaultModel: j.Session.CodexDefaultModel},
+		Session:         config.SessionConfig{ClaudeCommand: j.Session.ClaudeCommand, CursorCommand: j.Session.CursorCommand, DefaultRole: j.Session.DefaultRole, DefaultModel: j.Session.DefaultModel, ClaudeDefaultModel: j.Session.ClaudeDefaultModel, CodexDefaultModel: j.Session.CodexDefaultModel, CursorDefaultModel: j.Session.CursorDefaultModel},
 		Claude:          config.ClaudeConfig{PermissionMode: j.Claude.PermissionMode},
 		DevMode:         j.DevMode,
 		Templates:       templates,

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -492,8 +492,10 @@ func (sp *HolderStreamProcess) Send(message string) error {
 
 // SendWithImages writes a user message with optional images via the socket.
 func (sp *HolderStreamProcess) SendWithImages(message string, images []ImageData) error {
-	// For Codex, check if the process has finished and handle restart
-	if sp.provider.Name() == ProviderCodex {
+	// Codex/Cursor are one-shot exec providers: the CLI exits after each prompt
+	// and must be re-spawned with --resume + the new prompt as positional arg.
+	// Both share the same restart-style send path (sendCodex).
+	if sp.provider.Name() == ProviderCodex || sp.provider.Name() == ProviderCursor {
 		return sp.sendCodex(message)
 	}
 

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -658,10 +658,10 @@ func (sp *HolderStreamProcess) sendCodex(message string) error {
 	sp.mu.RUnlock()
 
 	if cliSessionID == "" {
-		return fmt.Errorf("no CLI session ID available for codex resume")
+		return fmt.Errorf("no CLI session ID available for %s resume", sp.provider.Name())
 	}
 
-	slog.Info("restarting codex via new holder", "cliSessionID", cliSessionID, "message", message)
+	slog.Info("restarting one-shot provider via new holder", "provider", sp.provider.Name(), "cliSessionID", cliSessionID, "message", message)
 	return sp.restartForCodex(message, cliSessionID)
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -24,11 +24,13 @@ type Manager struct {
 	db                 *sql.DB
 	claudeCommand      string
 	codexCommand       string
+	cursorCommand      string
 	permissionMode     string
 	apiPort            int
 	systemPrompt       string
 	claudeDefaultModel string
 	codexDefaultModel  string
+	cursorDefaultModel string
 	notifyInterval     time.Duration
 	streamProcesses    map[string]*HolderStreamProcess
 	streamMu           sync.Mutex
@@ -70,6 +72,7 @@ func NewManager(db *sql.DB, claudeCommand string, permissionMode string, apiPort
 		db:              db,
 		claudeCommand:   claudeCommand,
 		codexCommand:    "codex",
+		cursorCommand:   "agent",
 		permissionMode:  permissionMode,
 		apiPort:         apiPort,
 		systemPrompt:    systemPrompt,
@@ -123,10 +126,23 @@ func (m *Manager) SetCodexCommand(cmd string) {
 	}
 }
 
+// SetCursorCommand sets the cursor agent command for the manager.
+func (m *Manager) SetCursorCommand(cmd string) {
+	if cmd != "" {
+		m.cursorCommand = cmd
+	}
+}
+
 // SetDefaultModels configures provider-specific default models.
 func (m *Manager) SetDefaultModels(claudeDefaultModel, codexDefaultModel string) {
 	m.claudeDefaultModel = claudeDefaultModel
 	m.codexDefaultModel = codexDefaultModel
+}
+
+// SetCursorDefaultModel configures the default model used for Cursor sessions
+// when no explicit --model is provided.
+func (m *Manager) SetCursorDefaultModel(model string) {
+	m.cursorDefaultModel = model
 }
 
 // SetOnNewLines sets a callback that fires when new stream lines arrive for any session.
@@ -144,6 +160,8 @@ func (m *Manager) getProvider(name ProviderName) Provider {
 	switch name {
 	case ProviderCodex:
 		return GetProvider(ProviderCodex, m.codexCommand, "")
+	case ProviderCursor:
+		return GetProvider(ProviderCursor, m.cursorCommand, "")
 	default:
 		return GetProvider(ProviderClaude, m.claudeCommand, m.permissionMode)
 	}
@@ -457,6 +475,8 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 			} else {
 				model = ReadCodexDefaultModel()
 			}
+		case ProviderCursor:
+			model = m.cursorDefaultModel
 		}
 	}
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -508,8 +508,10 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	}
 	streamOpts.APIPort = m.apiPort
 	var sp *HolderStreamProcess
-	if pn == ProviderCodex && prompt != "" {
-		// Codex: pass initial prompt as command-line argument (not stdin)
+	if (pn == ProviderCodex || pn == ProviderCursor) && prompt != "" {
+		// One-shot exec providers (Codex/Cursor): pass the initial prompt as a
+		// command-line positional argument rather than via stdin. The CLI exits
+		// after producing the response.
 		streamOpts.InitialPrompt = prompt
 		hsp, err := StartHolderStreamProcess(streamOpts, provider)
 		if err != nil {
@@ -1095,11 +1097,13 @@ func (m *Manager) wireSessionIDCallback(sessionID string, sp *HolderStreamProces
 		m.updateHolderPID(sid, newPID)
 	})
 	sp.SetOnProcessExit(func(sid string, exitErr error) {
-		// For Codex provider, exit code 0 is normal (exec finishes after each prompt).
-		// Keep the session running and the stream process in the map so that
-		// sendCodex can restart it with "codex exec resume" on the next message.
-		if sp.ProviderName() == ProviderCodex && exitErr == nil {
-			m.logger.Info("codex process exited normally (exit code 0), keeping session running for resume",
+		// For one-shot exec providers (Codex/Cursor), exit code 0 is normal —
+		// the CLI exits after each prompt. Keep the session running and the
+		// stream process in the map so the next message can re-spawn it with
+		// --resume + the new prompt as a positional arg.
+		if (sp.ProviderName() == ProviderCodex || sp.ProviderName() == ProviderCursor) && exitErr == nil {
+			m.logger.Info("one-shot provider exited normally (exit code 0), keeping session running for resume",
+				"provider", sp.ProviderName(),
 				"sessionId", sid,
 			)
 			return
@@ -1287,8 +1291,9 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 		canResume := s.ConversationStarted
 
 		effectiveSP := m.buildEffectiveSystemPrompt(s.SystemPrompt)
-		if s.Provider == ProviderCodex && cliSessionID != "" && canResume {
-			// For Codex, start resume directly with the prompt as a positional arg.
+		if (s.Provider == ProviderCodex || s.Provider == ProviderCursor) && cliSessionID != "" && canResume {
+			// For one-shot exec providers (Codex/Cursor), start resume directly
+			// with the prompt as a positional arg.
 			m.killStaleHolder(id)
 			hsp, err := StartHolderStreamProcess(StreamOpts{
 				SessionID:     s.ID,

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -10,6 +10,7 @@ type ProviderName string
 const (
 	ProviderClaude ProviderName = "claude"
 	ProviderCodex  ProviderName = "codex"
+	ProviderCursor ProviderName = "cursor"
 )
 
 // StreamOpts contains parameters for building a stream-mode command.
@@ -59,6 +60,8 @@ func GetProvider(name ProviderName, command string, permissionMode string) Provi
 	switch name {
 	case ProviderCodex:
 		return NewCodexProvider(command)
+	case ProviderCursor:
+		return NewCursorProvider(command)
 	default:
 		return NewClaudeProvider(command, permissionMode)
 	}

--- a/internal/session/provider_cursor.go
+++ b/internal/session/provider_cursor.go
@@ -1,0 +1,231 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// CursorProvider implements Provider for Cursor Agent CLI (`agent` / `cursor-agent`).
+//
+// The Cursor Agent CLI emits stream-json events that are largely Claude-compatible:
+//   - {"type":"system","subtype":"init","session_id":"<uuid>",...}
+//   - {"type":"assistant","message":{...}}
+//   - {"type":"user","message":{...}}
+//   - {"type":"tool_call","subtype":"started/completed",...}
+//   - {"type":"result","subtype":"success","is_error":false,"result":"..."}
+//
+// Phase 1 focuses on launching the CLI, parsing session_id/model, and passing
+// most events through unchanged. tool_call events are converted into the
+// Claude-compatible tool_use / tool_result shape so the frontend can render
+// them uniformly.
+type CursorProvider struct {
+	command string
+}
+
+// NewCursorProvider creates a CursorProvider with the given command.
+// If command is empty, defaults to "agent".
+func NewCursorProvider(command string) *CursorProvider {
+	if command == "" {
+		command = "agent"
+	}
+	return &CursorProvider{command: command}
+}
+
+func (p *CursorProvider) Name() ProviderName {
+	return ProviderCursor
+}
+
+func (p *CursorProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
+	args := []string{
+		"-p",
+		"--output-format", "stream-json",
+		"--trust",
+		"--force",
+	}
+
+	if opts.Resume && opts.CLISessionID != "" {
+		args = append(args, "--resume", opts.CLISessionID)
+	}
+
+	if opts.ProjectPath != "" {
+		args = append(args, "--workspace", opts.ProjectPath)
+	}
+
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+
+	// Build the prompt to pass as the last positional argument.
+	prompt := opts.InitialPrompt
+	if !(opts.Resume && opts.CLISessionID != "") {
+		if prompt == "" {
+			prompt = "Follow the instructions given via stdin"
+		}
+		if opts.SystemPrompt != "" {
+			prompt = opts.SystemPrompt + "\n\n" + prompt
+		}
+	}
+	if prompt != "" {
+		args = append(args, prompt)
+	}
+
+	cmd := exec.Command(p.command, args...)
+	cmd.Dir = opts.ProjectPath
+	// Filter out CLAUDECODE env var to avoid nested session detection.
+	for _, env := range os.Environ() {
+		if !strings.HasPrefix(env, "CLAUDECODE=") {
+			cmd.Env = append(cmd.Env, env)
+		}
+	}
+	return cmd
+}
+
+func (p *CursorProvider) ParseSessionID(jsonlLine []byte) (string, bool) {
+	// Cursor emits Claude-compatible system init events:
+	// {"type":"system","subtype":"init","session_id":"<uuid>",...}
+	var msg struct {
+		Type      string `json:"type"`
+		Subtype   string `json:"subtype"`
+		SessionID string `json:"session_id"`
+	}
+	if json.Unmarshal(jsonlLine, &msg) == nil && msg.Type == "system" && msg.SessionID != "" {
+		return msg.SessionID, true
+	}
+	return "", false
+}
+
+func (p *CursorProvider) ParseModel(jsonlLine []byte) (string, bool) {
+	// system init event: {"type":"system","subtype":"init","model":"sonnet-4",...}
+	var sysMsg struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+		Model   string `json:"model"`
+	}
+	if json.Unmarshal(jsonlLine, &sysMsg) == nil && sysMsg.Type == "system" && sysMsg.Subtype == "init" && sysMsg.Model != "" {
+		return sysMsg.Model, true
+	}
+
+	// assistant message: {"type":"assistant","message":{"model":"sonnet-4",...}}
+	var assistantMsg struct {
+		Type    string `json:"type"`
+		Message struct {
+			Model string `json:"model"`
+		} `json:"message"`
+	}
+	if json.Unmarshal(jsonlLine, &assistantMsg) == nil && assistantMsg.Type == "assistant" && assistantMsg.Message.Model != "" {
+		return assistantMsg.Message.Model, true
+	}
+
+	return "", false
+}
+
+func (p *CursorProvider) SetupMCP(sessionID string, port int) (string, error) {
+	// Phase 1: no MCP integration for Cursor.
+	return "", nil
+}
+
+func (p *CursorProvider) CleanupMCP(sessionID string) error {
+	// Phase 1: no per-session MCP config file to clean up.
+	return nil
+}
+
+func (p *CursorProvider) AppendOTelEnv(env []string, port int) []string {
+	// Cursor Agent CLI does not support OTel yet.
+	return env
+}
+
+// NormalizeStreamLine converts Cursor-specific events into Claude-compatible
+// stream-json format. Most event types are already Claude-compatible and pass
+// through unchanged.
+func (p *CursorProvider) NormalizeStreamLine(line []byte) []byte {
+	var envelope struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+	}
+	if json.Unmarshal(line, &envelope) != nil {
+		return line
+	}
+
+	switch envelope.Type {
+	case "tool_call":
+		return p.normalizeToolCall(line, envelope.Subtype)
+	default:
+		// system, assistant, user, result, etc. are Claude-compatible.
+		return line
+	}
+}
+
+func (p *CursorProvider) normalizeToolCall(line []byte, subtype string) []byte {
+	// Drop in-progress tool_call events; only emit something on completion.
+	if subtype != "completed" {
+		return nil
+	}
+
+	var msg struct {
+		Type    string          `json:"type"`
+		Subtype string          `json:"subtype"`
+		Name    string          `json:"name"`
+		Input   json.RawMessage `json:"input"`
+		Result  json.RawMessage `json:"result"`
+		Output  json.RawMessage `json:"output"`
+	}
+	if json.Unmarshal(line, &msg) != nil {
+		return line
+	}
+
+	name := msg.Name
+	if name == "" {
+		name = "tool"
+	}
+
+	type toolUseBlock struct {
+		Type  string          `json:"type"`
+		Name  string          `json:"name"`
+		Input json.RawMessage `json:"input,omitempty"`
+	}
+	type toolResultBlock struct {
+		Type    string `json:"type"`
+		Content string `json:"content"`
+	}
+
+	tu := toolUseBlock{Type: "tool_use", Name: name, Input: msg.Input}
+
+	// Prefer "result" then fall back to "output".
+	resultRaw := msg.Result
+	if len(resultRaw) == 0 {
+		resultRaw = msg.Output
+	}
+	resultStr := jsonRawToString(resultRaw)
+	tr := toolResultBlock{Type: "tool_result", Content: resultStr}
+
+	tuJSON, _ := json.Marshal(tu)
+	trJSON, _ := json.Marshal(tr)
+
+	wrapper := struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string            `json:"role"`
+			Content []json.RawMessage `json:"content"`
+		} `json:"message"`
+	}{Type: "assistant"}
+	wrapper.Message.Role = "assistant"
+	wrapper.Message.Content = []json.RawMessage{tuJSON, trJSON}
+	b, _ := json.Marshal(wrapper)
+	return b
+}
+
+// jsonRawToString converts a json.RawMessage to a string representation
+// suitable for tool_result.content. Strings are unquoted; other types are
+// serialized as compact JSON. Empty input returns "".
+func jsonRawToString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	return string(raw)
+}

--- a/internal/session/provider_cursor.go
+++ b/internal/session/provider_cursor.go
@@ -58,14 +58,14 @@ func (p *CursorProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
 	}
 
 	// Build the prompt to pass as the last positional argument.
+	// Unlike Codex, Cursor has no stdin code path, so we never inject a dummy
+	// placeholder for empty prompts — we simply omit the positional arg. The
+	// only callers that reach here with an empty prompt are the ones that
+	// resume an existing session (where the prompt is added by the resume
+	// branch above) or callers that genuinely don't want to send anything.
 	prompt := opts.InitialPrompt
-	if !(opts.Resume && opts.CLISessionID != "") {
-		if prompt == "" {
-			prompt = "Follow the instructions given via stdin"
-		}
-		if opts.SystemPrompt != "" {
-			prompt = opts.SystemPrompt + "\n\n" + prompt
-		}
+	if !(opts.Resume && opts.CLISessionID != "") && opts.SystemPrompt != "" && prompt != "" {
+		prompt = opts.SystemPrompt + "\n\n" + prompt
 	}
 	if prompt != "" {
 		args = append(args, prompt)

--- a/internal/session/provider_cursor_test.go
+++ b/internal/session/provider_cursor_test.go
@@ -149,6 +149,29 @@ func TestCursorProvider_BuildStreamCommand_WithSystemPrompt(t *testing.T) {
 	}
 }
 
+func TestCursorProvider_BuildStreamCommand_EmptyPromptOmitsPositional(t *testing.T) {
+	p := NewCursorProvider("agent")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:   "sess-1",
+		ProjectPath: "/tmp/project",
+	})
+
+	args := cmd.Args
+	// No positional prompt should be appended when InitialPrompt is empty
+	// (Cursor has no stdin path, so a placeholder would only confuse users).
+	for _, a := range args {
+		if strings.Contains(a, "Follow the instructions given via stdin") {
+			t.Errorf("did not expect stdin placeholder in args, got: %v", args)
+		}
+	}
+	// Last arg should be the --workspace value (or some flag-style arg),
+	// not a positional prompt placeholder.
+	lastArg := args[len(args)-1]
+	if !strings.HasPrefix(lastArg, "/") && !strings.HasPrefix(lastArg, "-") {
+		t.Errorf("expected last arg to be a flag-style or path value when prompt is empty, got: %q", lastArg)
+	}
+}
+
 func TestCursorProvider_BuildStreamCommand_EnvFiltersCLAUDECODE(t *testing.T) {
 	p := NewCursorProvider("agent")
 	cmd := p.BuildStreamCommand(StreamOpts{

--- a/internal/session/provider_cursor_test.go
+++ b/internal/session/provider_cursor_test.go
@@ -1,0 +1,361 @@
+package session
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCursorProvider_Name(t *testing.T) {
+	p := NewCursorProvider("")
+	if p.Name() != ProviderCursor {
+		t.Errorf("expected %q, got %q", ProviderCursor, p.Name())
+	}
+}
+
+func TestCursorProvider_DefaultCommand(t *testing.T) {
+	p := NewCursorProvider("")
+	if p.command != "agent" {
+		t.Errorf("expected default command %q, got %q", "agent", p.command)
+	}
+}
+
+func TestCursorProvider_CustomCommand(t *testing.T) {
+	p := NewCursorProvider("cursor-agent")
+	if p.command != "cursor-agent" {
+		t.Errorf("expected command %q, got %q", "cursor-agent", p.command)
+	}
+}
+
+func TestCursorProvider_BuildStreamCommand_NewSession(t *testing.T) {
+	p := NewCursorProvider("agent")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:   "sess-1",
+		ProjectPath: "/tmp/project",
+	})
+
+	args := cmd.Args
+	if args[0] != "agent" {
+		t.Errorf("expected command %q, got %q", "agent", args[0])
+	}
+	if cmd.Dir != "/tmp/project" {
+		t.Errorf("expected dir %q, got %q", "/tmp/project", cmd.Dir)
+	}
+
+	for _, expected := range []string{"-p", "--output-format", "stream-json", "--trust", "--force", "--workspace", "/tmp/project"} {
+		if !containsArg(args[1:], expected) {
+			t.Errorf("expected args to contain %q, got: %v", expected, args[1:])
+		}
+	}
+
+	// New session (no resume) should not include --resume.
+	for _, a := range args {
+		if a == "--resume" {
+			t.Errorf("new session should not contain --resume, got: %v", args)
+		}
+	}
+}
+
+func TestCursorProvider_BuildStreamCommand_Resume(t *testing.T) {
+	p := NewCursorProvider("agent")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:    "sess-1",
+		ProjectPath:  "/tmp/project",
+		Resume:       true,
+		CLISessionID: "chat-abc123",
+	})
+
+	args := cmd.Args
+	if !containsArg(args, "--resume") {
+		t.Errorf("expected --resume in args, got: %v", args)
+	}
+	if !containsArg(args, "chat-abc123") {
+		t.Errorf("expected session ID 'chat-abc123' in args, got: %v", args)
+	}
+	if !containsArg(args, "--workspace") {
+		t.Errorf("expected --workspace in args, got: %v", args)
+	}
+}
+
+func TestCursorProvider_BuildStreamCommand_ResumeWithFollowup(t *testing.T) {
+	p := NewCursorProvider("agent")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:     "sess-1",
+		ProjectPath:   "/tmp/project",
+		Resume:        true,
+		CLISessionID:  "chat-abc",
+		InitialPrompt: "follow up message",
+	})
+
+	args := cmd.Args
+	lastArg := args[len(args)-1]
+	if lastArg != "follow up message" {
+		t.Errorf("expected last arg to be followup message %q, got %q", "follow up message", lastArg)
+	}
+}
+
+func TestCursorProvider_BuildStreamCommand_WithModel(t *testing.T) {
+	p := NewCursorProvider("agent")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:   "sess-1",
+		ProjectPath: "/tmp/project",
+		Model:       "sonnet-4",
+	})
+
+	args := cmd.Args
+	foundModel := false
+	for i, a := range args {
+		if a == "--model" && i+1 < len(args) && args[i+1] == "sonnet-4" {
+			foundModel = true
+			break
+		}
+	}
+	if !foundModel {
+		t.Errorf("expected --model sonnet-4 in args, got: %v", args)
+	}
+}
+
+func TestCursorProvider_BuildStreamCommand_WithInitialPrompt(t *testing.T) {
+	p := NewCursorProvider("agent")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:     "sess-1",
+		ProjectPath:   "/tmp/project",
+		InitialPrompt: "hello world",
+	})
+
+	args := cmd.Args
+	lastArg := args[len(args)-1]
+	if lastArg != "hello world" {
+		t.Errorf("expected last arg %q, got %q", "hello world", lastArg)
+	}
+}
+
+func TestCursorProvider_BuildStreamCommand_WithSystemPrompt(t *testing.T) {
+	p := NewCursorProvider("agent")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:     "sess-1",
+		ProjectPath:   "/tmp/project",
+		SystemPrompt:  "be helpful",
+		InitialPrompt: "do a thing",
+	})
+
+	args := cmd.Args
+	lastArg := args[len(args)-1]
+	if !strings.Contains(lastArg, "be helpful") {
+		t.Errorf("expected system prompt in prompt arg, got: %q", lastArg)
+	}
+	if !strings.Contains(lastArg, "do a thing") {
+		t.Errorf("expected initial prompt in prompt arg, got: %q", lastArg)
+	}
+}
+
+func TestCursorProvider_BuildStreamCommand_EnvFiltersCLAUDECODE(t *testing.T) {
+	p := NewCursorProvider("agent")
+	cmd := p.BuildStreamCommand(StreamOpts{
+		SessionID:   "sess-1",
+		ProjectPath: "/tmp",
+	})
+
+	for _, env := range cmd.Env {
+		if strings.HasPrefix(env, "CLAUDECODE=") {
+			t.Errorf("CLAUDECODE env var should be filtered out, found: %s", env)
+		}
+	}
+}
+
+func TestCursorProvider_ParseSessionID(t *testing.T) {
+	p := NewCursorProvider("")
+
+	tests := []struct {
+		name   string
+		input  string
+		wantID string
+		wantOK bool
+	}{
+		{
+			name:   "system init event",
+			input:  `{"type":"system","subtype":"init","session_id":"abc-123","cwd":"/tmp","model":"sonnet-4"}`,
+			wantID: "abc-123",
+			wantOK: true,
+		},
+		{
+			name:   "system event without session_id",
+			input:  `{"type":"system","subtype":"init"}`,
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "non-system event",
+			input:  `{"type":"assistant","message":{}}`,
+			wantID: "",
+			wantOK: false,
+		},
+		{
+			name:   "invalid JSON",
+			input:  `not json`,
+			wantID: "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok := p.ParseSessionID([]byte(tt.input))
+			if id != tt.wantID || ok != tt.wantOK {
+				t.Errorf("ParseSessionID(%q) = (%q, %v), want (%q, %v)",
+					tt.input, id, ok, tt.wantID, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestCursorProvider_ParseModel(t *testing.T) {
+	p := NewCursorProvider("")
+
+	tests := []struct {
+		name      string
+		input     string
+		wantModel string
+		wantOK    bool
+	}{
+		{
+			name:      "system init with model",
+			input:     `{"type":"system","subtype":"init","session_id":"s","model":"sonnet-4"}`,
+			wantModel: "sonnet-4",
+			wantOK:    true,
+		},
+		{
+			name:      "assistant with model",
+			input:     `{"type":"assistant","message":{"model":"sonnet-4","role":"assistant"}}`,
+			wantModel: "sonnet-4",
+			wantOK:    true,
+		},
+		{
+			name:      "system without model",
+			input:     `{"type":"system","subtype":"init","session_id":"s"}`,
+			wantModel: "",
+			wantOK:    false,
+		},
+		{
+			name:      "invalid JSON",
+			input:     `not json`,
+			wantModel: "",
+			wantOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model, ok := p.ParseModel([]byte(tt.input))
+			if model != tt.wantModel || ok != tt.wantOK {
+				t.Errorf("ParseModel(%q) = (%q, %v), want (%q, %v)",
+					tt.input, model, ok, tt.wantModel, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestCursorProvider_SetupMCP_Noop(t *testing.T) {
+	p := NewCursorProvider("agent")
+	path, err := p.SetupMCP("sess-test", 4321)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path, got %q", path)
+	}
+}
+
+func TestCursorProvider_CleanupMCP_Noop(t *testing.T) {
+	p := NewCursorProvider("agent")
+	if err := p.CleanupMCP("sess-test"); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func TestCursorProvider_AppendOTelEnv_Noop(t *testing.T) {
+	p := NewCursorProvider("agent")
+	initial := []string{"FOO=bar"}
+	got := p.AppendOTelEnv(initial, 4321)
+	if len(got) != len(initial) {
+		t.Errorf("expected env to be unchanged, got: %v", got)
+	}
+}
+
+func TestCursorProvider_NormalizeStreamLine(t *testing.T) {
+	p := NewCursorProvider("")
+
+	tests := []struct {
+		name     string
+		input    string
+		wantNil  bool
+		wantJSON string // empty means keep original
+	}{
+		{
+			name:  "system init passes through",
+			input: `{"type":"system","subtype":"init","session_id":"abc","model":"sonnet-4"}`,
+		},
+		{
+			name:  "assistant passes through",
+			input: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}`,
+		},
+		{
+			name:  "user passes through",
+			input: `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}`,
+		},
+		{
+			name:  "result passes through",
+			input: `{"type":"result","subtype":"success","is_error":false,"result":"done","session_id":"abc"}`,
+		},
+		{
+			name:    "tool_call started is dropped",
+			input:   `{"type":"tool_call","subtype":"started","name":"bash","input":{"cmd":"ls"}}`,
+			wantNil: true,
+		},
+		{
+			name:     "tool_call completed becomes assistant tool_use+tool_result",
+			input:    `{"type":"tool_call","subtype":"completed","name":"bash","input":{"command":"ls"},"result":"file1\nfile2"}`,
+			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"bash","input":{"command":"ls"}},{"type":"tool_result","content":"file1\nfile2"}]}}`,
+		},
+		{
+			name:  "invalid JSON passes through",
+			input: `not json at all`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.NormalizeStreamLine([]byte(tt.input))
+
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil, got %s", string(result))
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+
+			if tt.wantJSON != "" {
+				var got, want interface{}
+				if err := json.Unmarshal(result, &got); err != nil {
+					t.Fatalf("failed to parse result JSON: %v\nresult: %s", err, string(result))
+				}
+				if err := json.Unmarshal([]byte(tt.wantJSON), &want); err != nil {
+					t.Fatalf("failed to parse expected JSON: %v", err)
+				}
+				gotBytes, _ := json.Marshal(got)
+				wantBytes, _ := json.Marshal(want)
+				if string(gotBytes) != string(wantBytes) {
+					t.Errorf("JSON mismatch\ngot:  %s\nwant: %s", string(gotBytes), string(wantBytes))
+				}
+			} else {
+				if string(result) != tt.input {
+					t.Errorf("expected line to pass through unchanged\ngot:  %s\nwant: %s", string(result), tt.input)
+				}
+			}
+		})
+	}
+}

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -69,6 +69,8 @@ type SessionService interface {
 	StopAllStreamProcesses()
 	// SetCodexCommand sets the codex command for the manager.
 	SetCodexCommand(cmd string)
+	// SetCursorCommand sets the cursor agent command for the manager.
+	SetCursorCommand(cmd string)
 
 	// ListRecentProjects returns recently used project paths.
 	ListRecentProjects(limit int) ([]RecentProject, error)

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -71,6 +71,9 @@ type SessionService interface {
 	SetCodexCommand(cmd string)
 	// SetCursorCommand sets the cursor agent command for the manager.
 	SetCursorCommand(cmd string)
+	// SetCursorDefaultModel configures the default model used for Cursor sessions
+	// when no explicit model is provided.
+	SetCursorDefaultModel(model string)
 
 	// ListRecentProjects returns recently used project paths.
 	ListRecentProjects(limit int) ([]RecentProject, error)


### PR DESCRIPTION
## Summary

agmux に Cursor Agent CLI (`agent` / `cursor-agent`) を新しい Provider として追加する Phase 1 実装。

最低限の動作 (CLI 起動 / session_id・model パース / Claude 互換イベントの正規化) に絞り、MCP/OTel などの統合は後続フェーズで対応する。

### 実装内容

- **`internal/session/provider_cursor.go`**: `CursorProvider` 新規追加
  - `BuildStreamCommand`: `agent -p --output-format stream-json --trust --force --workspace <path> [--resume <id>] [--model X] [prompt]`
  - `ParseSessionID` / `ParseModel`: Claude 互換 `{"type":"system","subtype":"init","session_id":"...","model":"..."}` を解釈
  - `NormalizeStreamLine`: `system` / `assistant` / `user` / `result` はそのまま透過。`tool_call`(completed) のみ Claude 互換の `tool_use` + `tool_result` に変換
  - `SetupMCP` / `CleanupMCP` / `AppendOTelEnv` は no-op
- **`internal/session/provider.go`**: `ProviderCursor` 定数 + `GetProvider` 分岐追加
- **`internal/config/config.go`**: `SessionConfig` に `CursorCommand` (default `"agent"`) / `CursorDefaultModel` を追加
- **`internal/session/manager.go`** / **`internal/session/service.go`**: `SetCursorCommand` / `SetCursorDefaultModel` を追加、`getProvider` / モデル解決に cursor 分岐
- **`cmd/agmux/main.go`**: 起動時に cursor 関連設定を Manager に注入。`--provider` のヘルプも更新
- **`internal/server/server.go`**: `configJSON` に `cursorCommand` / `cursorDefaultModel` を追加 (フロントへ往復)
- **frontend (`CreateSession.tsx` / `ConfigPage.tsx` / `api/client.ts`)**: Provider セレクタに "Cursor" 追加、Config ページに Cursor Command / Cursor Default Model 入力欄を追加
- **`internal/session/provider_cursor_test.go`**: `BuildStreamCommand` (new / resume / model / system prompt / env filter), `ParseSessionID`, `ParseModel`, `NormalizeStreamLine` (tool_call 変換含む), MCP/OTel no-op を網羅

### Phase 2 (将来) 候補

- 実機での動作確認 (issue 完了条件では Phase 2 扱い)
- MCP 統合 (cursor agent が MCP server 設定の渡し方をサポートし次第)
- OTel 統合
- 外部プロセス検出 (`internal/session/external.go`) への cursor agent 対応
- `tool_call` 系のさらに細かい正規化 (現在は最小実装)
- Cursor の models 一覧取得 API 対応 (現状は Default Model を Config から読むのみ)

Closes #639

## Test plan

- [x] `make build` 通過 (frontend + go ビルド)
- [x] `go test ./...` 全パス
- [x] frontend ビルド通過 (tsc + vite build)
- [ ] (Phase 2) 実機で `agent login` 済み環境にて session 作成 → メッセージ送信 → resume の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)