### PR TITLE
feat: 設定画面にホストマシン情報セクションを追加 (#653)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -61,6 +61,8 @@ export const api = {
   getAgmuxVersion: () =>
     request<{ version: string; commit: string; buildDate: string }>("/version"),
 
+  getHostInfo: () => request<HostInfo>("/host-info"),
+
   getSession: (id: string) => request<Session>(`/sessions/${id}`),
 
   stopSession: (id: string) =>
@@ -212,6 +214,29 @@ export interface RecentProject {
   projectPath: string;
   lastUsedAt: string;
   sessionCount: number;
+}
+
+export interface HostMachineInfo {
+  os: string;
+  arch: string;
+  kernelVersion: string;
+  hostname: string;
+  ipAddresses: string[];
+  pid: number;
+  uptime: string;
+  memoryBytes: number;
+}
+
+export interface HostProviderInfo {
+  name: string;
+  command: string;
+  available: boolean;
+}
+
+export interface HostInfo {
+  machine: HostMachineInfo;
+  providers: HostProviderInfo[];
+  skills: string[];
 }
 
 export interface CodexModel {

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useLoaderData } from "react-router-dom";
 import { api } from "../api/client";
-import type { AppConfig, RoleTemplate, PromptTemplate } from "../api/client";
+import type { AppConfig, RoleTemplate, PromptTemplate, HostInfo } from "../api/client";
 
 type ConfigUpdater = (updater: (prev: AppConfig) => AppConfig) => void;
 import { Section, Field } from "../components/ui/Section";
@@ -209,6 +209,8 @@ export function ConfigPage() {
           </div>
         )}
 
+        <HostMachineSection />
+
         <VersionInfo />
 
         <div className="pt-4">
