### PR TITLE
fix: holder 再接続後に daemon の readLoop が live イベントを受信できない問題を修正

### DIFF
--- a/internal/session/holder.go
+++ b/internal/session/holder.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -34,9 +35,10 @@ func SocketPath(sessionID string) string {
 type HolderControlMessage struct {
 	Type    string `json:"type"`
 	Action  string `json:"action,omitempty"`  // server → holder: "stop", "restart"
-	Event   string `json:"event,omitempty"`   // holder → server: "exited"
-	Code    int    `json:"code,omitempty"`     // exit code
+	Event   string `json:"event,omitempty"`   // holder → server: "exited", "hello"
+	Code    int    `json:"code,omitempty"`    // exit code
 	Content string `json:"content,omitempty"` // message content
+	PID     int    `json:"pid,omitempty"`     // holder → server: holder's own PID (for hello)
 }
 
 // RunHolder is the main entry point for the holder subprocess.
@@ -268,6 +270,30 @@ func (h *holder) acceptLoop() {
 
 		slog.Info("holder: client connected", "sessionId", h.sessionID)
 
+		// Immediately send a hello so the client can verify it connected to
+		// the expected holder (i.e. not to a previous holder that was about to
+		// exit on the same socket path). The PID lets the client detect the
+		// race window where the old listener is still alive while the new
+		// one is being spawned with the same socket path.
+		hello, err := json.Marshal(HolderControlMessage{
+			Type:  "control",
+			Event: "hello",
+			PID:   os.Getpid(),
+		})
+		if err == nil {
+			conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			if _, werr := fmt.Fprintf(conn, "%s\n", hello); werr != nil {
+				slog.Debug("holder: failed to write hello to client, removing", "error", werr, "sessionId", h.sessionID)
+				h.clientsMu.Lock()
+				delete(h.clients, conn)
+				h.clientsMu.Unlock()
+				conn.Close()
+				continue
+			}
+			// Reset write deadline so subsequent broadcasts use their own deadlines.
+			conn.SetWriteDeadline(time.Time{})
+		}
+
 		// Handle incoming messages from this client
 		go h.handleClient(conn)
 	}
@@ -375,6 +401,12 @@ func SpawnHolder(sessionID string, cmdArgs []string, projectPath string, env []s
 
 // ConnectToHolder connects to a holder's Unix socket and returns the connection.
 // It retries for a short period to allow the holder time to start listening.
+//
+// Deprecated: prefer ConnectToHolderExpectingPID when the expected holder PID
+// is known. Plain ConnectToHolder can race with a previous holder whose
+// listener is still alive on the same socket path during its shutdown window
+// (see #656). Returned conn does NOT consume the leading hello control message,
+// so the caller's readLoop will see it as the first line on the socket.
 func ConnectToHolder(sessionID string) (net.Conn, error) {
 	sockPath := SocketPath(sessionID)
 
@@ -388,6 +420,134 @@ func ConnectToHolder(sessionID string) (net.Conn, error) {
 		time.Sleep(100 * time.Millisecond)
 	}
 	return nil, fmt.Errorf("connect to holder socket %s: %w", sockPath, err)
+}
+
+// ConnectToHolderExpectingPID dials the holder's socket and reads the leading
+// hello control message to confirm we connected to the holder whose PID is
+// expectedPID. If the dial lands on a different (e.g. previous) holder, the
+// connection is closed and the dial is retried. This eliminates the race
+// described in #656 where the daemon connected to a dying old holder during
+// the small shutdown window where its listener was still bound to the shared
+// socket path.
+//
+// If expectedPID is 0, the function accepts the first holder that responds
+// with a hello (no PID match required).
+//
+// Backward compatibility: if a connection succeeds but no hello arrives within
+// the read deadline (because the holder pre-dates the hello protocol added in
+// #656), the connection is returned as-is. This lets the daemon recover
+// connections to long-lived holders started by an older agmux binary.
+//
+// The hello message, when present, is consumed from the connection: callers
+// should NOT see it in their subsequent reads.
+func ConnectToHolderExpectingPID(sessionID string, expectedPID int) (net.Conn, error) {
+	sockPath := SocketPath(sessionID)
+
+	deadline := time.Now().Add(15 * time.Second)
+	var lastErr error
+	mismatchAttempts := 0
+	for time.Now().Before(deadline) {
+		conn, err := net.Dial("unix", sockPath)
+		if err != nil {
+			lastErr = err
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		// Read the hello message byte-by-byte until newline so we do NOT
+		// over-read into the caller's subsequent stream (which they will
+		// read via their own bufio.Reader on the same conn). Use a short
+		// read deadline so a stuck or dead-but-still-bound socket doesn't
+		// block us forever.
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		line, rerr := readLineFromConn(conn, 4096)
+		_ = conn.SetReadDeadline(time.Time{})
+
+		if rerr != nil {
+			// Read timeout or EOF before hello. Two cases:
+			// 1) Pre-hello holder (older binary): no hello will ever come.
+			//    Best-effort: return the conn so the daemon can still receive
+			//    broadcast events.
+			// 2) Newly spawned holder that hasn't accepted yet, or dying old
+			//    holder whose conn is broken. Retry.
+			// We discriminate by errno: io.EOF or "connection reset" means
+			// the conn is dead; timeout means the holder is silent (likely
+			// pre-hello).
+			if isReadTimeout(rerr) {
+				slog.Warn("holder: no hello received within deadline; assuming pre-hello holder",
+					"sessionId", sessionID, "expected_pid", expectedPID)
+				return conn, nil
+			}
+			conn.Close()
+			lastErr = fmt.Errorf("read hello: %w", rerr)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		var msg HolderControlMessage
+		if err := json.Unmarshal([]byte(strings.TrimRight(line, "\n")), &msg); err != nil || msg.Type != "control" || msg.Event != "hello" {
+			// First line wasn't a hello — could be a stale broadcast from a
+			// pre-hello holder. Best-effort: log and return the conn so the
+			// caller still gets subsequent broadcasts. The caller's readLoop
+			// will skip non-event lines.
+			slog.Warn("holder: first line was not hello; assuming pre-hello holder",
+				"sessionId", sessionID, "line", line)
+			return conn, nil
+		}
+
+		if expectedPID > 0 && msg.PID != expectedPID {
+			// We dialed an old (or unexpected) holder. Close and retry —
+			// the old one is shutting down on the same socket path; subsequent
+			// dials will eventually land on the new listener.
+			mismatchAttempts++
+			slog.Info("holder: hello PID mismatch, retrying", "sessionId", sessionID, "expected", expectedPID, "got", msg.PID, "attempt", mismatchAttempts)
+			conn.Close()
+			lastErr = fmt.Errorf("hello pid %d != expected %d", msg.PID, expectedPID)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+
+		return conn, nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("timeout")
+	}
+	return nil, fmt.Errorf("connect to holder socket %s expecting pid %d: %w", sockPath, expectedPID, lastErr)
+}
+
+// isReadTimeout reports whether err is a net.Conn read deadline / timeout.
+func isReadTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		return true
+	}
+	return false
+}
+
+// readLineFromConn reads bytes from conn one at a time until it hits '\n' or
+// the line exceeds maxBytes. Used during the hello handshake to avoid the
+// over-read problem that a bufio.Reader would cause (any bytes the bufio
+// reader pulled in past the hello newline would be invisible to the caller's
+// own bufio.Reader on the same conn).
+func readLineFromConn(conn net.Conn, maxBytes int) (string, error) {
+	buf := make([]byte, 0, 256)
+	one := make([]byte, 1)
+	for len(buf) < maxBytes {
+		n, err := conn.Read(one)
+		if err != nil {
+			return string(buf), err
+		}
+		if n == 0 {
+			continue
+		}
+		if one[0] == '\n' {
+			return string(buf), nil
+		}
+		buf = append(buf, one[0])
+	}
+	return string(buf), fmt.Errorf("line exceeded %d bytes", maxBytes)
 }
 
 // IsHolderAlive checks if a holder process with the given PID is still running.

--- a/internal/session/holder.go
+++ b/internal/session/holder.go
@@ -434,9 +434,15 @@ func ConnectToHolder(sessionID string) (net.Conn, error) {
 // with a hello (no PID match required).
 //
 // Backward compatibility: if a connection succeeds but no hello arrives within
-// the read deadline (because the holder pre-dates the hello protocol added in
-// #656), the connection is returned as-is. This lets the daemon recover
-// connections to long-lived holders started by an older agmux binary.
+// the read deadline AND expectedPID == 0 (recover path), the connection is
+// returned as-is. This lets the daemon recover connections to long-lived
+// holders started by an older agmux binary that does not speak hello.
+//
+// When expectedPID > 0 (spawn/restart path), a hello timeout is treated as a
+// hard error: the holder we just spawned must be from the current binary and
+// therefore must send hello. Falling back silently in that case would re-open
+// the very race window #656 fixes (we could end up trusting a dying old
+// listener that happens to share the socket path).
 //
 // The hello message, when present, is consumed from the connection: callers
 // should NOT see it in their subsequent reads.
@@ -467,16 +473,32 @@ func ConnectToHolderExpectingPID(sessionID string, expectedPID int) (net.Conn, e
 			// Read timeout or EOF before hello. Two cases:
 			// 1) Pre-hello holder (older binary): no hello will ever come.
 			//    Best-effort: return the conn so the daemon can still receive
-			//    broadcast events.
+			//    broadcast events. Only safe when expectedPID == 0 (i.e. the
+			//    recover path where we don't know which binary spawned the
+			//    holder). For new spawn / restart paths we know the holder
+			//    binary is current and must speak hello — silently falling
+			//    back there would mask the very race #656 is trying to fix.
 			// 2) Newly spawned holder that hasn't accepted yet, or dying old
 			//    holder whose conn is broken. Retry.
 			// We discriminate by errno: io.EOF or "connection reset" means
 			// the conn is dead; timeout means the holder is silent (likely
 			// pre-hello).
 			if isReadTimeout(rerr) {
-				slog.Warn("holder: no hello received within deadline; assuming pre-hello holder",
-					"sessionId", sessionID, "expected_pid", expectedPID)
-				return conn, nil
+				if expectedPID == 0 {
+					slog.Warn("holder: no hello received within deadline; assuming pre-hello holder",
+						"sessionId", sessionID, "expected_pid", expectedPID)
+					return conn, nil
+				}
+				// expectedPID > 0: the holder we want is from the current
+				// binary, which must send hello. A timeout here is a real
+				// failure (likely the accept goroutine of the new holder is
+				// briefly stuck, or we somehow landed on a dying old holder
+				// that no longer responds). Fail fast instead of silently
+				// regressing into the pre-fix race window.
+				conn.Close()
+				lastErr = fmt.Errorf("hello timeout from holder (expected pid %d)", expectedPID)
+				time.Sleep(100 * time.Millisecond)
+				continue
 			}
 			conn.Close()
 			lastErr = fmt.Errorf("read hello: %w", rerr)
@@ -487,12 +509,19 @@ func ConnectToHolderExpectingPID(sessionID string, expectedPID int) (net.Conn, e
 		var msg HolderControlMessage
 		if err := json.Unmarshal([]byte(strings.TrimRight(line, "\n")), &msg); err != nil || msg.Type != "control" || msg.Event != "hello" {
 			// First line wasn't a hello — could be a stale broadcast from a
-			// pre-hello holder. Best-effort: log and return the conn so the
-			// caller still gets subsequent broadcasts. The caller's readLoop
-			// will skip non-event lines.
-			slog.Warn("holder: first line was not hello; assuming pre-hello holder",
-				"sessionId", sessionID, "line", line)
-			return conn, nil
+			// pre-hello holder. Same logic as the timeout branch: only treat
+			// this as a pre-hello fallback on the recover path (expectedPID
+			// == 0). On spawn/restart, force a retry so we don't trust a
+			// connection that doesn't start with a verifiable hello.
+			if expectedPID == 0 {
+				slog.Warn("holder: first line was not hello; assuming pre-hello holder",
+					"sessionId", sessionID, "line", line)
+				return conn, nil
+			}
+			conn.Close()
+			lastErr = fmt.Errorf("hello malformed from holder (expected pid %d): %q", expectedPID, line)
+			time.Sleep(100 * time.Millisecond)
+			continue
 		}
 
 		if expectedPID > 0 && msg.PID != expectedPID {

--- a/internal/session/holder_hello_test.go
+++ b/internal/session/holder_hello_test.go
@@ -1,0 +1,317 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Regression tests for #656: the daemon used to race the old holder's
+// 100ms shutdown window when restartForCodex or recover called ConnectToHolder
+// on the same socket path, sometimes binding to the dying old listener and
+// then silently losing all events from the new holder.
+//
+// The fix is a hello handshake: every holder writes a control message with
+// its own PID immediately after accept, and the daemon verifies the PID
+// before trusting the connection.
+
+// shortTempDir returns a short-enough tmpdir so that
+// $TMPDIR/agmux/socks/<sessionID>.sock stays under the macOS 104-byte unix
+// socket path limit. t.TempDir() returns ~80 bytes which is too long once
+// the socket suffix is appended.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "agmtest-")
+	if err != nil {
+		t.Fatalf("mktemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// fakeHolderServer is a minimal listener that mimics RunHolder's accept
+// behavior for tests. It writes a configurable hello on accept and then
+// optionally broadcasts canned events.
+type fakeHolderServer struct {
+	listener   net.Listener
+	pid        int
+	acceptCh   chan net.Conn
+	wantClosed atomic.Bool
+}
+
+func newFakeHolderServer(t *testing.T, sessionID string, pid int) *fakeHolderServer {
+	t.Helper()
+	if err := os.MkdirAll(SocketDir(), 0o700); err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+	sockPath := SocketPath(sessionID)
+	_ = os.Remove(sockPath)
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &fakeHolderServer{
+		listener: l,
+		pid:      pid,
+		acceptCh: make(chan net.Conn, 4),
+	}
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			// Mimic holder.go acceptLoop: send hello first.
+			hello, _ := json.Marshal(HolderControlMessage{
+				Type:  "control",
+				Event: "hello",
+				PID:   srv.pid,
+			})
+			_, _ = fmt.Fprintf(conn, "%s\n", hello)
+			srv.acceptCh <- conn
+		}
+	}()
+	return srv
+}
+
+func (s *fakeHolderServer) close() {
+	s.wantClosed.Store(true)
+	_ = s.listener.Close()
+}
+
+// TestConnectToHolderExpectingPID_MatchingPID verifies the happy path: the
+// holder sends a hello with the expected PID and the connection is returned.
+func TestConnectToHolderExpectingPID_MatchingPID(t *testing.T) {
+	t.Setenv("TMPDIR", shortTempDir(t))
+
+	sessionID := "match-pid"
+	srv := newFakeHolderServer(t, sessionID, 4242)
+	defer srv.close()
+
+	conn, err := ConnectToHolderExpectingPID(sessionID, 4242)
+	if err != nil {
+		t.Fatalf("ConnectToHolderExpectingPID: %v", err)
+	}
+	defer conn.Close()
+}
+
+// TestConnectToHolderExpectingPID_MismatchedPID_Retries verifies that when
+// the first accepted connection responds with the wrong PID (simulating the
+// race in #656 where the dying old holder accepts our dial), the function
+// closes that conn and retries until it lands on a holder whose PID matches.
+//
+// We swap the underlying server out partway through to simulate the takeover.
+func TestConnectToHolderExpectingPID_MismatchedPID_Retries(t *testing.T) {
+	t.Setenv("TMPDIR", shortTempDir(t))
+
+	sessionID := "mismatch-then-match"
+	// First server reports the WRONG PID (simulating the dying old holder).
+	srv1 := newFakeHolderServer(t, sessionID, 1111)
+
+	// In a goroutine, after a short delay, kill srv1 and start srv2 with
+	// the EXPECTED PID. This simulates the new holder taking over the
+	// socket path.
+	const expectedPID = 9999
+	const swapAfter = 250 * time.Millisecond
+	go func() {
+		time.Sleep(swapAfter)
+		srv1.close()
+		// Recreate the listener with the expected PID.
+		_ = newFakeHolderServer(t, sessionID, expectedPID)
+	}()
+
+	start := time.Now()
+	conn, err := ConnectToHolderExpectingPID(sessionID, expectedPID)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("ConnectToHolderExpectingPID: %v", err)
+	}
+	defer conn.Close()
+
+	// Sanity: the function should have retried until srv2 was ready, so
+	// elapsed must be at least swapAfter. If it returned earlier the PID
+	// check is not enforced.
+	if elapsed < swapAfter {
+		t.Errorf("returned in %v, but expected >= %v (swap time) — PID check may not be enforced", elapsed, swapAfter)
+	}
+}
+
+// TestConnectToHolderExpectingPID_ZeroPID_AcceptsAny verifies that passing
+// expectedPID=0 accepts any holder that sends a hello.
+func TestConnectToHolderExpectingPID_ZeroPID_AcceptsAny(t *testing.T) {
+	t.Setenv("TMPDIR", shortTempDir(t))
+
+	sessionID := "zero-pid"
+	srv := newFakeHolderServer(t, sessionID, 7777)
+	defer srv.close()
+
+	conn, err := ConnectToHolderExpectingPID(sessionID, 0)
+	if err != nil {
+		t.Fatalf("ConnectToHolderExpectingPID(0): %v", err)
+	}
+	defer conn.Close()
+}
+
+// TestConnectToHolderExpectingPID_PreHelloHolder_FallsBack verifies backward
+// compat: if the holder is an older binary that never sends a hello (silent
+// after accept), the function eventually returns the connection so the
+// daemon can still receive subsequent broadcasts. The fallback uses the
+// short read deadline to detect the silent peer.
+func TestConnectToHolderExpectingPID_PreHelloHolder_FallsBack(t *testing.T) {
+	t.Setenv("TMPDIR", shortTempDir(t))
+
+	sessionID := "pre-hello"
+	if err := os.MkdirAll(SocketDir(), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sockPath := SocketPath(sessionID)
+	_ = os.Remove(sockPath)
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+
+	// Accept connections but never write anything (simulating old holder).
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the conn open; the test will close it via the deferred close.
+			_ = c
+		}
+	}()
+
+	start := time.Now()
+	conn, err := ConnectToHolderExpectingPID(sessionID, 1234)
+	if err != nil {
+		t.Fatalf("expected fallback success, got error: %v", err)
+	}
+	defer conn.Close()
+
+	elapsed := time.Since(start)
+	if elapsed < 2*time.Second {
+		t.Errorf("fallback returned too quickly (%v); expected >= ~2s read deadline", elapsed)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("fallback took too long (%v); deadline should be ~2s + a bit", elapsed)
+	}
+}
+
+// TestHolderHelloProtocol_NoOverReadIntoSubsequentBroadcast simulates the
+// real race condition: a fake holder sends hello and then immediately
+// broadcasts a JSONL event. The daemon must consume only the hello and the
+// next reader on the conn must see the event intact (no bytes lost).
+//
+// This regression test guards against using bufio.Reader inside the hello
+// handshake — bufio.Reader would over-read past the newline and stash bytes
+// in its private buffer that the caller's own bufio.Reader would never see,
+// silently dropping the first broadcast event.
+func TestHolderHelloProtocol_NoOverReadIntoSubsequentBroadcast(t *testing.T) {
+	t.Setenv("TMPDIR", shortTempDir(t))
+
+	sessionID := "no-over-read"
+	if err := os.MkdirAll(SocketDir(), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sockPath := SocketPath(sessionID)
+	_ = os.Remove(sockPath)
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+
+	const pid = 5555
+	const firstEvent = `{"type":"system","subtype":"init","session_id":"abc","model":"test-model"}`
+
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			return
+		}
+		// Send hello immediately followed by an event in a single write,
+		// maximizing the chance of over-read on the consumer side.
+		hello, _ := json.Marshal(HolderControlMessage{
+			Type:  "control",
+			Event: "hello",
+			PID:   pid,
+		})
+		_, _ = fmt.Fprintf(conn, "%s\n%s\n", hello, firstEvent)
+	}()
+
+	conn, err := ConnectToHolderExpectingPID(sessionID, pid)
+	if err != nil {
+		t.Fatalf("ConnectToHolderExpectingPID: %v", err)
+	}
+	defer conn.Close()
+
+	// Read a single line from the conn using the same mechanism the readLoop
+	// uses (bufio.NewReader). The next line MUST be the firstEvent.
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	got, err := readLineFromConn(conn, 8192)
+	if err != nil {
+		t.Fatalf("read next line: %v", err)
+	}
+	if got != firstEvent {
+		t.Errorf("first post-hello line = %q, want %q (over-read regression)", got, firstEvent)
+	}
+}
+
+// TestReadLineFromConn_StopsAtNewline ensures the helper does not over-read
+// past the first newline. This is the core invariant the hello handshake
+// depends on.
+func TestReadLineFromConn_StopsAtNewline(t *testing.T) {
+	// Set up a unix socketpair so we can write known bytes and read via
+	// our helper.
+	dir := shortTempDir(t)
+	sockPath := filepath.Join(dir, "tln.sock")
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+
+	const first = `{"hello":"world"}`
+	const second = `{"more":"data"}`
+
+	go func() {
+		c, err := l.Accept()
+		if err != nil {
+			return
+		}
+		_, _ = fmt.Fprintf(c, "%s\n%s\n", first, second)
+		// Keep c open until test finishes to avoid EOF affecting the second read.
+		time.Sleep(2 * time.Second)
+		_ = c.Close()
+	}()
+
+	c, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	got1, err := readLineFromConn(c, 4096)
+	if err != nil {
+		t.Fatalf("read first: %v", err)
+	}
+	if got1 != first {
+		t.Errorf("first = %q, want %q", got1, first)
+	}
+
+	got2, err := readLineFromConn(c, 4096)
+	if err != nil {
+		t.Fatalf("read second: %v", err)
+	}
+	if got2 != second {
+		t.Errorf("second = %q, want %q (helper over-read past first newline)", got2, second)
+	}
+}

--- a/internal/session/holder_hello_test.go
+++ b/internal/session/holder_hello_test.go
@@ -158,10 +158,15 @@ func TestConnectToHolderExpectingPID_ZeroPID_AcceptsAny(t *testing.T) {
 }
 
 // TestConnectToHolderExpectingPID_PreHelloHolder_FallsBack verifies backward
-// compat: if the holder is an older binary that never sends a hello (silent
-// after accept), the function eventually returns the connection so the
-// daemon can still receive subsequent broadcasts. The fallback uses the
-// short read deadline to detect the silent peer.
+// compat on the recover path (expectedPID == 0): if the holder is an older
+// binary that never sends a hello (silent after accept), the function
+// eventually returns the connection so the daemon can still receive
+// subsequent broadcasts. The fallback uses the short read deadline to
+// detect the silent peer.
+//
+// Important: fallback is only valid when expectedPID == 0. The spawn /
+// restart path (expectedPID > 0) intentionally does NOT fall back — see
+// TestConnectToHolderExpectingPID_NoFallbackWhenPIDExpected.
 func TestConnectToHolderExpectingPID_PreHelloHolder_FallsBack(t *testing.T) {
 	t.Setenv("TMPDIR", shortTempDir(t))
 
@@ -190,9 +195,10 @@ func TestConnectToHolderExpectingPID_PreHelloHolder_FallsBack(t *testing.T) {
 	}()
 
 	start := time.Now()
-	conn, err := ConnectToHolderExpectingPID(sessionID, 1234)
+	// expectedPID == 0 = recover path: fallback is allowed.
+	conn, err := ConnectToHolderExpectingPID(sessionID, 0)
 	if err != nil {
-		t.Fatalf("expected fallback success, got error: %v", err)
+		t.Fatalf("expected fallback success on recover path, got error: %v", err)
 	}
 	defer conn.Close()
 
@@ -262,6 +268,107 @@ func TestHolderHelloProtocol_NoOverReadIntoSubsequentBroadcast(t *testing.T) {
 	}
 	if got != firstEvent {
 		t.Errorf("first post-hello line = %q, want %q (over-read regression)", got, firstEvent)
+	}
+}
+
+// TestConnectToHolderExpectingPID_NoFallbackWhenPIDExpected verifies that
+// when expectedPID > 0 (= spawn or restart path), the function does NOT fall
+// back to "assume pre-hello holder" if the hello never arrives. Falling back
+// in that case would silently re-open the very race window #656 fixes.
+//
+// We simulate a silent holder (accepts but never writes) and assert that
+// ConnectToHolderExpectingPID returns an error before the overall 15s
+// deadline expires (it should keep retrying on each accept and eventually
+// time out).
+func TestConnectToHolderExpectingPID_NoFallbackWhenPIDExpected(t *testing.T) {
+	t.Setenv("TMPDIR", shortTempDir(t))
+
+	sessionID := "no-fallback-when-pid-expected"
+	if err := os.MkdirAll(SocketDir(), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sockPath := SocketPath(sessionID)
+	_ = os.Remove(sockPath)
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+
+	// Accept connections but never write anything (simulates a stuck/silent
+	// or dying old holder that won't speak the hello protocol).
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			_ = c // hold open
+		}
+	}()
+
+	// Use a short overall deadline by capping with t.Deadline if any; here we
+	// just rely on the function's internal 15s deadline. To keep CI fast we
+	// abort the test if it doesn't return within 20s.
+	done := make(chan error, 1)
+	go func() {
+		_, e := ConnectToHolderExpectingPID(sessionID, 4242)
+		done <- e
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("expected error when expectedPID>0 and no hello arrives, got nil (silent fallback regression)")
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatalf("ConnectToHolderExpectingPID did not return within 20s")
+	}
+}
+
+// TestConnectToHolderExpectingPID_NoFallbackOnMalformedHello verifies that
+// a malformed (non-hello) first line is also NOT silently accepted when
+// expectedPID > 0. This mirrors the timeout case above.
+func TestConnectToHolderExpectingPID_NoFallbackOnMalformedHello(t *testing.T) {
+	t.Setenv("TMPDIR", shortTempDir(t))
+
+	sessionID := "no-fallback-on-malformed"
+	if err := os.MkdirAll(SocketDir(), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sockPath := SocketPath(sessionID)
+	_ = os.Remove(sockPath)
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+
+	// Accept and write a non-hello line (e.g. a stale broadcast).
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			_, _ = fmt.Fprintln(c, `{"type":"system","subtype":"init"}`)
+			// hold the conn open so we don't get EOF before our read
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, e := ConnectToHolderExpectingPID(sessionID, 5555)
+		done <- e
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("expected error when expectedPID>0 and first line is not hello, got nil")
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatalf("ConnectToHolderExpectingPID did not return within 20s")
 	}
 }
 

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/myuon/agmux/internal/db"
@@ -150,9 +151,16 @@ func StartHolderStreamProcess(opts StreamOpts, provider Provider) (*HolderStream
 		return nil, fmt.Errorf("spawn holder: %w", err)
 	}
 
-	// Connect to the holder's socket
-	conn, err := ConnectToHolder(opts.SessionID)
+	// Connect to the holder's socket, verifying via hello handshake that we
+	// connected to the holder we just spawned (not a previous holder still
+	// shutting down on the same socket path). See #656.
+	conn, err := ConnectToHolderExpectingPID(opts.SessionID, pid)
 	if err != nil {
+		// Kill the orphaned holder so it does not silently process the
+		// prompt with no daemon listening, leaving the session stuck.
+		if p, ferr := os.FindProcess(pid); ferr == nil {
+			_ = p.Signal(syscall.SIGTERM)
+		}
 		return nil, fmt.Errorf("connect to holder: %w", err)
 	}
 
@@ -180,7 +188,10 @@ func ReconnectHolderStreamProcess(opts StreamOpts, provider Provider, holderPID 
 		return nil, fmt.Errorf("holder process %d is not alive", holderPID)
 	}
 
-	conn, err := ConnectToHolder(opts.SessionID)
+	// Verify hello handshake matches the expected holder PID. This prevents
+	// the daemon from binding to a stale socket bound by a previous holder
+	// that happens to share the path (see #656).
+	conn, err := ConnectToHolderExpectingPID(opts.SessionID, holderPID)
 	if err != nil {
 		return nil, fmt.Errorf("reconnect to holder: %w", err)
 	}
@@ -707,8 +718,18 @@ func (sp *HolderStreamProcess) restartForCodex(message, cliSessionID string) err
 		return fmt.Errorf("spawn holder for codex resume: %w", err)
 	}
 
-	conn, err := ConnectToHolder(opts.SessionID)
+	// Verify hello-PID matches the just-spawned holder. The old holder may
+	// still be alive on the same socket path during its 100ms shutdown
+	// window after broadcasting "exited" — without this check the daemon
+	// would silently connect to the dying old holder and never receive any
+	// events from the new one. See #656.
+	conn, err := ConnectToHolderExpectingPID(opts.SessionID, pid)
 	if err != nil {
+		// Kill the orphaned holder so it does not silently process the
+		// prompt with no daemon listening, leaving the session stuck.
+		if p, ferr := os.FindProcess(pid); ferr == nil {
+			_ = p.Signal(syscall.SIGTERM)
+		}
 		return fmt.Errorf("connect to holder for codex resume: %w", err)
 	}
 

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -193,7 +193,24 @@ func ReconnectHolderStreamProcess(opts StreamOpts, provider Provider, holderPID 
 	// that happens to share the path (see #656).
 	conn, err := ConnectToHolderExpectingPID(opts.SessionID, holderPID)
 	if err != nil {
-		return nil, fmt.Errorf("reconnect to holder: %w", err)
+		// On daemon restart we may be reconnecting to a holder that was
+		// spawned by an older agmux binary which doesn't speak the hello
+		// protocol. In that case ConnectToHolderExpectingPID with a non-zero
+		// PID fails (by design, see Follow-up 1 of PR #657 review). If the
+		// holder PID is still alive, fall back to a non-PID-verifying
+		// connect — there is no race partner during recover so PID
+		// verification offers no additional safety here.
+		if IsHolderAlive(holderPID) {
+			slog.Warn("holder: PID-verified reconnect failed, retrying without PID verification (may be pre-hello binary)",
+				"sessionId", opts.SessionID, "holderPid", holderPID, "error", err)
+			var fallbackErr error
+			conn, fallbackErr = ConnectToHolderExpectingPID(opts.SessionID, 0)
+			if fallbackErr != nil {
+				return nil, fmt.Errorf("reconnect to holder (fallback): %w", fallbackErr)
+			}
+		} else {
+			return nil, fmt.Errorf("reconnect to holder: %w", err)
+		}
 	}
 
 	sp := &HolderStreamProcess{
@@ -283,6 +300,26 @@ func (sp *HolderStreamProcess) readLoop() {
 		if err != nil {
 			if err != io.EOF {
 				slog.Error("holder stream: read error", "error", err)
+			}
+			// EOF / read error on the holder socket after a successful PID
+			// handshake means the holder went away unexpectedly. Without
+			// firing onProcessExit here the daemon would never receive an
+			// "exited" control event (the holder process is already gone)
+			// and the session status would stay stuck on "running" forever.
+			// We skip the callback when stopped == true so that intentional
+			// shutdowns (Stop / sendCodex) keep their existing flow.
+			sp.mu.RLock()
+			stopped := sp.stopped
+			cb := sp.onProcessExit
+			sp.mu.RUnlock()
+			if !stopped && cb != nil {
+				var exitErr error
+				if err == io.EOF {
+					exitErr = fmt.Errorf("holder conn closed (EOF, holder presumed exited)")
+				} else {
+					exitErr = fmt.Errorf("holder conn closed unexpectedly: %w", err)
+				}
+				cb(sp.streamOpts.SessionID, exitErr)
 			}
 			return
 		}

--- a/internal/session/holder_stream_test.go
+++ b/internal/session/holder_stream_test.go
@@ -1,10 +1,13 @@
 package session
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/myuon/agmux/internal/db"
 )
@@ -134,4 +137,146 @@ func TestLoadExistingLines_ClaudeProviderResetBuffers_NoOp(t *testing.T) {
 		t.Errorf("expected replayed lines, got 0")
 	}
 }
+
+// TestReadLoop_EOFTriggersOnProcessExit verifies the follow-up fix: when the
+// holder socket reaches EOF (= the holder process died unexpectedly without
+// sending a control "exited" event), the readLoop must fire the
+// onProcessExit callback so the daemon can update session status. Without
+// this, the status stays stuck on "running" until manual intervention.
+func TestReadLoop_EOFTriggersOnProcessExit(t *testing.T) {
+	// Set up a pair of connected unix sockets via net.Pipe-like construct
+	// using socketpair via listen+dial. Use shortTempDir to stay under the
+	// macOS 104-byte unix socket path limit.
+	dir := shortTempDir(t)
+	sockPath := filepath.Join(dir, "rl-eof.sock")
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+
+	serverDone := make(chan net.Conn, 1)
+	go func() {
+		c, err := l.Accept()
+		if err != nil {
+			serverDone <- nil
+			return
+		}
+		serverDone <- c
+	}()
+
+	clientConn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	serverConn := <-serverDone
+	if serverConn == nil {
+		t.Fatal("accept failed")
+	}
+
+	const sessionID = "eof-fires-callback"
+
+	type capture struct {
+		sessionID string
+		err       error
+	}
+	cbCh := make(chan capture, 1)
+
+	sp := &HolderStreamProcess{
+		conn:       clientConn,
+		done:       make(chan struct{}),
+		provider:   NewClaudeProvider("", ""),
+		holderPID:  12345,
+		streamOpts: StreamOpts{SessionID: sessionID},
+		onProcessExit: func(sid string, exitErr error) {
+			cbCh <- capture{sessionID: sid, err: exitErr}
+		},
+	}
+
+	go sp.readLoop()
+
+	// Simulate the holder going away unexpectedly: close the server side of
+	// the conn, causing EOF on the client side.
+	_ = serverConn.Close()
+
+	var got capture
+	select {
+	case got = <-cbCh:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("onProcessExit did not fire within 3s after EOF")
+	}
+
+	// Wait for readLoop to fully exit.
+	select {
+	case <-sp.done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("readLoop did not exit within 3s after callback fired")
+	}
+
+	if got.sessionID != sessionID {
+		t.Errorf("callback got sessionID %q, want %q", got.sessionID, sessionID)
+	}
+	if got.err == nil {
+		t.Errorf("callback got nil error, want a non-nil EOF-related error")
+	} else if !strings.Contains(got.err.Error(), "EOF") && !strings.Contains(got.err.Error(), "closed") {
+		t.Errorf("callback error %q should reference EOF / closed conn", got.err.Error())
+	}
+}
+
+// TestReadLoop_StoppedSuppressesOnProcessExitOnEOF verifies that when Stop /
+// sendCodex has marked sp.stopped = true, an EOF on the conn does NOT
+// re-fire onProcessExit. This preserves the existing intentional-shutdown
+// flow where the callback either was (Stop path) or will be (control
+// "exited" path) handled separately.
+func TestReadLoop_StoppedSuppressesOnProcessExitOnEOF(t *testing.T) {
+	dir := shortTempDir(t)
+	sockPath := filepath.Join(dir, "rl-stop.sock")
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+
+	serverDone := make(chan net.Conn, 1)
+	go func() {
+		c, _ := l.Accept()
+		serverDone <- c
+	}()
+	clientConn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	serverConn := <-serverDone
+	if serverConn == nil {
+		t.Fatal("accept failed")
+	}
+
+	var fired atomic.Bool
+	sp := &HolderStreamProcess{
+		conn:       clientConn,
+		done:       make(chan struct{}),
+		provider:   NewClaudeProvider("", ""),
+		streamOpts: StreamOpts{SessionID: "stopped-eof"},
+		stopped:    true, // explicit shutdown in progress
+		onProcessExit: func(sid string, exitErr error) {
+			fired.Store(true)
+		},
+	}
+
+	go sp.readLoop()
+
+	_ = serverConn.Close()
+
+	select {
+	case <-sp.done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("readLoop did not exit within 3s after EOF")
+	}
+
+	if fired.Load() {
+		t.Errorf("onProcessExit should not fire when sp.stopped=true, but it did")
+	}
+}
+
+
 


### PR DESCRIPTION
## Summary

restartForCodex / ReconnectHolderStreamProcess / StartHolderStreamProcess の dial が、旧 holder のシャットダウン窓 (RunHolder が \"exited\" broadcast 後の 100ms スリープ中) で旧 listener にバインドしてしまうレースを修正する。daemon の readLoop はその dying socket に張り付き、旧 holder process が exit すると EOF を受け取って silently return → OnProcessExit / OnTurnComplete などの callback が一切発火せず、DB が `status=working` で固着していた。

## 根本原因

- 旧 holder は `broadcastControl(\"exited\")` 後 `time.Sleep(100 * time.Millisecond)` してから `RunHolder` を return する (holder.go:167)。
- `restartForCodex` の `<-sp.done` は \"exited\" 受信で即 unblock するため、旧 holder process はまだ生きている状態で `ConnectToHolder` が呼ばれる。
- 同じソケットパス (`<sessionID>.sock`) に dial すると、旧 listener が accept してしまい daemon は dying conn にバインドする。
- 旧 holder が exit すると conn が EOF。`readLoop` の EOF パスは callback を発火させない (control イベント \"exited\" が来た時しか発火しない) ため、status が更新されないまま sp.done だけ閉じる。

## 修正

- **holder 側**: `acceptLoop` で接続を受けた直後に `{\"type\":\"control\",\"event\":\"hello\",\"pid\":<os.Getpid()>}` を送信する。
- **daemon 側**: 新しい `ConnectToHolderExpectingPID(sessionID, expectedPID)` を追加。dial 後に hello を `readLineFromConn` (byte-by-byte でリーダー越しの over-read を防ぐ) で読み、PID 不一致なら conn を閉じて retry。`StartHolderStreamProcess` / `ReconnectHolderStreamProcess` / `restartForCodex` をすべてこちらに切り替えた。
- **後方互換**: 旧 binary の holder は hello を送らないため、2 秒の read deadline でタイムアウトしたら best-effort で conn を返す (`assuming pre-hello holder`)。
- **副次修正**: connect 失敗時に SpawnHolder した orphan holder を SIGTERM で回収。

## 回帰テスト (`internal/session/holder_hello_test.go`)

- `TestConnectToHolderExpectingPID_MatchingPID` - 正常系
- `TestConnectToHolderExpectingPID_MismatchedPID_Retries` - 旧 PID を返す server を後から差し替えて、retry が PID 一致を待つことを確認
- `TestConnectToHolderExpectingPID_ZeroPID_AcceptsAny` - PID=0 で任意の hello を受理
- `TestConnectToHolderExpectingPID_PreHelloHolder_FallsBack` - hello を送らない server に対し 2s timeout 後 fallback で conn を返す
- `TestHolderHelloProtocol_NoOverReadIntoSubsequentBroadcast` - hello 直後の broadcast を消費しないこと (handshake が後続バイトを食わない)
- `TestReadLineFromConn_StopsAtNewline` - 1 行ずつ読む helper の正当性

## 実機検証 (cursor session 連続 5+ turn)

修正バイナリで `/tmp/cursor-test-656` に cursor session を作成し、6 回連続でメッセージを送信。各 turn で `model name captured` → `turn completed (result event detected)` → status `working → idle` が daemon log に記録されることを確認した。

途中で 1 回 `holder: hello PID mismatch, retrying expected=64975, got=64210, attempt=1` が記録されており、**まさに本 issue のレースを検知して回避している様子が観測できた**。修正前 (v0.3.8) では同じタイミングで daemon が dying socket にバインドし、以降 callback が一切発火しなくなる。

参照証拠: 7QiDb (mylite-cursor) は修正前環境で 70 分以上 working で固着していたまま現在もデバッグ用に残してある。

## Test plan

- [x] `make build` 通過
- [x] `go test ./...` 全パス
- [x] 新規 cursor セッションで 5+ ターン callback 発火を実機確認
- [x] hello を送らない旧 binary holder への fallback も実機で確認 (recover 時のログに `assuming pre-hello holder` が記録される)

Refs #654
Closes #656