### PR TITLE
fix: host-info の claude provider available 誤判定を修正

### DIFF
--- a/internal/server/hostinfo_test.go
+++ b/internal/server/hostinfo_test.go
@@ -139,6 +139,45 @@ func TestCollectProviderInfo(t *testing.T) {
 	}
 }
 
+func TestCollectProviderInfoCommandWithFlags(t *testing.T) {
+	// A configured command may include flags (e.g. "claude --foo --bar"). The
+	// availability check must resolve only the leading executable token, not the
+	// whole string, otherwise LookPath fails on the flags.
+	binDir := t.TempDir()
+	fakeBin := "agmux-fake-provider"
+	fakePath := filepath.Join(binDir, fakeBin)
+	if err := os.WriteFile(fakePath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	claudeCmd := fakeBin + " --foo --bar"
+	configBody := "" +
+		"[session]\n" +
+		"claude_command = \"" + claudeCmd + "\"\n"
+	newTestHomeConfig(t, configBody)
+
+	s := &Server{startTime: time.Now()}
+	providers := s.collectProviderInfo()
+
+	byName := make(map[string]hostProviderInfo, len(providers))
+	for _, p := range providers {
+		byName[p.Name] = p
+	}
+
+	claude, ok := byName["claude"]
+	if !ok {
+		t.Fatalf("missing claude provider in %+v", providers)
+	}
+	if !claude.Available {
+		t.Errorf("claude should be available when command has flags (resolves to %s)", fakePath)
+	}
+	// The displayed command keeps the full configured string (flags included).
+	if claude.Command != claudeCmd {
+		t.Errorf("claude command = %q, want %q", claude.Command, claudeCmd)
+	}
+}
+
 func TestCollectGlobalSkills(t *testing.T) {
 	home := newTestHomeConfig(t, "")
 	skillsDir := filepath.Join(home, ".claude", "skills")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1629,11 +1629,18 @@ func (s *Server) collectProviderInfo() []hostProviderInfo {
 
 	providers := make([]hostProviderInfo, 0, len(specs))
 	for _, spec := range specs {
-		_, lookErr := exec.LookPath(spec.cmd)
+		// The configured command may include flags (e.g.
+		// "claude --dangerously-skip-permissions --model ..."), so resolve
+		// availability using only the leading executable token.
+		available := false
+		if fields := strings.Fields(spec.cmd); len(fields) > 0 {
+			_, lookErr := exec.LookPath(fields[0])
+			available = lookErr == nil
+		}
 		providers = append(providers, hostProviderInfo{
 			Name:      spec.name,
 			Command:   spec.cmd,
-			Available: lookErr == nil,
+			Available: available,
 		})
 	}
 	return providers


### PR DESCRIPTION
## 問題
設定画面 Host Machine セクション (`GET /api/host-info`) で claude provider が `available: false` と誤判定される。

## 原因
`internal/server/server.go` の `collectProviderInfo` が、設定されたコマンド文字列全体（フラグ込み）をそのまま `exec.LookPath` に渡していた。claude のコマンドは `claude --dangerously-skip-permissions --model ...` とフラグを含むため、その文字列全体を実行ファイル名として探して失敗していた。codex/cursor はフラグなし(`codex`/`agent`)なので通っていた。

## 修正
`exec.LookPath` に渡す前に `strings.Fields` で先頭トークン（実行ファイル名）だけを抜き出して判定するようにした。空文字列のケースもガードしている。表示用の `Command` フィールドは従来通りフルコマンド文字列のまま返す。

## テスト
`internal/server/hostinfo_test.go` に `TestCollectProviderInfoCommandWithFlags` を追加。フラグ付きコマンド (`<fakeBin> --foo --bar`) でも、PATH に実行ファイルがあれば `available: true` になることを検証。

- `make build` OK
- `go test ./internal/server/` OK

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)