### PR TITLE
fix: cursor provider の thinking delta をバッファリングして1つの assistant メッセージにまとめる

### DIFF
--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -247,6 +247,20 @@ func (sp *HolderStreamProcess) loadExistingLines(sessionID string, clearOffset i
 			sp.lines = append(sp.lines, normalizedStr)
 		}
 	}
+
+	// Drop any per-session normalization state left over from replay (e.g.
+	// cursor thinking deltas whose `completed` never arrived because the
+	// underlying CLI process died mid-turn). Without this, live events
+	// arriving after a reconnect could be prefixed with stale thinking text
+	// from a previous turn.
+	//
+	// We pass the empty string to clear every buffer this provider instance
+	// is currently holding: providers are created per-stream by Manager (see
+	// Manager.getProvider), and the cursor provider's buffers are keyed by
+	// the cursor CLI session_id (read from JSONL events) — not the agmux
+	// session ID we'd otherwise pass here — so a targeted delete would miss
+	// the buffer when the agmux/CLI IDs differ.
+	sp.provider.ResetBuffers("")
 }
 
 func (sp *HolderStreamProcess) readLoop() {

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -227,23 +227,25 @@ func (sp *HolderStreamProcess) loadExistingLines(sessionID string, clearOffset i
 	for scanner.Scan() {
 		line := scanner.Text()
 		// Normalize lines from JSONL (holder writes raw lines)
-		normalized := sp.provider.NormalizeStreamLine([]byte(line))
-		if normalized == nil {
-			continue
-		}
-		normalizedStr := string(normalized)
-
-		// Skip stream_events (transient, not for history)
-		if len(normalized) > 0 && normalized[0] == '{' {
-			var peek struct {
-				Type string `json:"type"`
-			}
-			if json.Unmarshal(normalized, &peek) == nil && peek.Type == "stream_event" {
+		normalizedLines := sp.provider.NormalizeStreamLine([]byte(line))
+		for _, normalized := range normalizedLines {
+			if normalized == nil {
 				continue
 			}
-		}
+			normalizedStr := string(normalized)
 
-		sp.lines = append(sp.lines, normalizedStr)
+			// Skip stream_events (transient, not for history)
+			if len(normalized) > 0 && normalized[0] == '{' {
+				var peek struct {
+					Type string `json:"type"`
+				}
+				if json.Unmarshal(normalized, &peek) == nil && peek.Type == "stream_event" {
+					continue
+				}
+			}
+
+			sp.lines = append(sp.lines, normalizedStr)
+		}
 	}
 }
 
@@ -380,35 +382,39 @@ func (sp *HolderStreamProcess) readLoop() {
 			}
 		}
 
-		// Normalize the line
-		normalized := sp.provider.NormalizeStreamLine([]byte(line))
-		if normalized == nil {
-			continue
-		}
-		normalizedStr := string(normalized)
-
-		// Check for stream_event (real-time only, not persisted)
-		isStreamEvent := false
-		if len(normalized) > 0 && normalized[0] == '{' {
-			var peek struct {
-				Type string `json:"type"`
+		// Normalize the line (may expand to multiple output lines, e.g. when
+		// the cursor provider flushes buffered thinking text before the
+		// current event).
+		normalizedLines := sp.provider.NormalizeStreamLine([]byte(line))
+		for _, normalized := range normalizedLines {
+			if normalized == nil {
+				continue
 			}
-			if json.Unmarshal(normalized, &peek) == nil && peek.Type == "stream_event" {
-				isStreamEvent = true
+			normalizedStr := string(normalized)
+
+			// Check for stream_event (real-time only, not persisted)
+			isStreamEvent := false
+			if len(normalized) > 0 && normalized[0] == '{' {
+				var peek struct {
+					Type string `json:"type"`
+				}
+				if json.Unmarshal(normalized, &peek) == nil && peek.Type == "stream_event" {
+					isStreamEvent = true
+				}
 			}
-		}
 
-		sp.mu.Lock()
-		if !isStreamEvent {
-			sp.lines = append(sp.lines, normalizedStr)
-			// Note: holder already writes to JSONL file, so we don't write here
-		}
-		total := len(sp.lines)
-		cb := sp.onNewLines
-		sp.mu.Unlock()
+			sp.mu.Lock()
+			if !isStreamEvent {
+				sp.lines = append(sp.lines, normalizedStr)
+				// Note: holder already writes to JSONL file, so we don't write here
+			}
+			total := len(sp.lines)
+			cb := sp.onNewLines
+			sp.mu.Unlock()
 
-		if cb != nil {
-			cb(sp.streamOpts.SessionID, []string{normalizedStr}, total)
+			if cb != nil {
+				cb(sp.streamOpts.SessionID, []string{normalizedStr}, total)
+			}
 		}
 	}
 }

--- a/internal/session/holder_stream_test.go
+++ b/internal/session/holder_stream_test.go
@@ -1,0 +1,137 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/myuon/agmux/internal/db"
+)
+
+// TestLoadExistingLines_CursorThinkingBufferReset verifies the fix for the
+// post-replay buffer leak: when loadExistingLines replays a JSONL file whose
+// last turn never reached `thinking/completed` (e.g. the CLI process died
+// mid-turn), the cursor provider's per-session thinking buffer must be reset
+// at the end of replay so that the next live event does not get prefixed with
+// stale thinking text from a previous turn.
+//
+// Regression for PR #651 review comment 4526884382.
+func TestLoadExistingLines_CursorThinkingBufferReset(t *testing.T) {
+	// loadExistingLines reads from db.StreamsDir(), so point HOME at a temp
+	// dir to isolate file IO.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "test-cursor-buffer-reset"
+	jsonlPath := filepath.Join(streamsDir, sessionID+".jsonl")
+
+	// Simulate a JSONL where the last turn emitted thinking/delta events but
+	// never reached thinking/completed (e.g. the process died mid-turn).
+	// Two complete turns precede it so we exercise normal replay too.
+	content := `{"type":"system","subtype":"init","session_id":"chat-1","model":"sonnet-4"}
+{"type":"thinking","subtype":"delta","text":"turn1 ","session_id":"chat-1"}
+{"type":"thinking","subtype":"delta","text":"thought","session_id":"chat-1"}
+{"type":"thinking","subtype":"completed","session_id":"chat-1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"answer1"}]},"session_id":"chat-1"}
+{"type":"result","subtype":"success","is_error":false,"result":"ok","session_id":"chat-1"}
+{"type":"thinking","subtype":"delta","text":"leftover-","session_id":"chat-1"}
+{"type":"thinking","subtype":"delta","text":"never-flushed","session_id":"chat-1"}
+`
+	if err := os.WriteFile(jsonlPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := NewCursorProvider("")
+	sp := &HolderStreamProcess{
+		provider: provider,
+	}
+
+	sp.loadExistingLines(sessionID, 0)
+
+	// After replay, the buffer for the cursor session must be empty: the
+	// trailing un-flushed delta should have been dropped by ResetBuffers,
+	// NOT carried over into live processing.
+	provider.thinkingMu.Lock()
+	_, hasBuf := provider.thinkingBuffers["chat-1"]
+	totalBuffers := len(provider.thinkingBuffers)
+	provider.thinkingMu.Unlock()
+
+	if hasBuf {
+		t.Errorf("expected thinking buffer for chat-1 to be cleared after loadExistingLines, but it still exists")
+	}
+	if totalBuffers != 0 {
+		t.Errorf("expected no thinking buffers after loadExistingLines, got %d", totalBuffers)
+	}
+
+	// Now feed a live event for the same session — it must NOT be prefixed
+	// with the stale "leftover-never-flushed" thinking text.
+	live := provider.NormalizeStreamLine([]byte(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"live-answer"}]},"session_id":"chat-1"}`))
+	if len(live) != 1 {
+		t.Fatalf("expected live event to produce exactly 1 output line (no stale thinking flush), got %d", len(live))
+	}
+	if strings.Contains(string(live[0]), "leftover") || strings.Contains(string(live[0]), "never-flushed") {
+		t.Errorf("live event leaked stale buffered thinking text: %s", string(live[0]))
+	}
+
+	// The first replayed turn's thinking should have been preserved during
+	// replay (it had completed), so sp.lines should contain at least one
+	// thinking message.
+	foundReplayedThinking := false
+	for _, l := range sp.lines {
+		if strings.Contains(l, `"thinking":"turn1 thought"`) {
+			foundReplayedThinking = true
+			break
+		}
+	}
+	if !foundReplayedThinking {
+		t.Errorf("expected replayed thinking text 'turn1 thought' to be in sp.lines, lines=%v", sp.lines)
+	}
+
+	// And the trailing un-flushed thinking must NOT appear in sp.lines.
+	for _, l := range sp.lines {
+		if strings.Contains(l, "leftover") || strings.Contains(l, "never-flushed") {
+			t.Errorf("un-flushed trailing thinking leaked into replayed lines: %s", l)
+		}
+	}
+}
+
+// TestLoadExistingLines_ClaudeProviderResetBuffers_NoOp ensures that calling
+// loadExistingLines with a non-cursor provider does not panic and the no-op
+// ResetBuffers is invoked cleanly.
+func TestLoadExistingLines_ClaudeProviderResetBuffers_NoOp(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "test-claude-reset-noop"
+	jsonlPath := filepath.Join(streamsDir, sessionID+".jsonl")
+
+	content := `{"type":"system","subtype":"init","session_id":"c-1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}
+`
+	if err := os.WriteFile(jsonlPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sp := &HolderStreamProcess{
+		provider: NewClaudeProvider("", ""),
+	}
+
+	// Should not panic.
+	sp.loadExistingLines(sessionID, 0)
+
+	if len(sp.lines) == 0 {
+		t.Errorf("expected replayed lines, got 0")
+	}
+}
+

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -62,6 +62,15 @@ type Provider interface {
 	//
 	// Callers must iterate the returned slice in order.
 	NormalizeStreamLine(line []byte) [][]byte
+	// ResetBuffers drops any per-session normalization state (e.g. partially
+	// accumulated thinking text) for the given session ID without emitting
+	// the buffered content. This is intended for use after replaying past
+	// JSONL through NormalizeStreamLine (e.g. loadExistingLines), so that
+	// state left over from a turn that never reached `completed` is not
+	// carried into the live stream.
+	//
+	// Providers without buffered state should implement this as a no-op.
+	ResetBuffers(sessionID string)
 }
 
 // GetProvider returns a Provider instance for the given name.

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -50,10 +50,18 @@ type Provider interface {
 	// and must be re-spawned with --resume to continue the conversation.
 	IsOneShot() bool
 	// NormalizeStreamLine converts a provider-specific JSONL line into
-	// Claude-compatible stream-json format. If the line should be kept as-is,
-	// it returns the original bytes unchanged. If the line should be dropped,
-	// it returns nil.
-	NormalizeStreamLine(line []byte) []byte
+	// zero or more Claude-compatible stream-json lines.
+	//
+	// Most providers return a single-element slice (line kept as-is or
+	// converted in place). Providers that buffer multiple input events into
+	// one logical output (e.g. cursor coalescing thinking/delta) may return:
+	//   - nil or empty slice: drop this input line
+	//   - one entry: a single output line
+	//   - multiple entries: e.g. flush a buffered thinking message AND emit
+	//     the current event (preserving original ordering).
+	//
+	// Callers must iterate the returned slice in order.
+	NormalizeStreamLine(line []byte) [][]byte
 }
 
 // GetProvider returns a Provider instance for the given name.

--- a/internal/session/provider_claude.go
+++ b/internal/session/provider_claude.go
@@ -192,3 +192,7 @@ func (p *ClaudeProvider) NormalizeStreamLine(line []byte) [][]byte {
 	return [][]byte{line}
 }
 
+// ResetBuffers is a no-op for ClaudeProvider — it holds no per-session
+// normalization state.
+func (p *ClaudeProvider) ResetBuffers(sessionID string) {}
+

--- a/internal/session/provider_claude.go
+++ b/internal/session/provider_claude.go
@@ -187,8 +187,8 @@ func (p *ClaudeProvider) AppendOTelEnv(env []string, port int) []string {
 	return env
 }
 
-func (p *ClaudeProvider) NormalizeStreamLine(line []byte) []byte {
+func (p *ClaudeProvider) NormalizeStreamLine(line []byte) [][]byte {
 	// Claude lines are already in the expected format; return as-is.
-	return line
+	return [][]byte{line}
 }
 

--- a/internal/session/provider_codex.go
+++ b/internal/session/provider_codex.go
@@ -215,6 +215,10 @@ func (p *CodexProvider) buildAssistantText(text string) []byte {
 	return b
 }
 
+// ResetBuffers is a no-op for CodexProvider — it holds no per-session
+// normalization state.
+func (p *CodexProvider) ResetBuffers(sessionID string) {}
+
 func (p *CodexProvider) buildAssistantToolUse(command, output string) []byte {
 	type toolUseBlock struct {
 		Type  string            `json:"type"`

--- a/internal/session/provider_codex.go
+++ b/internal/session/provider_codex.go
@@ -148,24 +148,27 @@ func (p *CodexProvider) AppendOTelEnv(env []string, port int) []string {
 
 // NormalizeStreamLine converts a Codex JSONL event into Claude-compatible
 // stream-json format so the frontend can render it uniformly.
-func (p *CodexProvider) NormalizeStreamLine(line []byte) []byte {
+func (p *CodexProvider) NormalizeStreamLine(line []byte) [][]byte {
 	var envelope struct {
 		Type string          `json:"type"`
 		Item json.RawMessage `json:"item"`
 	}
 	if json.Unmarshal(line, &envelope) != nil {
-		return line
+		return [][]byte{line}
 	}
 
 	switch envelope.Type {
 	case "item.completed":
-		return p.normalizeItemCompleted(envelope.Item, line)
+		if out := p.normalizeItemCompleted(envelope.Item, line); out != nil {
+			return [][]byte{out}
+		}
+		return nil
 	case "item.started":
 		// Skip in-progress events; they have no useful content yet.
 		return nil
 	default:
 		// thread.started, turn.started, turn.completed, etc. – keep as-is.
-		return line
+		return [][]byte{line}
 	}
 }
 

--- a/internal/session/provider_codex_test.go
+++ b/internal/session/provider_codex_test.go
@@ -461,18 +461,19 @@ func TestCodexProvider_NormalizeStreamLine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := p.NormalizeStreamLine([]byte(tt.input))
+			results := p.NormalizeStreamLine([]byte(tt.input))
 
 			if tt.wantNil {
-				if result != nil {
-					t.Errorf("expected nil, got %s", string(result))
+				if len(results) != 0 {
+					t.Errorf("expected no output, got %d lines", len(results))
 				}
 				return
 			}
 
-			if result == nil {
-				t.Fatal("expected non-nil result")
+			if len(results) != 1 {
+				t.Fatalf("expected exactly 1 output line, got %d", len(results))
 			}
+			result := results[0]
 
 			if tt.wantJSON != "" {
 				// Compare as parsed JSON for stable comparison
@@ -638,8 +639,11 @@ func TestClaudeProvider_ParseModel(t *testing.T) {
 func TestClaudeProvider_NormalizeStreamLine(t *testing.T) {
 	p := NewClaudeProvider("", "")
 	input := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}`
-	result := p.NormalizeStreamLine([]byte(input))
-	if string(result) != input {
-		t.Errorf("ClaudeProvider should pass through unchanged\ngot:  %s\nwant: %s", string(result), input)
+	results := p.NormalizeStreamLine([]byte(input))
+	if len(results) != 1 {
+		t.Fatalf("expected exactly 1 output line, got %d", len(results))
+	}
+	if string(results[0]) != input {
+		t.Errorf("ClaudeProvider should pass through unchanged\ngot:  %s\nwant: %s", string(results[0]), input)
 	}
 }

--- a/internal/session/provider_cursor.go
+++ b/internal/session/provider_cursor.go
@@ -380,6 +380,12 @@ func cursorExtractToolResult(raw json.RawMessage) string {
 //	  "content":[{"type":"thinking","thinking":"<concatenated text>"}]}}
 //
 // so the frontend's StreamDisplayItem("thinking") rendering picks it up.
+//
+// NOTE: In practice the Cursor CLI does not currently emit a standalone
+// thinking/completed event — flushes are driven almost entirely by the
+// arrival of the next non-thinking event (e.g. an assistant message or
+// tool_call) for the same session. The completed branch below is kept so
+// that we behave correctly if/when Cursor starts emitting it.
 func (p *CursorProvider) handleThinking(line []byte, subtype, sessionID string) [][]byte {
 	switch subtype {
 	case "delta":
@@ -429,6 +435,23 @@ func (p *CursorProvider) flushThinking(sessionID string) [][]byte {
 	delete(p.thinkingBuffers, sessionID)
 	p.thinkingMu.Unlock()
 	return [][]byte{buildCursorThinkingMessage(text)}
+}
+
+// ResetBuffers drops any accumulated thinking text for the given session ID
+// without emitting it. Intended to be called after replaying historical
+// JSONL through NormalizeStreamLine (e.g. loadExistingLines) so that a
+// partially-buffered turn whose `completed` event never arrived does not
+// leak into the live stream that follows.
+//
+// If sessionID is empty, all buffered sessions are dropped.
+func (p *CursorProvider) ResetBuffers(sessionID string) {
+	p.thinkingMu.Lock()
+	defer p.thinkingMu.Unlock()
+	if sessionID == "" {
+		p.thinkingBuffers = make(map[string]*strings.Builder)
+		return
+	}
+	delete(p.thinkingBuffers, sessionID)
 }
 
 // flushAllThinking emits every buffered session's accumulated thinking text

--- a/internal/session/provider_cursor.go
+++ b/internal/session/provider_cursor.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // knownCursorToolKinds lists the tool kind keys that may appear in
@@ -38,6 +39,14 @@ var knownCursorToolKinds = []string{
 // them uniformly.
 type CursorProvider struct {
 	command string
+
+	// thinkingMu guards thinkingBuffers.
+	thinkingMu sync.Mutex
+	// thinkingBuffers accumulates thinking/delta text per Cursor session_id.
+	// A buffer is flushed (and removed) when thinking/completed arrives, or
+	// when any non-thinking event is observed for that session_id, so that
+	// the buffered thinking text is emitted before the interrupting event.
+	thinkingBuffers map[string]*strings.Builder
 }
 
 // NewCursorProvider creates a CursorProvider with the given command.
@@ -46,7 +55,10 @@ func NewCursorProvider(command string) *CursorProvider {
 	if command == "" {
 		command = "agent"
 	}
-	return &CursorProvider{command: command}
+	return &CursorProvider{
+		command:         command,
+		thinkingBuffers: make(map[string]*strings.Builder),
+	}
 }
 
 func (p *CursorProvider) Name() ProviderName {
@@ -161,23 +173,43 @@ func (p *CursorProvider) AppendOTelEnv(env []string, port int) []string {
 // NormalizeStreamLine converts Cursor-specific events into Claude-compatible
 // stream-json format. Most event types are already Claude-compatible and pass
 // through unchanged.
-func (p *CursorProvider) NormalizeStreamLine(line []byte) []byte {
+//
+// Returns a slice of zero or more output lines. The cursor provider buffers
+// consecutive thinking/delta events and emits them as a single assistant
+// message when thinking/completed arrives or when an intervening non-thinking
+// event needs to be emitted first.
+func (p *CursorProvider) NormalizeStreamLine(line []byte) [][]byte {
 	var envelope struct {
-		Type    string `json:"type"`
-		Subtype string `json:"subtype"`
+		Type      string `json:"type"`
+		Subtype   string `json:"subtype"`
+		SessionID string `json:"session_id"`
 	}
 	if json.Unmarshal(line, &envelope) != nil {
-		return line
+		// Non-JSON line: flush any buffered thinking (we don't know which
+		// session it belongs to, so flush all) and then pass through.
+		flushed := p.flushAllThinking()
+		flushed = append(flushed, line)
+		return flushed
 	}
 
 	switch envelope.Type {
-	case "tool_call":
-		return p.normalizeToolCall(line, envelope.Subtype)
 	case "thinking":
-		return p.normalizeThinking(line, envelope.Subtype)
+		return p.handleThinking(line, envelope.Subtype, envelope.SessionID)
+	case "tool_call":
+		// Flush any buffered thinking for this session before emitting the
+		// tool_call so ordering is preserved.
+		out := p.flushThinking(envelope.SessionID)
+		if normalized := p.normalizeToolCall(line, envelope.Subtype); normalized != nil {
+			out = append(out, normalized)
+		}
+		return out
 	default:
 		// system, assistant, user, result, etc. are Claude-compatible.
-		return line
+		// Flush any buffered thinking for this session first so that thinking
+		// text appears before the interrupting event.
+		out := p.flushThinking(envelope.SessionID)
+		out = append(out, line)
+		return out
 	}
 }
 
@@ -332,42 +364,106 @@ func cursorExtractToolResult(raw json.RawMessage) string {
 	return jsonRawToString(raw)
 }
 
-// normalizeThinking converts Cursor's incremental thinking events into a
-// Claude-compatible assistant message with a thinking block. Cursor emits:
+// handleThinking buffers Cursor's incremental thinking deltas and emits a
+// single Claude-compatible assistant message when the run of deltas ends
+// (either via thinking/completed or because another event for the same
+// session is about to be emitted).
+//
+// Cursor emits:
 //
 //	{"type":"thinking","subtype":"delta","text":"...",...}
 //	{"type":"thinking","subtype":"completed",...}
 //
-// Each delta is converted into an assistant message of the form
+// The combined text is emitted as
 //
 //	{"type":"assistant","message":{"role":"assistant",
-//	  "content":[{"type":"thinking","thinking":"<text>"}]}}
+//	  "content":[{"type":"thinking","thinking":"<concatenated text>"}]}}
 //
 // so the frontend's StreamDisplayItem("thinking") rendering picks it up.
-// The "completed" event is dropped — it carries no new text.
-func (p *CursorProvider) normalizeThinking(line []byte, subtype string) []byte {
-	if subtype != "delta" {
-		// "completed" (and any unknown subtype) carries no payload.
+func (p *CursorProvider) handleThinking(line []byte, subtype, sessionID string) [][]byte {
+	switch subtype {
+	case "delta":
+		var msg struct {
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(line, &msg) != nil {
+			// Malformed delta — keep raw line for visibility.
+			out := p.flushThinking(sessionID)
+			out = append(out, line)
+			return out
+		}
+		if msg.Text == "" {
+			return nil
+		}
+		p.thinkingMu.Lock()
+		buf, ok := p.thinkingBuffers[sessionID]
+		if !ok {
+			buf = &strings.Builder{}
+			p.thinkingBuffers[sessionID] = buf
+		}
+		buf.WriteString(msg.Text)
+		p.thinkingMu.Unlock()
+		return nil
+	case "completed":
+		return p.flushThinking(sessionID)
+	default:
+		// Unknown thinking subtype — flush and drop.
+		return p.flushThinking(sessionID)
+	}
+}
+
+// flushThinking emits the buffered thinking text for the given session_id (if
+// any) as a single assistant message and clears the buffer. Returns the
+// produced output lines (zero or one).
+func (p *CursorProvider) flushThinking(sessionID string) [][]byte {
+	p.thinkingMu.Lock()
+	buf, ok := p.thinkingBuffers[sessionID]
+	if !ok || buf.Len() == 0 {
+		if ok {
+			delete(p.thinkingBuffers, sessionID)
+		}
+		p.thinkingMu.Unlock()
 		return nil
 	}
+	text := buf.String()
+	delete(p.thinkingBuffers, sessionID)
+	p.thinkingMu.Unlock()
+	return [][]byte{buildCursorThinkingMessage(text)}
+}
 
-	var msg struct {
-		Type    string `json:"type"`
-		Subtype string `json:"subtype"`
-		Text    string `json:"text"`
-	}
-	if json.Unmarshal(line, &msg) != nil {
-		return line
-	}
-	if msg.Text == "" {
+// flushAllThinking emits every buffered session's accumulated thinking text
+// as separate assistant messages, then clears all buffers. Used as a
+// defensive fallback when we can't determine which session a line belongs to
+// (e.g. unparseable JSON).
+func (p *CursorProvider) flushAllThinking() [][]byte {
+	p.thinkingMu.Lock()
+	if len(p.thinkingBuffers) == 0 {
+		p.thinkingMu.Unlock()
 		return nil
 	}
+	keys := make([]string, 0, len(p.thinkingBuffers))
+	for k := range p.thinkingBuffers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // deterministic ordering
+	out := make([][]byte, 0, len(keys))
+	for _, k := range keys {
+		buf := p.thinkingBuffers[k]
+		if buf.Len() > 0 {
+			out = append(out, buildCursorThinkingMessage(buf.String()))
+		}
+		delete(p.thinkingBuffers, k)
+	}
+	p.thinkingMu.Unlock()
+	return out
+}
 
+func buildCursorThinkingMessage(text string) []byte {
 	type thinkingBlock struct {
 		Type     string `json:"type"`
 		Thinking string `json:"thinking"`
 	}
-	tb := thinkingBlock{Type: "thinking", Thinking: msg.Text}
+	tb := thinkingBlock{Type: "thinking", Thinking: text}
 	tbJSON, _ := json.Marshal(tb)
 
 	wrapper := struct {

--- a/internal/session/provider_cursor_test.go
+++ b/internal/session/provider_cursor_test.go
@@ -405,11 +405,11 @@ func TestCursorProvider_NormalizeToolCall_MoreKinds(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			out := p.NormalizeStreamLine([]byte(tc.input))
-			if out == nil {
-				t.Fatalf("expected normalized output, got nil")
+			outs := p.NormalizeStreamLine([]byte(tc.input))
+			if len(outs) == 0 {
+				t.Fatalf("expected normalized output, got none")
 			}
-			got := parse(t, out)
+			got := parse(t, outs[len(outs)-1])
 			if got.Name != tc.wantName {
 				t.Errorf("name = %q, want %q", got.Name, tc.wantName)
 			}
@@ -427,8 +427,9 @@ func TestCursorProvider_NormalizeToolCall_MoreKinds(t *testing.T) {
 }
 
 func TestCursorProvider_NormalizeStreamLine(t *testing.T) {
-	p := NewCursorProvider("")
-
+	// Each test case is a single line processed in isolation; the test
+	// constructs a fresh provider per case so buffered thinking from one case
+	// doesn't leak into the next.
 	tests := []struct {
 		name     string
 		input    string
@@ -477,12 +478,15 @@ func TestCursorProvider_NormalizeStreamLine(t *testing.T) {
 			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tool_a1","name":"Await","input":{}},{"type":"tool_result","tool_use_id":"tool_a1","content":"{\"error\":\"No shell found for id 45563\"}"}]}}`,
 		},
 		{
-			name:     "thinking delta becomes assistant thinking block",
-			input:    `{"type":"thinking","subtype":"delta","text":"Let me think","session_id":"abc","timestamp_ms":1}`,
-			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"Let me think"}]}}`,
+			// Single delta with no following completed or interrupt is
+			// buffered and produces no immediate output.
+			name:    "thinking delta is buffered (no output until flush)",
+			input:   `{"type":"thinking","subtype":"delta","text":"Let me think","session_id":"abc","timestamp_ms":1}`,
+			wantNil: true,
 		},
 		{
-			name:    "thinking completed is dropped",
+			// Without any prior buffered text, completed produces nothing.
+			name:    "thinking completed with empty buffer is dropped",
 			input:   `{"type":"thinking","subtype":"completed","session_id":"abc","timestamp_ms":1}`,
 			wantNil: true,
 		},
@@ -499,18 +503,20 @@ func TestCursorProvider_NormalizeStreamLine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := p.NormalizeStreamLine([]byte(tt.input))
+			p := NewCursorProvider("")
+			results := p.NormalizeStreamLine([]byte(tt.input))
 
 			if tt.wantNil {
-				if result != nil {
-					t.Errorf("expected nil, got %s", string(result))
+				if len(results) != 0 {
+					t.Errorf("expected no output, got %d lines: %v", len(results), bytesSliceToStrings(results))
 				}
 				return
 			}
 
-			if result == nil {
-				t.Fatal("expected non-nil result")
+			if len(results) != 1 {
+				t.Fatalf("expected exactly 1 output line, got %d: %v", len(results), bytesSliceToStrings(results))
 			}
+			result := results[0]
 
 			if tt.wantJSON != "" {
 				var got, want interface{}
@@ -532,4 +538,168 @@ func TestCursorProvider_NormalizeStreamLine(t *testing.T) {
 			}
 		})
 	}
+}
+
+func bytesSliceToStrings(bs [][]byte) []string {
+	out := make([]string, len(bs))
+	for i, b := range bs {
+		out[i] = string(b)
+	}
+	return out
+}
+
+// TestCursorProvider_ThinkingBuffering covers the per-session buffering of
+// thinking/delta events introduced for issue #650: many small deltas should
+// be coalesced into a single assistant thinking message, and intervening
+// non-thinking events should cause an in-progress buffer to be flushed first
+// so ordering is preserved.
+func TestCursorProvider_ThinkingBuffering(t *testing.T) {
+	type assistantThinking struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string `json:"role"`
+			Content []struct {
+				Type     string `json:"type"`
+				Thinking string `json:"thinking"`
+			} `json:"content"`
+		} `json:"message"`
+	}
+
+	parseThinking := func(t *testing.T, raw []byte) string {
+		t.Helper()
+		var msg assistantThinking
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			t.Fatalf("failed to parse thinking message: %v\n%s", err, string(raw))
+		}
+		if msg.Type != "assistant" {
+			t.Fatalf("expected type=assistant, got %q", msg.Type)
+		}
+		if len(msg.Message.Content) != 1 || msg.Message.Content[0].Type != "thinking" {
+			t.Fatalf("expected single thinking content block, got %+v", msg.Message.Content)
+		}
+		return msg.Message.Content[0].Thinking
+	}
+
+	t.Run("multiple deltas coalesce into one assistant message on completed", func(t *testing.T) {
+		p := NewCursorProvider("")
+		inputs := []string{
+			`{"type":"thinking","subtype":"delta","text":"Hello ","session_id":"sess1"}`,
+			`{"type":"thinking","subtype":"delta","text":"world","session_id":"sess1"}`,
+			`{"type":"thinking","subtype":"delta","text":"!","session_id":"sess1"}`,
+		}
+		for _, in := range inputs {
+			if out := p.NormalizeStreamLine([]byte(in)); len(out) != 0 {
+				t.Fatalf("expected delta to be buffered (no output), got %d lines: %v", len(out), bytesSliceToStrings(out))
+			}
+		}
+
+		completed := []byte(`{"type":"thinking","subtype":"completed","session_id":"sess1"}`)
+		out := p.NormalizeStreamLine(completed)
+		if len(out) != 1 {
+			t.Fatalf("expected 1 flushed thinking message, got %d: %v", len(out), bytesSliceToStrings(out))
+		}
+		got := parseThinking(t, out[0])
+		if got != "Hello world!" {
+			t.Errorf("thinking text = %q, want %q", got, "Hello world!")
+		}
+	})
+
+	t.Run("tool_call interrupt flushes buffered thinking before tool message", func(t *testing.T) {
+		p := NewCursorProvider("")
+		// First chunk of thinking
+		buffered := []string{
+			`{"type":"thinking","subtype":"delta","text":"think1-a ","session_id":"sess1"}`,
+			`{"type":"thinking","subtype":"delta","text":"think1-b","session_id":"sess1"}`,
+		}
+		for _, in := range buffered {
+			if out := p.NormalizeStreamLine([]byte(in)); len(out) != 0 {
+				t.Fatalf("expected delta to be buffered, got %v", bytesSliceToStrings(out))
+			}
+		}
+
+		// tool_call completed should flush thinking1 first, then emit the tool message.
+		toolCompleted := []byte(`{"type":"tool_call","subtype":"completed","call_id":"tool_r1","session_id":"sess1","tool_call":{"readToolCall":{"args":{"path":"/x.md"},"result":{"success":{"content":"x"}}}}}`)
+		out := p.NormalizeStreamLine(toolCompleted)
+		if len(out) != 2 {
+			t.Fatalf("expected 2 output lines (thinking flush + tool), got %d: %v", len(out), bytesSliceToStrings(out))
+		}
+		if got := parseThinking(t, out[0]); got != "think1-a think1-b" {
+			t.Errorf("thinking flush text = %q, want %q", got, "think1-a think1-b")
+		}
+		// Second line should be the tool message (an assistant with tool_use/tool_result blocks).
+		var env struct {
+			Type    string `json:"type"`
+			Message struct {
+				Content []map[string]interface{} `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(out[1], &env); err != nil {
+			t.Fatalf("failed to parse tool message: %v\n%s", err, string(out[1]))
+		}
+		if env.Type != "assistant" || len(env.Message.Content) == 0 {
+			t.Errorf("expected assistant tool message with content, got %s", string(out[1]))
+		}
+		if got, _ := env.Message.Content[0]["type"].(string); got != "tool_use" {
+			t.Errorf("expected first block tool_use, got %q", got)
+		}
+
+		// Second chunk of thinking after the tool — should buffer fresh.
+		buffered2 := []string{
+			`{"type":"thinking","subtype":"delta","text":"think2-x ","session_id":"sess1"}`,
+			`{"type":"thinking","subtype":"delta","text":"think2-y","session_id":"sess1"}`,
+		}
+		for _, in := range buffered2 {
+			if out := p.NormalizeStreamLine([]byte(in)); len(out) != 0 {
+				t.Fatalf("expected delta to be buffered, got %v", bytesSliceToStrings(out))
+			}
+		}
+
+		completed := p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"completed","session_id":"sess1"}`))
+		if len(completed) != 1 {
+			t.Fatalf("expected 1 flushed thinking message, got %d: %v", len(completed), bytesSliceToStrings(completed))
+		}
+		if got := parseThinking(t, completed[0]); got != "think2-x think2-y" {
+			t.Errorf("second thinking text = %q, want %q", got, "think2-x think2-y")
+		}
+	})
+
+	t.Run("assistant text interrupt flushes buffered thinking first", func(t *testing.T) {
+		p := NewCursorProvider("")
+		if out := p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"delta","text":"pre","session_id":"s1"}`)); len(out) != 0 {
+			t.Fatalf("expected buffered, got %v", bytesSliceToStrings(out))
+		}
+		assistantLine := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},"session_id":"s1"}`
+		out := p.NormalizeStreamLine([]byte(assistantLine))
+		if len(out) != 2 {
+			t.Fatalf("expected thinking flush + assistant passthrough, got %d: %v", len(out), bytesSliceToStrings(out))
+		}
+		if got := parseThinking(t, out[0]); got != "pre" {
+			t.Errorf("thinking flush = %q, want %q", got, "pre")
+		}
+		if string(out[1]) != assistantLine {
+			t.Errorf("assistant line not passed through unchanged\ngot:  %s\nwant: %s", string(out[1]), assistantLine)
+		}
+	})
+
+	t.Run("buffers are isolated per session_id", func(t *testing.T) {
+		p := NewCursorProvider("")
+		_ = p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"delta","text":"A","session_id":"sA"}`))
+		_ = p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"delta","text":"B","session_id":"sB"}`))
+
+		outA := p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"completed","session_id":"sA"}`))
+		if len(outA) != 1 {
+			t.Fatalf("session A: expected 1 flushed message, got %d", len(outA))
+		}
+		if got := parseThinking(t, outA[0]); got != "A" {
+			t.Errorf("session A thinking = %q, want %q", got, "A")
+		}
+
+		outB := p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"completed","session_id":"sB"}`))
+		if len(outB) != 1 {
+			t.Fatalf("session B: expected 1 flushed message, got %d", len(outB))
+		}
+		if got := parseThinking(t, outB[0]); got != "B" {
+			t.Errorf("session B thinking = %q, want %q", got, "B")
+		}
+	})
 }

--- a/internal/session/provider_cursor_test.go
+++ b/internal/session/provider_cursor_test.go
@@ -702,4 +702,129 @@ func TestCursorProvider_ThinkingBuffering(t *testing.T) {
 			t.Errorf("session B thinking = %q, want %q", got, "B")
 		}
 	})
+
+	// Covers the edge case where a session ends without ever emitting a
+	// thinking delta: nothing is buffered, and a follow-up flush (or
+	// ResetBuffers) is a no-op.
+	t.Run("session with no thinking delta has empty buffer", func(t *testing.T) {
+		p := NewCursorProvider("")
+		// Drive a system + assistant + result pipeline without any thinking.
+		_ = p.NormalizeStreamLine([]byte(`{"type":"system","subtype":"init","session_id":"sX","model":"sonnet-4"}`))
+		_ = p.NormalizeStreamLine([]byte(`{"type":"assistant","message":{"role":"assistant","model":"sonnet-4","content":[{"type":"text","text":"ok"}]},"session_id":"sX"}`))
+		_ = p.NormalizeStreamLine([]byte(`{"type":"result","subtype":"success","is_error":false,"result":"done","session_id":"sX"}`))
+
+		p.thinkingMu.Lock()
+		_, hasBuf := p.thinkingBuffers["sX"]
+		bufCount := len(p.thinkingBuffers)
+		p.thinkingMu.Unlock()
+		if hasBuf {
+			t.Errorf("expected no thinking buffer for sX, but one exists")
+		}
+		if bufCount != 0 {
+			t.Errorf("expected no thinking buffers at all, got %d", bufCount)
+		}
+
+		// A completed event with nothing buffered should produce no output.
+		out := p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"completed","session_id":"sX"}`))
+		if len(out) != 0 {
+			t.Errorf("expected no output for completed-with-empty-buffer, got %d", len(out))
+		}
+
+		// ResetBuffers on a session that never buffered should also be a
+		// safe no-op.
+		p.ResetBuffers("sX")
+		p.thinkingMu.Lock()
+		bufCount = len(p.thinkingBuffers)
+		p.thinkingMu.Unlock()
+		if bufCount != 0 {
+			t.Errorf("expected no buffers after ResetBuffers, got %d", bufCount)
+		}
+	})
+}
+
+func TestCursorProvider_ResetBuffers(t *testing.T) {
+	t.Run("drops partially buffered thinking without emitting it", func(t *testing.T) {
+		p := NewCursorProvider("")
+
+		// Accumulate some thinking text but never reach `completed`.
+		_ = p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"delta","text":"half-","session_id":"sR"}`))
+		_ = p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"delta","text":"baked","session_id":"sR"}`))
+
+		// Sanity check: buffer is populated.
+		p.thinkingMu.Lock()
+		buf, ok := p.thinkingBuffers["sR"]
+		p.thinkingMu.Unlock()
+		if !ok || buf == nil || buf.Len() == 0 {
+			t.Fatalf("precondition: expected non-empty buffer for sR")
+		}
+
+		// Reset and verify buffer is gone.
+		p.ResetBuffers("sR")
+		p.thinkingMu.Lock()
+		_, stillThere := p.thinkingBuffers["sR"]
+		p.thinkingMu.Unlock()
+		if stillThere {
+			t.Errorf("ResetBuffers should have removed sR's buffer")
+		}
+
+		// A subsequent flush attempt produces nothing (delta dropped, not emitted).
+		out := p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"completed","session_id":"sR"}`))
+		if len(out) != 0 {
+			t.Errorf("expected no flushed output after ResetBuffers, got %d: %v", len(out), bytesSliceToStrings(out))
+		}
+
+		// And the next live event for this session must NOT carry leaked thinking text.
+		live := p.NormalizeStreamLine([]byte(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"fresh"}]},"session_id":"sR"}`))
+		if len(live) != 1 {
+			t.Fatalf("expected single passthrough output, got %d: %v", len(live), bytesSliceToStrings(live))
+		}
+		// The output should be the assistant line itself, not a thinking message.
+		if strings.Contains(string(live[0]), `"thinking"`) {
+			t.Errorf("ResetBuffers leaked thinking into live stream: %s", string(live[0]))
+		}
+	})
+
+	t.Run("only drops the targeted session", func(t *testing.T) {
+		p := NewCursorProvider("")
+
+		_ = p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"delta","text":"keep","session_id":"sKeep"}`))
+		_ = p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"delta","text":"drop","session_id":"sDrop"}`))
+
+		p.ResetBuffers("sDrop")
+
+		p.thinkingMu.Lock()
+		_, keepOK := p.thinkingBuffers["sKeep"]
+		_, dropOK := p.thinkingBuffers["sDrop"]
+		p.thinkingMu.Unlock()
+		if !keepOK {
+			t.Errorf("ResetBuffers should not have touched sKeep's buffer")
+		}
+		if dropOK {
+			t.Errorf("ResetBuffers should have removed sDrop's buffer")
+		}
+	})
+
+	t.Run("empty sessionID drops all buffers", func(t *testing.T) {
+		p := NewCursorProvider("")
+
+		_ = p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"delta","text":"a","session_id":"s1"}`))
+		_ = p.NormalizeStreamLine([]byte(`{"type":"thinking","subtype":"delta","text":"b","session_id":"s2"}`))
+
+		p.ResetBuffers("")
+
+		p.thinkingMu.Lock()
+		count := len(p.thinkingBuffers)
+		p.thinkingMu.Unlock()
+		if count != 0 {
+			t.Errorf("ResetBuffers(\"\") should drop all buffers, got %d remaining", count)
+		}
+	})
+
+	t.Run("no-op on Claude and Codex providers", func(t *testing.T) {
+		// Both should expose ResetBuffers and not panic.
+		var _ Provider = NewClaudeProvider("", "")
+		var _ Provider = NewCodexProvider("")
+		NewClaudeProvider("", "").ResetBuffers("anything")
+		NewCodexProvider("").ResetBuffers("anything")
+	})
 }