@@ -239,6 +241,110 @@ function VersionInfo() {
       <div>Version: {info.version} ({info.commit})</div>
       <div>Build date: {info.buildDate}</div>
     </div>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (!bytes) return "-";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  return `${value.toFixed(1)} ${units[unit]}`;
+}
+
+function HostMachineSection() {
+  const [info, setInfo] = useState<HostInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.getHostInfo().then(setInfo).catch((e) => setError(String(e)));
+  }, []);
+
+  if (error) {
+    return (
+      <Section title="Host Machine">
+        <div className="text-sm text-red-500">Failed to load host info: {error}</div>
+      </Section>
+    );
+  }
+
+  if (!info) {
+    return (
+      <Section title="Host Machine">
+        <div className="text-sm text-gray-400">Loading...</div>
+      </Section>
+    );
+  }
+
+  const { machine, providers, skills } = info;
+
+  return (
+    <Section title="Host Machine">
+      <Field label="OS / Arch">
+        <span className="text-sm text-gray-800">
+          {machine.os} / {machine.arch}
+        </span>
+      </Field>
+      {machine.kernelVersion && (
+        <Field label="Kernel">
+          <span className="text-sm text-gray-800">{machine.kernelVersion}</span>
+        </Field>
+      )}
+      <Field label="Hostname">
+        <span className="text-sm text-gray-800">{machine.hostname}</span>
+      </Field>
+      <Field label="IP Addresses">
+        <span className="text-sm text-gray-800 text-right">
+          {machine.ipAddresses.length > 0 ? machine.ipAddresses.join(", ") : "-"}
+        </span>
+      </Field>
+      <Field label="Daemon PID">
+        <span className="text-sm text-gray-800">{machine.pid}</span>
+      </Field>
+      <Field label="Uptime">
+        <span className="text-sm text-gray-800">{machine.uptime}</span>
+      </Field>
+      <Field label="Memory">
+        <span className="text-sm text-gray-800">{formatBytes(machine.memoryBytes)}</span>
+      </Field>
+
+      <div className="border-t border-gray-100 pt-4">
+        <div className="text-xs font-semibold text-gray-500 mb-2">Providers</div>
+        {providers.map((p) => (
+          <Field key={p.name} label={`${p.name} (${p.command})`}>
+            <span
+              className={`text-sm font-medium ${
+                p.available ? "text-green-600" : "text-gray-400"
+              }`}
+            >
+              {p.available ? "Available" : "Not found"}
+            </span>
+          </Field>
+        ))}
+      </div>
+
+      <div className="border-t border-gray-100 pt-4">
+        <div className="text-xs font-semibold text-gray-500 mb-2">Global Skills</div>
+        {skills.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {skills.map((s) => (
+              <span
+                key={s}
+                className="text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded"
+              >
+                {s}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <div className="text-sm text-gray-400">No global skills found</div>
+        )}
+      </div>
+    </Section>
   );
 }
 

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -308,7 +308,7 @@ function HostMachineSection() {
       <Field label="Uptime">
         <span className="text-sm text-gray-800">{machine.uptime}</span>
       </Field>
-      <Field label="Memory">
+      <Field label="Daemon memory">
         <span className="text-sm text-gray-800">{formatBytes(machine.memoryBytes)}</span>
       </Field>
 

--- a/internal/server/hostinfo_test.go
+++ b/internal/server/hostinfo_test.go
@@ -1,0 +1,206 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// newTestHomeConfig points config.Load() and collectGlobalSkills() at a fresh
+// temp HOME and writes an optional ~/.agmux/config.toml with the given body.
+// The previous HOME is restored automatically via t.Cleanup.
+func newTestHomeConfig(t *testing.T, configBody string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if configBody != "" {
+		agmuxDir := filepath.Join(home, ".agmux")
+		if err := os.MkdirAll(agmuxDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(agmuxDir, "config.toml"), []byte(configBody), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return home
+}
+
+func TestGetHostInfo(t *testing.T) {
+	// Isolate HOME so provider config / skills come from a clean dir.
+	newTestHomeConfig(t, "")
+
+	s := &Server{startTime: time.Now().Add(-90 * time.Second)}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/host-info", nil)
+	rec := httptest.NewRecorder()
+
+	s.getHostInfo(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	// Decode into a generic map to assert the expected top-level keys exist.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	for _, key := range []string{"machine", "providers", "skills"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("response missing key %q; body = %s", key, rec.Body.String())
+		}
+	}
+
+	// Decode into the typed struct and sanity-check the machine fields.
+	var resp hostInfoResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode hostInfoResponse: %v", err)
+	}
+	if resp.Machine.OS != runtime.GOOS {
+		t.Errorf("machine.os = %q, want %q", resp.Machine.OS, runtime.GOOS)
+	}
+	if resp.Machine.Arch != runtime.GOARCH {
+		t.Errorf("machine.arch = %q, want %q", resp.Machine.Arch, runtime.GOARCH)
+	}
+	if resp.Machine.PID != os.Getpid() {
+		t.Errorf("machine.pid = %d, want %d", resp.Machine.PID, os.Getpid())
+	}
+	if resp.Machine.Uptime == "" {
+		t.Error("machine.uptime is empty")
+	}
+	// MemoryBytes is the daemon (Go runtime) memory usage; it must be non-zero
+	// for a running process.
+	if resp.Machine.MemoryBytes == 0 {
+		t.Error("machine.memoryBytes is zero, want daemon memory > 0")
+	}
+	if len(resp.Providers) == 0 {
+		t.Error("providers is empty, want claude/codex/cursor entries")
+	}
+	// Skills must be a non-nil slice (so it serializes as [] not null).
+	if resp.Skills == nil {
+		t.Error("skills is nil, want a (possibly empty) slice")
+	}
+}
+
+func TestCollectProviderInfo(t *testing.T) {
+	// Create a temp dir with a fake executable that LookPath can resolve, and
+	// prepend it to PATH so availability is deterministic.
+	binDir := t.TempDir()
+	fakeBin := "agmux-fake-provider"
+	fakePath := filepath.Join(binDir, fakeBin)
+	if err := os.WriteFile(fakePath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Point claude at the fake (available) binary and the others at a name that
+	// cannot resolve (unavailable).
+	missing := "agmux-definitely-missing-binary"
+	configBody := "" +
+		"[session]\n" +
+		"claude_command = \"" + fakeBin + "\"\n" +
+		"codex_command = \"" + missing + "\"\n" +
+		"cursor_command = \"" + missing + "\"\n"
+	newTestHomeConfig(t, configBody)
+
+	s := &Server{startTime: time.Now()}
+	providers := s.collectProviderInfo()
+
+	byName := make(map[string]hostProviderInfo, len(providers))
+	for _, p := range providers {
+		byName[p.Name] = p
+	}
+
+	claude, ok := byName["claude"]
+	if !ok {
+		t.Fatalf("missing claude provider in %+v", providers)
+	}
+	if claude.Command != fakeBin {
+		t.Errorf("claude command = %q, want %q", claude.Command, fakeBin)
+	}
+	if !claude.Available {
+		t.Errorf("claude should be available (resolves to %s)", fakePath)
+	}
+
+	codex, ok := byName["codex"]
+	if !ok {
+		t.Fatalf("missing codex provider in %+v", providers)
+	}
+	if codex.Available {
+		t.Errorf("codex should be unavailable (command %q does not exist)", codex.Command)
+	}
+}
+
+func TestCollectGlobalSkills(t *testing.T) {
+	home := newTestHomeConfig(t, "")
+	skillsDir := filepath.Join(home, ".claude", "skills")
+
+	// valid skill: directory containing SKILL.md
+	mustMkdir(t, filepath.Join(skillsDir, "alpha"))
+	mustWrite(t, filepath.Join(skillsDir, "alpha", "SKILL.md"), "# alpha")
+
+	mustMkdir(t, filepath.Join(skillsDir, "beta"))
+	mustWrite(t, filepath.Join(skillsDir, "beta", "SKILL.md"), "# beta")
+
+	// directory without SKILL.md should be ignored
+	mustMkdir(t, filepath.Join(skillsDir, "no-skill-md"))
+	mustWrite(t, filepath.Join(skillsDir, "no-skill-md", "README.md"), "# nope")
+
+	// a plain file at the skills root should be ignored
+	mustWrite(t, filepath.Join(skillsDir, "loose-file.md"), "# loose")
+
+	skills := collectGlobalSkills()
+
+	got := make(map[string]bool, len(skills))
+	for _, s := range skills {
+		got[s] = true
+	}
+
+	if !got["alpha"] || !got["beta"] {
+		t.Errorf("expected alpha and beta in skills, got %v", skills)
+	}
+	if got["no-skill-md"] {
+		t.Errorf("directory without SKILL.md should be excluded, got %v", skills)
+	}
+	if got["loose-file.md"] {
+		t.Errorf("loose file should be excluded, got %v", skills)
+	}
+	if len(skills) != 2 {
+		t.Errorf("expected exactly 2 skills, got %d (%v)", len(skills), skills)
+	}
+}
+
+func TestCollectGlobalSkillsMissingDir(t *testing.T) {
+	// HOME has no ~/.claude/skills at all; should return an empty (non-nil) slice.
+	newTestHomeConfig(t, "")
+
+	skills := collectGlobalSkills()
+	if skills == nil {
+		t.Fatal("skills is nil, want empty slice")
+	}
+	if len(skills) != 0 {
+		t.Errorf("expected no skills, got %v", skills)
+	}
+}
+
+func mustMkdir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1526,7 +1526,10 @@ type hostMachineInfo struct {
 	IPAddresses   []string `json:"ipAddresses"`
 	PID           int      `json:"pid"`
 	Uptime        string   `json:"uptime"`
-	MemoryBytes   uint64   `json:"memoryBytes"`
+	// MemoryBytes is the memory used by the agmux daemon (Go runtime) process,
+	// taken from runtime.MemStats.Sys. It is NOT the host's total physical
+	// memory; the frontend labels it as "Daemon memory" to avoid confusion.
+	MemoryBytes uint64 `json:"memoryBytes"`
 }
 
 type hostProviderInfo struct {
@@ -1552,6 +1555,8 @@ func (s *Server) collectMachineInfo() hostMachineInfo {
 		hostname = "unknown"
 	}
 
+	// memStats reports memory used by this agmux daemon (Go runtime) process,
+	// not the host's total physical memory.
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 
@@ -1563,7 +1568,8 @@ func (s *Server) collectMachineInfo() hostMachineInfo {
 		IPAddresses:   localIPAddresses(),
 		PID:           os.Getpid(),
 		Uptime:        time.Since(s.startTime).Round(time.Second).String(),
-		MemoryBytes:   memStats.Sys,
+		// Daemon (Go runtime) memory usage, not host physical memory.
+		MemoryBytes: memStats.Sys,
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -43,6 +44,7 @@ type Server struct {
 	version          string
 	commit           string
 	buildDate        string
+	startTime        time.Time
 }
 
 func New(sessions session.SessionService, hub *Hub, devMode bool, logger *slog.Logger, sqlDB *sql.DB, port int) *Server {
@@ -59,6 +61,7 @@ func New(sessions session.SessionService, hub *Hub, devMode bool, logger *slog.L
 		otelReceiver:     otel.NewReceiver(sqlDB, logger),
 		sqlDB:            sqlDB,
 		externalDetector: extDetector,
+		startTime:        time.Now(),
 	}
 
 	// Wire real-time stream updates via WebSocket
@@ -171,6 +174,7 @@ func (s *Server) setupRoutes() {
 		r.Get("/metrics/summary", s.getMetricsSummary)
 		r.Get("/metrics/events", s.getMetricsEvents)
 		r.Get("/version", s.getVersion)
+		r.Get("/host-info", s.getHostInfo)
 
 	})
 
@@ -1505,6 +1509,153 @@ func (s *Server) getCodexVersion(w http.ResponseWriter, r *http.Request) {
 	}
 	version := strings.TrimSpace(string(out))
 	writeJSON(w, http.StatusOK, map[string]string{"version": version})
+}
+
+// hostInfoResponse is the payload for GET /api/host-info.
+type hostInfoResponse struct {
+	Machine   hostMachineInfo    `json:"machine"`
+	Providers []hostProviderInfo `json:"providers"`
+	Skills    []string           `json:"skills"`
+}
+
+type hostMachineInfo struct {
+	OS            string   `json:"os"`
+	Arch          string   `json:"arch"`
+	KernelVersion string   `json:"kernelVersion"`
+	Hostname      string   `json:"hostname"`
+	IPAddresses   []string `json:"ipAddresses"`
+	PID           int      `json:"pid"`
+	Uptime        string   `json:"uptime"`
+	MemoryBytes   uint64   `json:"memoryBytes"`
+}
+
+type hostProviderInfo struct {
+	Name      string `json:"name"`
+	Command   string `json:"command"`
+	Available bool   `json:"available"`
+}
+
+// getHostInfo returns information about the host machine, registered providers
+// and global skills. It is a one-shot snapshot (no live updates).
+func (s *Server) getHostInfo(w http.ResponseWriter, r *http.Request) {
+	resp := hostInfoResponse{
+		Machine:   s.collectMachineInfo(),
+		Providers: s.collectProviderInfo(),
+		Skills:    collectGlobalSkills(),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) collectMachineInfo() hostMachineInfo {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+
+	return hostMachineInfo{
+		OS:            runtime.GOOS,
+		Arch:          runtime.GOARCH,
+		KernelVersion: kernelVersion(),
+		Hostname:      hostname,
+		IPAddresses:   localIPAddresses(),
+		PID:           os.Getpid(),
+		Uptime:        time.Since(s.startTime).Round(time.Second).String(),
+		MemoryBytes:   memStats.Sys,
+	}
+}
+
+// kernelVersion returns the OS kernel version via "uname -r".
+func kernelVersion() string {
+	out, err := exec.Command("uname", "-r").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// localIPAddresses returns the host's non-link-local unicast IPv4/IPv6
+// addresses (including loopback) as strings.
+func localIPAddresses() []string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return []string{}
+	}
+	result := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		ip := ipNet.IP
+		if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			continue
+		}
+		result = append(result, ip.String())
+	}
+	return result
+}
+
+func (s *Server) collectProviderInfo() []hostProviderInfo {
+	cfg, err := config.Load()
+	if err != nil {
+		cfg = config.Default()
+	}
+
+	defaults := config.Default().Session
+	resolve := func(configured, fallback string) string {
+		if strings.TrimSpace(configured) != "" {
+			return configured
+		}
+		return fallback
+	}
+
+	specs := []struct {
+		name string
+		cmd  string
+	}{
+		{"claude", resolve(cfg.Session.ClaudeCommand, defaults.ClaudeCommand)},
+		{"codex", resolve(cfg.Session.CodexCommand, defaults.CodexCommand)},
+		{"cursor", resolve(cfg.Session.CursorCommand, defaults.CursorCommand)},
+	}
+
+	providers := make([]hostProviderInfo, 0, len(specs))
+	for _, spec := range specs {
+		_, lookErr := exec.LookPath(spec.cmd)
+		providers = append(providers, hostProviderInfo{
+			Name:      spec.name,
+			Command:   spec.cmd,
+			Available: lookErr == nil,
+		})
+	}
+	return providers
+}
+
+// collectGlobalSkills lists global skills under ~/.claude/skills/ (directories
+// that contain a SKILL.md file).
+func collectGlobalSkills() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return []string{}
+	}
+	skillsDir := filepath.Join(home, ".claude", "skills")
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return []string{}
+	}
+	skills := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, statErr := os.Stat(filepath.Join(skillsDir, entry.Name(), "SKILL.md")); statErr != nil {
+			continue
+		}
+		skills = append(skills, entry.Name())
+	}
+	return skills
 }
 
 // helpers


### PR DESCRIPTION
## 概要
設定画面 (`ConfigPage`) に "Host Machine" セクションを追加し、ページ表示時に1度だけ取得したホスト情報を read-only 表示する。定期更新はしない。

## 表示項目
1. **マシン情報**: OS / Arch、kernel version (`uname -r`)、hostname、IP addresses (loopback / LAN)、daemon プロセス情報 (PID, uptime, memory)
2. **登録 provider**: claude / codex / cursor の available 判定 (config の command + `exec.LookPath`)
3. **global skills**: `~/.claude/skills/` 配下で `SKILL.md` を持つディレクトリ一覧

## 実装
**バックエンド** (`internal/server/server.go`):
- `GET /api/host-info` を追加
- `Server` 構造体に `startTime` を追加し uptime を算出
- memory は `runtime.MemStats.Sys`

**フロントエンド**:
- `api/client.ts` に `getHostInfo` と型定義を追加
- `ConfigPage.tsx` に `HostMachineSection` コンポーネントを追加

## 確認
- `make build` 成功 (frontend + Go)
- `make test` 成功 (既存テスト維持)

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)