### PR TITLE
fix: cursor provider の thinking / tool_call を Claude 互換に正規化

### DIFF
--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -248,6 +248,13 @@ export type DisplayGroup =
   | { role: "user" | "assistant"; items: StreamDisplayItem[] }
   | { role: "system"; items: StreamDisplayItem[] };
 
+// Providers that emit tool_use and tool_result co-located in the same assistant
+// message content array (instead of the Claude pattern where tool_result lives
+// in a follow-up user entry, looked up by tool_use_id).
+function isProviderCoLocatedTools(provider?: string): boolean {
+  return provider === "codex" || provider === "cursor";
+}
+
 // Merge assistant/user entries into display items, pairing tool_use with tool_result by id
 // partialText: incremental text from stream_event deltas (shown as "typing" in the last assistant group)
 export function mergeStreamEntries(entries: StreamEntry[], partialText?: string, provider?: string): DisplayGroup[] {
@@ -444,8 +451,8 @@ export function mergeStreamEntries(entries: StreamEntry[], partialText?: string,
           let result: string | undefined;
           let resultImages: Array<{ mediaType: string; data: string }> | undefined;
 
-          if (provider === "codex") {
-            // Codex: tool_result is in the same assistant content array, directly after tool_use
+          if (isProviderCoLocatedTools(provider)) {
+            // Codex/Cursor: tool_result is in the same assistant content array, directly after tool_use
             if (bi + 1 < blocks.length && blocks[bi + 1].type === "tool_result") {
               const nextBlock = blocks[bi + 1];
               if (typeof nextBlock.content === "string") {

--- a/internal/session/provider_cursor.go
+++ b/internal/session/provider_cursor.go
@@ -14,11 +14,12 @@ import (
 //   - {"type":"assistant","message":{...}}
 //   - {"type":"user","message":{...}}
 //   - {"type":"tool_call","subtype":"started/completed",...}
+//   - {"type":"thinking","subtype":"delta/completed",...}
 //   - {"type":"result","subtype":"success","is_error":false,"result":"..."}
 //
 // Phase 1 focuses on launching the CLI, parsing session_id/model, and passing
-// most events through unchanged. tool_call events are converted into the
-// Claude-compatible tool_use / tool_result shape so the frontend can render
+// most events through unchanged. tool_call and thinking events are converted
+// into the Claude-compatible assistant message shape so the frontend can render
 // them uniformly.
 type CursorProvider struct {
 	command string
@@ -157,10 +158,41 @@ func (p *CursorProvider) NormalizeStreamLine(line []byte) []byte {
 	switch envelope.Type {
 	case "tool_call":
 		return p.normalizeToolCall(line, envelope.Subtype)
+	case "thinking":
+		return p.normalizeThinking(line, envelope.Subtype)
 	default:
 		// system, assistant, user, result, etc. are Claude-compatible.
 		return line
 	}
+}
+
+// cursorToolKindToName maps the Cursor tool_call kind key (e.g. "readToolCall")
+// to a human-readable Claude-style tool name (e.g. "Read").
+func cursorToolKindToName(kind string) string {
+	switch kind {
+	case "readToolCall":
+		return "Read"
+	case "shellToolCall":
+		return "Bash"
+	case "editToolCall":
+		return "Edit"
+	case "globToolCall":
+		return "Glob"
+	case "grepToolCall":
+		return "Grep"
+	case "awaitToolCall":
+		return "Await"
+	case "listDirToolCall":
+		return "ListDir"
+	case "todoToolCall":
+		return "Todo"
+	}
+	// Fallback: strip "ToolCall" suffix and Title-case the first rune.
+	name := strings.TrimSuffix(kind, "ToolCall")
+	if name == "" {
+		return "tool"
+	}
+	return strings.ToUpper(name[:1]) + name[1:]
 }
 
 func (p *CursorProvider) normalizeToolCall(line []byte, subtype string) []byte {
@@ -169,42 +201,64 @@ func (p *CursorProvider) normalizeToolCall(line []byte, subtype string) []byte {
 		return nil
 	}
 
+	// Cursor format:
+	//   {"type":"tool_call","subtype":"completed",
+	//    "call_id":"tool_xxx",
+	//    "tool_call":{"<kind>ToolCall":{"args":{...},"result":{...}}},
+	//    ...}
 	var msg struct {
-		Type    string          `json:"type"`
-		Subtype string          `json:"subtype"`
-		Name    string          `json:"name"`
-		Input   json.RawMessage `json:"input"`
-		Result  json.RawMessage `json:"result"`
-		Output  json.RawMessage `json:"output"`
+		Type     string                     `json:"type"`
+		Subtype  string                     `json:"subtype"`
+		CallID   string                     `json:"call_id"`
+		ToolCall map[string]json.RawMessage `json:"tool_call"`
 	}
 	if json.Unmarshal(line, &msg) != nil {
 		return line
 	}
 
-	name := msg.Name
-	if name == "" {
-		name = "tool"
+	// Find the first kind key (there should be exactly one).
+	var kind string
+	var inner json.RawMessage
+	for k, v := range msg.ToolCall {
+		kind = k
+		inner = v
+		break
 	}
+	if kind == "" {
+		// Unknown shape — fall back to pass-through to avoid losing data.
+		return line
+	}
+
+	var innerObj struct {
+		Args   json.RawMessage `json:"args"`
+		Result json.RawMessage `json:"result"`
+	}
+	_ = json.Unmarshal(inner, &innerObj)
+
+	name := cursorToolKindToName(kind)
 
 	type toolUseBlock struct {
 		Type  string          `json:"type"`
+		ID    string          `json:"id,omitempty"`
 		Name  string          `json:"name"`
 		Input json.RawMessage `json:"input,omitempty"`
 	}
 	type toolResultBlock struct {
-		Type    string `json:"type"`
-		Content string `json:"content"`
+		Type      string `json:"type"`
+		ToolUseID string `json:"tool_use_id,omitempty"`
+		Content   string `json:"content"`
 	}
 
-	tu := toolUseBlock{Type: "tool_use", Name: name, Input: msg.Input}
-
-	// Prefer "result" then fall back to "output".
-	resultRaw := msg.Result
-	if len(resultRaw) == 0 {
-		resultRaw = msg.Output
+	args := innerObj.Args
+	if len(args) == 0 {
+		// Always emit an object so the frontend can render an empty input.
+		args = json.RawMessage(`{}`)
 	}
-	resultStr := jsonRawToString(resultRaw)
-	tr := toolResultBlock{Type: "tool_result", Content: resultStr}
+
+	tu := toolUseBlock{Type: "tool_use", ID: msg.CallID, Name: name, Input: args}
+
+	resultStr := cursorExtractToolResult(innerObj.Result)
+	tr := toolResultBlock{Type: "tool_result", ToolUseID: msg.CallID, Content: resultStr}
 
 	tuJSON, _ := json.Marshal(tu)
 	trJSON, _ := json.Marshal(tr)
@@ -218,6 +272,82 @@ func (p *CursorProvider) normalizeToolCall(line []byte, subtype string) []byte {
 	}{Type: "assistant"}
 	wrapper.Message.Role = "assistant"
 	wrapper.Message.Content = []json.RawMessage{tuJSON, trJSON}
+	b, _ := json.Marshal(wrapper)
+	return b
+}
+
+// cursorExtractToolResult unwraps the Cursor result envelope. Cursor results
+// look like:
+//
+//	{"success": {...payload...}}
+//	{"failure": {...payload...}}
+//	{"error":   {...payload...} | "string"}
+//
+// It returns the inner payload serialized for display in tool_result.content.
+// Strings are returned unquoted; other shapes are returned as compact JSON.
+func cursorExtractToolResult(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return jsonRawToString(raw)
+	}
+	for _, key := range []string{"success", "failure", "error"} {
+		if inner, ok := obj[key]; ok && len(inner) > 0 {
+			return jsonRawToString(inner)
+		}
+	}
+	return jsonRawToString(raw)
+}
+
+// normalizeThinking converts Cursor's incremental thinking events into a
+// Claude-compatible assistant message with a thinking block. Cursor emits:
+//
+//	{"type":"thinking","subtype":"delta","text":"...",...}
+//	{"type":"thinking","subtype":"completed",...}
+//
+// Each delta is converted into an assistant message of the form
+//
+//	{"type":"assistant","message":{"role":"assistant",
+//	  "content":[{"type":"thinking","thinking":"<text>"}]}}
+//
+// so the frontend's StreamDisplayItem("thinking") rendering picks it up.
+// The "completed" event is dropped — it carries no new text.
+func (p *CursorProvider) normalizeThinking(line []byte, subtype string) []byte {
+	if subtype != "delta" {
+		// "completed" (and any unknown subtype) carries no payload.
+		return nil
+	}
+
+	var msg struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+		Text    string `json:"text"`
+	}
+	if json.Unmarshal(line, &msg) != nil {
+		return line
+	}
+	if msg.Text == "" {
+		return nil
+	}
+
+	type thinkingBlock struct {
+		Type     string `json:"type"`
+		Thinking string `json:"thinking"`
+	}
+	tb := thinkingBlock{Type: "thinking", Thinking: msg.Text}
+	tbJSON, _ := json.Marshal(tb)
+
+	wrapper := struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string            `json:"role"`
+			Content []json.RawMessage `json:"content"`
+		} `json:"message"`
+	}{Type: "assistant"}
+	wrapper.Message.Role = "assistant"
+	wrapper.Message.Content = []json.RawMessage{tbJSON}
 	b, _ := json.Marshal(wrapper)
 	return b
 }

--- a/internal/session/provider_cursor.go
+++ b/internal/session/provider_cursor.go
@@ -4,8 +4,23 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 )
+
+// knownCursorToolKinds lists the tool kind keys that may appear in
+// {"tool_call":{"<kind>":{...}}}. They are tried in order so that the chosen
+// kind is deterministic even though Go map iteration is not.
+var knownCursorToolKinds = []string{
+	"readToolCall",
+	"shellToolCall",
+	"editToolCall",
+	"globToolCall",
+	"grepToolCall",
+	"awaitToolCall",
+	"listDirToolCall",
+	"todoToolCall",
+}
 
 // CursorProvider implements Provider for Cursor Agent CLI (`agent` / `cursor-agent`).
 //
@@ -216,13 +231,29 @@ func (p *CursorProvider) normalizeToolCall(line []byte, subtype string) []byte {
 		return line
 	}
 
-	// Find the first kind key (there should be exactly one).
+	// Find the kind key. Map iteration order in Go is non-deterministic, so we
+	// first try known kinds in a fixed order, then fall back to any remaining
+	// key (using sorted order for determinism) for forward-compatibility with
+	// new Cursor tool kinds.
 	var kind string
 	var inner json.RawMessage
-	for k, v := range msg.ToolCall {
-		kind = k
-		inner = v
-		break
+	for _, known := range knownCursorToolKinds {
+		if v, ok := msg.ToolCall[known]; ok {
+			kind = known
+			inner = v
+			break
+		}
+	}
+	if kind == "" {
+		keys := make([]string, 0, len(msg.ToolCall))
+		for k := range msg.ToolCall {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		if len(keys) > 0 {
+			kind = keys[0]
+			inner = msg.ToolCall[kind]
+		}
 	}
 	if kind == "" {
 		// Unknown shape — fall back to pass-through to avoid losing data.

--- a/internal/session/provider_cursor_test.go
+++ b/internal/session/provider_cursor_test.go
@@ -312,6 +312,120 @@ func TestCursorProvider_AppendOTelEnv_Noop(t *testing.T) {
 	}
 }
 
+func TestCursorProvider_cursorToolKindToName(t *testing.T) {
+	tests := map[string]string{
+		"readToolCall":    "Read",
+		"shellToolCall":   "Bash",
+		"editToolCall":    "Edit",
+		"globToolCall":    "Glob",
+		"grepToolCall":    "Grep",
+		"awaitToolCall":   "Await",
+		"listDirToolCall": "ListDir",
+		"todoToolCall":    "Todo",
+		"unknownToolCall": "Unknown",
+		"":                "tool",
+	}
+	for in, want := range tests {
+		if got := cursorToolKindToName(in); got != want {
+			t.Errorf("cursorToolKindToName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCursorProvider_NormalizeToolCall_MoreKinds(t *testing.T) {
+	p := NewCursorProvider("")
+
+	type extracted struct {
+		Name      string
+		ID        string
+		ToolUseID string
+		HasInput  bool
+		HasResult bool
+	}
+
+	parse := func(t *testing.T, raw []byte) extracted {
+		t.Helper()
+		var env struct {
+			Message struct {
+				Content []map[string]interface{} `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(raw, &env); err != nil {
+			t.Fatalf("failed to parse: %v\n%s", err, string(raw))
+		}
+		if len(env.Message.Content) != 2 {
+			t.Fatalf("expected 2 content blocks, got %d\n%s", len(env.Message.Content), string(raw))
+		}
+		e := extracted{}
+		for _, b := range env.Message.Content {
+			switch b["type"] {
+			case "tool_use":
+				if v, ok := b["name"].(string); ok {
+					e.Name = v
+				}
+				if v, ok := b["id"].(string); ok {
+					e.ID = v
+				}
+				if _, ok := b["input"]; ok {
+					e.HasInput = true
+				}
+			case "tool_result":
+				if v, ok := b["tool_use_id"].(string); ok {
+					e.ToolUseID = v
+				}
+				if v, ok := b["content"].(string); ok && v != "" {
+					e.HasResult = true
+				}
+			}
+		}
+		return e
+	}
+
+	cases := []struct {
+		name     string
+		input    string
+		wantName string
+	}{
+		{
+			name:     "edit",
+			input:    `{"type":"tool_call","subtype":"completed","call_id":"tool_e1","tool_call":{"editToolCall":{"args":{"path":"a.go","streamContent":"x"},"result":{"success":{"path":"a.go","linesAdded":1,"linesRemoved":0,"diffString":"--- a/a.go"}}}}}`,
+			wantName: "Edit",
+		},
+		{
+			name:     "glob",
+			input:    `{"type":"tool_call","subtype":"completed","call_id":"tool_g1","tool_call":{"globToolCall":{"args":{"globPattern":"**/*.go"},"result":{"success":{"files":["a.go","b.go"],"totalFiles":2}}}}}`,
+			wantName: "Glob",
+		},
+		{
+			name:     "grep",
+			input:    `{"type":"tool_call","subtype":"completed","call_id":"tool_p1","tool_call":{"grepToolCall":{"args":{"pattern":"foo"},"result":{"success":{"pattern":"foo","workspaceResults":[]}}}}}`,
+			wantName: "Grep",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := p.NormalizeStreamLine([]byte(tc.input))
+			if out == nil {
+				t.Fatalf("expected normalized output, got nil")
+			}
+			got := parse(t, out)
+			if got.Name != tc.wantName {
+				t.Errorf("name = %q, want %q", got.Name, tc.wantName)
+			}
+			if got.ID == "" || got.ToolUseID == "" || got.ID != got.ToolUseID {
+				t.Errorf("expected matching id/tool_use_id, got id=%q tool_use_id=%q", got.ID, got.ToolUseID)
+			}
+			if !got.HasInput {
+				t.Errorf("expected input present")
+			}
+			if !got.HasResult {
+				t.Errorf("expected result content present")
+			}
+		})
+	}
+}
+
 func TestCursorProvider_NormalizeStreamLine(t *testing.T) {
 	p := NewCursorProvider("")
 
@@ -339,13 +453,43 @@ func TestCursorProvider_NormalizeStreamLine(t *testing.T) {
 		},
 		{
 			name:    "tool_call started is dropped",
-			input:   `{"type":"tool_call","subtype":"started","name":"bash","input":{"cmd":"ls"}}`,
+			input:   `{"type":"tool_call","subtype":"started","call_id":"tool_x","tool_call":{"readToolCall":{"args":{"path":"/a"}}}}`,
 			wantNil: true,
 		},
 		{
-			name:     "tool_call completed becomes assistant tool_use+tool_result",
-			input:    `{"type":"tool_call","subtype":"completed","name":"bash","input":{"command":"ls"},"result":"file1\nfile2"}`,
-			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"bash","input":{"command":"ls"}},{"type":"tool_result","content":"file1\nfile2"}]}}`,
+			name:     "tool_call completed (read) becomes assistant tool_use+tool_result",
+			input:    `{"type":"tool_call","subtype":"completed","call_id":"tool_r1","tool_call":{"readToolCall":{"args":{"path":"/x.md"},"result":{"success":{"content":"hello","path":"/x.md","fileSize":5}}}}}`,
+			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tool_r1","name":"Read","input":{"path":"/x.md"}},{"type":"tool_result","tool_use_id":"tool_r1","content":"{\"content\":\"hello\",\"path\":\"/x.md\",\"fileSize\":5}"}]}}`,
+		},
+		{
+			name:     "tool_call completed (shell) maps to Bash",
+			input:    `{"type":"tool_call","subtype":"completed","call_id":"tool_s1","tool_call":{"shellToolCall":{"args":{"command":"ls"},"result":{"success":{"command":"ls","exitCode":0,"stdout":"a\nb","stderr":""}}}}}`,
+			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tool_s1","name":"Bash","input":{"command":"ls"}},{"type":"tool_result","tool_use_id":"tool_s1","content":"{\"command\":\"ls\",\"exitCode\":0,\"stdout\":\"a\\nb\",\"stderr\":\"\"}"}]}}`,
+		},
+		{
+			name:     "tool_call completed with failure result",
+			input:    `{"type":"tool_call","subtype":"completed","call_id":"tool_s2","tool_call":{"shellToolCall":{"args":{"command":"bad"},"result":{"failure":{"command":"bad","exitCode":127,"stderr":"not found"}}}}}`,
+			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tool_s2","name":"Bash","input":{"command":"bad"}},{"type":"tool_result","tool_use_id":"tool_s2","content":"{\"command\":\"bad\",\"exitCode\":127,\"stderr\":\"not found\"}"}]}}`,
+		},
+		{
+			name:     "tool_call completed with error result",
+			input:    `{"type":"tool_call","subtype":"completed","call_id":"tool_a1","tool_call":{"awaitToolCall":{"args":{},"result":{"error":{"error":"No shell found for id 45563"}}}}}`,
+			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tool_a1","name":"Await","input":{}},{"type":"tool_result","tool_use_id":"tool_a1","content":"{\"error\":\"No shell found for id 45563\"}"}]}}`,
+		},
+		{
+			name:     "thinking delta becomes assistant thinking block",
+			input:    `{"type":"thinking","subtype":"delta","text":"Let me think","session_id":"abc","timestamp_ms":1}`,
+			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"Let me think"}]}}`,
+		},
+		{
+			name:    "thinking completed is dropped",
+			input:   `{"type":"thinking","subtype":"completed","session_id":"abc","timestamp_ms":1}`,
+			wantNil: true,
+		},
+		{
+			name:    "thinking delta with empty text is dropped",
+			input:   `{"type":"thinking","subtype":"delta","text":"","session_id":"abc","timestamp_ms":1}`,
+			wantNil: true,
 		},
 		{
 			name:  "invalid JSON passes through",


### PR DESCRIPTION
## Summary

Cursor Agent CLI が emit する以下のイベントが UI に生の `type` 名のまま表示されてしまっていた問題を修正。

- `thinking` (subtype=`delta`/`completed`): 元々 `default` ブランチに落ちて素通しだったため UI が解釈できなかった
- `tool_call` (subtype=`started`/`completed`): 期待していた flat な `{name,input,result}` 形式と Cursor 実フォーマット (`tool_call.<kind>ToolCall.{args, result}` ネスト) が合っておらず、`name`/`input`/`result` が空のまま流れていた

## 変換内容

| 入力 | 出力 |
|---|---|
| `thinking/delta` | `{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":text}]}}` |
| `thinking/completed` | drop |
| `tool_call/started` | drop (既存動作維持) |
| `tool_call/completed` | `assistant` メッセージ内に `tool_use` + `tool_result` を emit |

`tool_use.id` と `tool_result.tool_use_id` には `call_id` を流用してペアリング可能にしている。
ツール名は kind から推定 (`readToolCall`→`Read`, `shellToolCall`→`Bash`, `editToolCall`→`Edit`, `globToolCall`→`Glob`, `grepToolCall`→`Grep`, `awaitToolCall`→`Await`, 他)。
`result.success` / `result.failure` / `result.error` の最初に見つかったキーを unwrap して `tool_result.content` に詰める。

## 動作確認

セッション `7QiDb` の `~/.agmux/streams/7QiDb.jsonl` (393 行) を実コードで流して確認:

```
203  thinking/delta -> assistant:[thinking]
 80  tool_call/completed -> assistant:[tool_use tool_result]
 78  tool_call/started:dropped
 14  thinking/completed:dropped
 10  assistant -> assistant:[text]
  4  user passthrough
  2  system/init passthrough
  2  result/success passthrough
```

すべて期待通りに変換 / drop / 素通しされる。

## Test plan

- [x] `go test ./...` 全パス
- [x] `make build` 通過
- [x] 各 tool kind (read, shell, edit, glob, grep, await) の `normalizeToolCall` テスト追加
- [x] `thinking/delta` / `thinking/completed` の変換テスト追加
- [x] 既存の pass-through テスト (system, assistant, user, result) 引き続きパス
- [x] 実セッション JSONL を流して網羅的に変換結果を確認

Closes #644