### PR DESCRIPTION
## Summary
- cursor provider の `thinking/delta` が個別の assistant メッセージとして emit され、UI 上に大量の `[thinking: ...]` 行が並んでいた問題を修正
- `Provider.NormalizeStreamLine` の戻り値を `[]byte` から `[][]byte` に変更し、cursor 内部で session_id 単位に thinking テキストをバッファリング
- `thinking/completed` または他イベント (`tool_call` / `assistant` / `result` 等) 割り込み時にバッファを 1 つの assistant thinking メッセージとして flush し、元のイベント順を維持

## 実装方針
- IF 変更ルートを採用 (`NormalizeStreamLine(line []byte) [][]byte`)。Claude / Codex は単一要素 slice を返すだけで済む
- `CursorProvider` に `map[string]*strings.Builder` を追加し、`sync.Mutex` で保護
- 割り込み時には先にバッファを flush してから当該イベントを emit するため、`tool_call` 等が thinking より前にずれて表示されることはない

## 変更ファイル
- `internal/session/provider.go` (IF 変更)
- `internal/session/provider_claude.go` / `provider_codex.go` (1要素 slice を返すよう更新)
- `internal/session/provider_cursor.go` (バッファリング実装)
- `internal/session/holder_stream.go` (呼び出し側を slice iteration へ)
- `internal/session/provider_cursor_test.go` / `provider_codex_test.go` (テスト更新 + cursor 用のバッファリングテスト追加)

## Test plan
- [x] `make build` 通過
- [x] `go test ./...` 全パス
- [x] 新規テスト: 連続 delta が 1 つの assistant メッセージに集約される
- [x] 新規テスト: `delta → tool_call/completed → delta → thinking/completed` の順で thinking1 / tool / thinking2 と展開される
- [x] 新規テスト: session_id ごとにバッファが分離される
- [ ] (任意) 実機: cursor セッションで thinking 表示が 1 つにまとまることを確認

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)