### PR TITLE
fix: one-shot provider で空 prompt 時の create を遅延 spawn にする

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -47,9 +47,9 @@ type Manager struct {
 	ephemeralCancels   map[string]context.CancelFunc
 	ephemeralCancelsMu sync.Mutex
 	logger             *slog.Logger
-	onNewLines     func(sessionID string, newLines []string, total int)
-	onStatusChange func(sessionID string, status Status, lastError string)
-	backgroundTasks *BackgroundTaskStore
+	onNewLines         func(sessionID string, newLines []string, total int)
+	onStatusChange     func(sessionID string, status Status, lastError string)
+	backgroundTasks    *BackgroundTaskStore
 }
 
 const nanoidAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
@@ -69,13 +69,13 @@ func NewManager(db *sql.DB, claudeCommand string, permissionMode string, apiPort
 		systemPrompt = defaultSystemPrompt
 	}
 	return &Manager{
-		db:              db,
-		claudeCommand:   claudeCommand,
-		codexCommand:    "codex",
-		cursorCommand:   "agent",
-		permissionMode:  permissionMode,
-		apiPort:         apiPort,
-		systemPrompt:    systemPrompt,
+		db:               db,
+		claudeCommand:    claudeCommand,
+		codexCommand:     "codex",
+		cursorCommand:    "agent",
+		permissionMode:   permissionMode,
+		apiPort:          apiPort,
+		systemPrompt:     systemPrompt,
 		streamProcesses:  make(map[string]*HolderStreamProcess),
 		deletingSet:      make(map[string]struct{}),
 		ephemeralCancels: make(map[string]context.CancelFunc),
@@ -508,7 +508,17 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	}
 	streamOpts.APIPort = m.apiPort
 	var sp *HolderStreamProcess
-	if provider.IsOneShot() && prompt != "" {
+	switch {
+	case provider.IsOneShot() && prompt == "":
+		// One-shot exec providers (Codex/Cursor) require a prompt to run. If the
+		// caller did not supply one at create time, defer spawning the holder
+		// until the first send arrives — otherwise the CLI would start with no
+		// input, exit immediately, and put the session into an unrecoverable
+		// loop. See issue #643.
+		m.logger.Info("deferring holder spawn for one-shot provider with empty initial prompt",
+			"sessionId", id, "provider", pn)
+		sp = nil
+	case provider.IsOneShot():
 		// One-shot exec providers (Codex/Cursor): pass the initial prompt as a
 		// command-line positional argument rather than via stdin. The CLI exits
 		// after producing the response.
@@ -520,7 +530,7 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		// Record the user message in the stream for UI display
 		hsp.recordUserMessage(prompt)
 		sp = hsp
-	} else {
+	default:
 		hsp, err := StartHolderStreamProcess(streamOpts, provider)
 		if err != nil {
 			return nil, fmt.Errorf("start stream process: %w", err)
@@ -533,10 +543,12 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		}
 		sp = hsp
 	}
-	m.wireSessionIDCallback(id, sp)
-	m.streamMu.Lock()
-	m.streamProcesses[id] = sp
-	m.streamMu.Unlock()
+	if sp != nil {
+		m.wireSessionIDCallback(id, sp)
+		m.streamMu.Lock()
+		m.streamProcesses[id] = sp
+		m.streamMu.Unlock()
+	}
 
 	now := time.Now()
 	sessionType := TypeWorker
@@ -560,10 +572,14 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		UpdatedAt:               now,
 	}
 
+	holderPID := 0
+	if sp != nil {
+		holderPID = sp.HolderPID()
+	}
 	if _, err := m.db.Exec(
 		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, system_prompt, parent_session_id, role_template, holder_pid, ephemeral_timeout_seconds, completion_report, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, s.RoleTemplate, sp.HolderPID(), s.EphemeralTimeoutSeconds, s.CompletionReport, s.CreatedAt, s.UpdatedAt,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, s.RoleTemplate, holderPID, s.EphemeralTimeoutSeconds, s.CompletionReport, s.CreatedAt, s.UpdatedAt,
 	); err != nil {
 		return nil, fmt.Errorf("insert session: %w", err)
 	}
