### PR TITLE
fix: 送信失敗時に入力欄が消えない問題を修正

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -127,6 +127,8 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
 
 
   const [pendingImages, setPendingImages] = useState<{ data: string; mediaType: string; preview: string }[]>([]);
+  const [isSending, setIsSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [pendingEscalationId, setPendingEscalationId] = useState<string | null>(null);
   const [escalationMessage, setEscalationMessage] = useState<string | null>(null);
@@ -351,17 +353,28 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
 
   const handleSend = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!sessionId || (!message.trim() && pendingImages.length === 0)) return;
-    const images = pendingImages.length > 0
-      ? pendingImages.map(({ data, mediaType }) => ({ data, mediaType }))
+    if (!sessionId || isSending || (!message.trim() && pendingImages.length === 0)) return;
+    const text = message;
+    const prevImages = pendingImages;
+    const images = prevImages.length > 0
+      ? prevImages.map(({ data, mediaType }) => ({ data, mediaType }))
       : undefined;
+    // Optimistic clear
+    setMessage("");
+    setPendingImages([]);
+    setSendError(null);
+    setIsSending(true);
     try {
-      await api.sendToSession(sessionId, message, images);
-      setMessage("");
-      setPendingImages([]);
+      await api.sendToSession(sessionId, text, images);
       // Stream mode updates arrive via WebSocket automatically
     } catch (err) {
       console.error("Failed to send message:", err);
+      // Rollback on failure
+      setMessage(text);
+      setPendingImages(prevImages);
+      setSendError(err instanceof Error ? err.message : "送信に失敗しました");
+    } finally {
+      setIsSending(false);
     }
   };
 
@@ -658,10 +671,22 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
           />
         </div>
         {/* Send button */}
-        <IconButton shape="circle" variant="primary" type="submit">
+        <IconButton
+          shape="circle"
+          variant="primary"
+          type="submit"
+          disabled={isSending || (!message.trim() && pendingImages.length === 0)}
+          title={isSending ? "送信中..." : "Send"}
+          className={isSending ? "opacity-60 cursor-not-allowed" : ""}
+        >
           <SendHorizonal className="w-4 h-4" />
         </IconButton>
       </div>
+      {sendError && (
+        <p className="text-red-600 text-xs mt-1" role="alert">
+          送信に失敗しました: {sendError}
+        </p>
+      )}
     </form>
     </div>
   ) : null;

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -395,7 +395,8 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
               <button
                 type="button"
                 onClick={() => removeImage(i)}
-                className="absolute -top-1.5 -right-1.5 w-4 h-4 bg-red-500 text-white rounded-full flex items-center justify-center text-[10px]"
+                disabled={isSending}
+                className="absolute -top-1.5 -right-1.5 w-4 h-4 bg-red-500 text-white rounded-full flex items-center justify-center text-[10px] disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 <X className="w-2.5 h-2.5" />
               </button>
@@ -410,7 +411,8 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
             shape="circle"
             variant="secondary"
             onClick={() => { setShowActionMenu((v) => !v); setShowTemplateMenu(false); }}
-            title="Actions"
+            disabled={isSending}
+            title={isSending ? "送信中..." : "Actions"}
           >
             <Plus className="w-4 h-4" />
           </IconButton>
@@ -666,8 +668,9 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
                 addImageFiles(imageFiles);
               }
             }}
+            disabled={isSending}
             placeholder="Send a message..."
-            className="block w-full border border-gray-300 rounded px-3 py-2 text-sm resize-none h-9 overflow-auto"
+            className="block w-full border border-gray-300 rounded px-3 py-2 text-sm resize-none h-9 overflow-auto disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
           />
         </div>
         {/* Send button */}
@@ -676,7 +679,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
           variant="primary"
           type="submit"
           disabled={isSending || (!message.trim() && pendingImages.length === 0)}
-          title={isSending ? "送信中..." : "Send"}
+          title={isSending ? "送信中..." : message.trim() || pendingImages.length > 0 ? "Send" : "入力してください"}
           className={isSending ? "opacity-60 cursor-not-allowed" : ""}
         >
           <SendHorizonal className="w-4 h-4" />
@@ -684,7 +687,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
       </div>
       {sendError && (
         <p className="text-red-600 text-xs mt-1" role="alert">
-          送信に失敗しました: {sendError}
+          {sendError}
         </p>
       )}
     </form>


### PR DESCRIPTION
## Summary

セッション画面でメッセージ送信時、HTTP エラーやネットワーク瞬断などで API 呼び出しが throw すると catch ブランチで `console.error` だけ走り、入力欄のテキストが残ったままになる silent failure を修正。

- `handleSend` を「楽観的クリア → 失敗時 rollback」方式に変更
- `isSending` フラグを追加し、二重送信を防止 + 送信ボタンを disable
- 失敗時は inline error メッセージ（`text-red-600`）でユーザーに通知し、メッセージ・添付画像を元に戻す
- 新規送信時にエラー表示をクリア

## Changes

- `frontend/src/pages/SessionPage.tsx`
  - `isSending` / `sendError` state を追加
  - `handleSend` を rewrite（楽観的クリア + try/catch/finally + rollback）
  - 送信ボタンに `disabled` と styling を追加
  - フォーム下に inline error 表示を追加

## Test plan

- [x] `cd frontend && npm run build` 通過
- [x] `cd frontend && npm run lint` で新規エラーが増えていないこと（既存の PreviewPage の lint エラーのみ）
- [ ] 動作確認: 送信成功時に入力欄がクリアされる
- [ ] 動作確認: 送信失敗時に入力欄が元に戻り、エラーメッセージが表示される
- [ ] 動作確認: 連打しても 1 回しか送信されない（ボタン disable）
- [ ] Cmd+Enter での送信が引き続き動作する

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)