@@ -729,7 +745,6 @@ func (m *Manager) List() ([]Session, error) {
 	}
 	return sessions, rows.Err()
 }
-
 
 func (m *Manager) Get(id string) (*Session, error) {
 	var s Session
@@ -1309,6 +1324,37 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			}, provider)
 			if err != nil {
 				return fmt.Errorf("restart stream process: %w", err)
+			}
+			hsp.recordUserMessage(text)
+			sp = hsp
+			m.wireSessionIDCallback(id, sp)
+			m.streamMu.Lock()
+			m.streamProcesses[id] = sp
+			m.streamMu.Unlock()
+			m.updateHolderPID(id, hsp.HolderPID())
+			return nil
+		}
+
+		if provider.IsOneShot() {
+			// First send for a one-shot session that was created without an
+			// initial prompt (or that never completed a turn): spawn the holder
+			// now with the user's message as the positional prompt. Spawning
+			// with no prompt would cause Codex/Cursor to exit immediately.
+			// See issue #643.
+			m.killStaleHolder(id)
+			hsp, err := StartHolderStreamProcess(StreamOpts{
+				SessionID:     s.ID,
+				ProjectPath:   s.ProjectPath,
+				MCPConfigPath: mcpPath,
+				SystemPrompt:  effectiveSP,
+				InitialPrompt: text,
+				Resume:        false,
+				Model:         s.Model,
+				APIPort:       m.apiPort,
+				ClearOffset:   s.ClearOffset,
+			}, provider)
+			if err != nil {
+				return fmt.Errorf("start stream process: %w", err)
 			}
 			hsp.recordUserMessage(text)
 			sp = hsp

--- a/internal/session/manager_lazy_spawn_test.go
+++ b/internal/session/manager_lazy_spawn_test.go
@@ -1,0 +1,216 @@
+package session
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// Tests for the lazy-spawn behavior of one-shot providers (Codex/Cursor) when
+// Create is invoked without an initial prompt. See issue #643.
+//
+// Without the lazy-spawn fix, Create would always call StartHolderStreamProcess
+// even when prompt == "", causing the one-shot CLI (cursor/codex) to start with
+// no input and exit immediately with code 1 (or 0), making subsequent sends
+// auto-recover into the same broken state.
+
+// TestCreate_OneShot_EmptyPrompt_SkipsHolderSpawn verifies that creating a
+// one-shot provider session without an initial prompt does NOT spawn a holder.
+// The session row must exist with holder_pid = 0 and status = idle so the next
+// send can lazily spawn the holder with the user's first message.
+func TestCreate_OneShot_EmptyPrompt_SkipsHolderSpawn(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider ProviderName
+	}{
+		{"cursor", ProviderCursor},
+		{"codex", ProviderCodex},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newTestDB(t)
+			defer db.Close()
+
+			m := &Manager{
+				db:              db,
+				logger:          slog.Default(),
+				cursorCommand:   "agent",
+				codexCommand:    "codex",
+				claudeCommand:   "claude",
+				streamProcesses: make(map[string]*HolderStreamProcess),
+				deletingSet:     make(map[string]struct{}),
+				systemPrompt:    "test",
+			}
+
+			sess, err := m.Create("test-no-prompt", "/tmp", "", false, CreateOpts{
+				Provider: tc.provider,
+			})
+			if err != nil {
+				t.Fatalf("Create with empty prompt should succeed, got: %v", err)
+			}
+			if sess == nil {
+				t.Fatal("expected session to be returned")
+			}
+
+			// The DB row should exist with holder_pid = 0 (no holder spawned).
+			var holderPID int
+			var status string
+			if err := db.QueryRow("SELECT holder_pid, status FROM sessions WHERE id = ?", sess.ID).Scan(&holderPID, &status); err != nil {
+				t.Fatalf("query session row: %v", err)
+			}
+			if holderPID != 0 {
+				t.Errorf("holder_pid = %d, want 0 (holder should not be spawned for one-shot + empty prompt)", holderPID)
+			}
+			if status != string(StatusIdle) {
+				t.Errorf("status = %q, want %q", status, string(StatusIdle))
+			}
+
+			// streamProcesses must not contain an entry for this session
+			// because no holder was spawned.
+			m.streamMu.Lock()
+			_, ok := m.streamProcesses[sess.ID]
+			m.streamMu.Unlock()
+			if ok {
+				t.Errorf("streamProcesses should not contain session %s when holder is not spawned", sess.ID)
+			}
+		})
+	}
+}
+
+// TestCreate_OneShot_EmptyPrompt_AllowsRetrieval verifies that the lazy-spawned
+// session can be retrieved via Get even though no holder process exists yet.
+func TestCreate_OneShot_EmptyPrompt_AllowsRetrieval(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	m := &Manager{
+		db:              db,
+		logger:          slog.Default(),
+		cursorCommand:   "agent",
+		streamProcesses: make(map[string]*HolderStreamProcess),
+		deletingSet:     make(map[string]struct{}),
+		systemPrompt:    "test",
+	}
+
+	sess, err := m.Create("retrieve-test", "/tmp", "", false, CreateOpts{
+		Provider: ProviderCursor,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := m.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", sess.ID, err)
+	}
+	if got.Provider != ProviderCursor {
+		t.Errorf("provider = %q, want %q", got.Provider, ProviderCursor)
+	}
+	if got.HolderPID != 0 {
+		t.Errorf("holderPID = %d, want 0", got.HolderPID)
+	}
+	if got.ConversationStarted {
+		t.Errorf("conversationStarted = true, want false for freshly created session")
+	}
+}
+
+// TestSendKeysAutoRecover_OneShotFirstSend_DerivesCorrectStreamOpts is a
+// data-shape test for the new lazy-spawn-on-first-send branch in
+// SendKeysWithImages. After a lazy create (holder_pid = 0,
+// conversation_started = 0), the first send must take the new branch that
+// passes InitialPrompt = text and Resume = false, NOT the resume branch
+// (which requires cli_session_id and ConversationStarted).
+func TestSendKeysAutoRecover_OneShotFirstSend_DerivesCorrectStreamOpts(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	id := "lazy-cursor-first-send"
+	if _, err := db.Exec(
+		`INSERT INTO sessions (id, name, project_path, tmux_session, status, type, output_mode, provider, model, cli_session_id, holder_pid, conversation_started)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, "lazy", "/tmp", "", "idle", "worker", "stream", "cursor", "", "", 0, 0,
+	); err != nil {
+		t.Fatalf("insert lazy session: %v", err)
+	}
+
+	m := newTestManager(t, db)
+
+	s, err := m.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	// Reproduce the branch-selection logic from SendKeysWithImages:
+	provider := m.getProvider(s.Provider)
+	canResume := s.ConversationStarted
+	cliSessionID := s.CliSessionID
+
+	if !provider.IsOneShot() {
+		t.Fatal("precondition: cursor must be one-shot")
+	}
+	if canResume {
+		t.Fatal("precondition: lazy session must not be resumable on first send")
+	}
+	if cliSessionID != "" {
+		t.Fatal("precondition: lazy session must not have a cli_session_id yet")
+	}
+
+	// The resume branch should NOT be taken (it requires cliSessionID != "" && canResume).
+	tookResumeBranch := provider.IsOneShot() && cliSessionID != "" && canResume
+	if tookResumeBranch {
+		t.Errorf("lazy session must NOT take the resume branch (cliSessionID=%q canResume=%v)", cliSessionID, canResume)
+	}
+
+	// The new lazy-first-send branch MUST be taken
+	// (provider.IsOneShot() && !tookResumeBranch).
+	tookLazyFirstSend := provider.IsOneShot() && !tookResumeBranch
+	if !tookLazyFirstSend {
+		t.Errorf("lazy session must take the one-shot-first-send branch; "+
+			"provider.IsOneShot()=%v tookResumeBranch=%v", provider.IsOneShot(), tookResumeBranch)
+	}
+}
+
+// TestRecoverStreamProcesses_SkipsLazySessions verifies that the SQL query in
+// RecoverStreamProcesses (WHERE holder_pid > 0) skips sessions created via
+// the lazy-spawn path (holder_pid = 0). This is critical: on daemon restart,
+// we must not try to "recover" a session that never had a holder.
+func TestRecoverStreamProcesses_SkipsLazySessions(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	// Insert one lazy session (holder_pid = 0) and one normal session (holder_pid > 0).
+	if _, err := db.Exec(
+		`INSERT INTO sessions (id, name, project_path, tmux_session, status, type, output_mode, provider, model, cli_session_id, holder_pid, conversation_started)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"lazy-sess", "lazy", "/tmp", "", "idle", "worker", "stream", "cursor", "", "", 0, 0,
+	); err != nil {
+		t.Fatalf("insert lazy session: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO sessions (id, name, project_path, tmux_session, status, type, output_mode, provider, model, cli_session_id, holder_pid, conversation_started)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"alive-sess", "alive", "/tmp", "", "working", "worker", "stream", "claude", "", "cli-x", 12345, 1,
+	); err != nil {
+		t.Fatalf("insert alive session: %v", err)
+	}
+
+	// This mirrors the exact WHERE clause used in RecoverStreamProcesses.
+	rows, err := db.Query(`SELECT id FROM sessions WHERE holder_pid > 0`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	var got []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, id)
+	}
+
+	if len(got) != 1 || got[0] != "alive-sess" {
+		t.Errorf("recovery query returned %v, want [alive-sess] only (lazy-sess must be skipped because holder_pid = 0)", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `cursor --provider cursor -p <path>` のように `-m` 無しで one-shot provider のセッションを作ると、holder が空入力で spawn されて即死し、後続 send もループする問題 (#643) を修正
- one-shot provider (Cursor/Codex) で `prompt == ""` の場合は create 時に holder を spawn せず、DB 行のみ作成 (`holder_pid = 0`)
- 初回 send が来たタイミングで `SendKeysWithImages` の auto-recover 経路から、そのテキストを `InitialPrompt` として渡して holder を初回 spawn する分岐を追加
- `RecoverStreamProcesses` は元々 `WHERE holder_pid > 0` でフィルタしているため、lazy セッションは自動でスキップされる (再起動安全)

Claude (non-one-shot) の挙動には変更なし。

## Test plan

- [x] `go test ./...` 全パス
- [x] `make build` 通過
- [x] `TestCreate_OneShot_EmptyPrompt_SkipsHolderSpawn` (cursor / codex 両方) で `holder_pid = 0` かつ `status = idle`、`streamProcesses` に登録されないことを検証
- [x] `TestCreate_OneShot_EmptyPrompt_AllowsRetrieval` で lazy セッションが `Get()` で取得可能なことを検証
- [x] `TestSendKeysAutoRecover_OneShotFirstSend_DerivesCorrectStreamOpts` で初回 send 時に resume 分岐ではなく新規 lazy-first-send 分岐に入る条件を検証
- [x] `TestRecoverStreamProcesses_SkipsLazySessions` で daemon 再起動時の復旧クエリ (`WHERE holder_pid > 0`) が lazy セッションをスキップすることを検証
- [ ] (実機) `agmux session create cursor-no-m --provider cursor -p /tmp/cursor-test` → 即死しないこと
- [ ] (実機) その後 `agmux session send cursor-no-m "1+1は？"` → 正常に応答が返ること

Closes #643