### PR TITLE
feat: セッション内でのモデルスイッチに対応 (#660)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -99,6 +99,12 @@ export const api = {
       body: JSON.stringify(data),
     }),
 
+  updateSessionModel: (id: string, model: string) =>
+    request<{ status: string }>(`/sessions/${id}/model`, {
+      method: "PUT",
+      body: JSON.stringify({ model }),
+    }),
+
   reconnectSession: (id: string) =>
     request<{ status: string }>(`/sessions/${id}/reconnect`, { method: "POST" }),
 

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -6,7 +6,7 @@ import {
   Square, RefreshCw, Trash2, ArrowLeft, GitBranch, FolderOpen,
   Sparkles, Settings, Copy,
   RotateCcw, ImagePlus, SendHorizonal, Plus, Slash,
-  Code, Eye, X, AlertTriangle, LayoutTemplate,
+  Code, Eye, X, AlertTriangle, LayoutTemplate, ChevronDown,
 } from "lucide-react";
 import { useDesktopPane } from "../App";
 import { Modal } from "../components/ui/Modal";
@@ -65,6 +65,114 @@ function ParentSessionLink({ parentId }: { parentId: string }) {
       <Link to={`/sessions/${parentId}`} className="underline hover:text-blue-700">
         {parentName ?? parentId}
       </Link>
+    </div>
+  );
+}
+
+// ModelSwitcher renders the model Chip in the session header. For providers
+// with a model list API (claude / codex), the Chip becomes clickable and shows
+// a dropdown to switch the session's model. Cursor has no model list API, so
+// its Chip stays non-clickable. Switching is disabled while a turn is in
+// progress (status = working).
+function ModelSwitcher({ session, onSwitched, onError }: {
+  session: Session;
+  onSwitched: (model: string) => void;
+  onError: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [models, setModels] = useState<{ id: string; name: string }[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [switching, setSwitching] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const switchable =
+    (session.provider === "claude" || session.provider === "codex") &&
+    session.status !== "working";
+
+  // Close the dropdown on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  if (!switchable) {
+    return (
+      <span className="inline-flex items-center"><Chip color="purple">{session.model}</Chip></span>
+    );
+  }
+
+  const toggleOpen = () => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    setOpen(true);
+    if (models === null && !loading) {
+      setLoading(true);
+      const fetchModels = session.provider === "codex"
+        ? api.getCodexModels().then((ms) => ms.map((m) => ({ id: m.id, name: m.name || m.id })))
+        : api.getClaudeModels().then((ms) => ms.map((m) => ({ id: m.id, name: m.name })));
+      fetchModels
+        .then(setModels)
+        .catch(() => setModels([]))
+        .finally(() => setLoading(false));
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative inline-flex items-center">
+      <button
+        type="button"
+        onClick={toggleOpen}
+        disabled={switching}
+        title="クリックでモデルを切替"
+        className={`inline-flex items-center ${switching ? "opacity-60 cursor-not-allowed" : "hover:opacity-80 cursor-pointer"}`}
+      >
+        <Chip color="purple">
+          {session.model}
+          <ChevronDown className="w-3 h-3 ml-0.5" />
+        </Chip>
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto z-50 min-w-44">
+          {loading ? (
+            <div className="px-3 py-2 text-xs text-gray-400">Loading models...</div>
+          ) : models && models.length > 0 ? (
+            models.map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                className={`w-full text-left px-3 py-2 text-xs hover:bg-purple-50 ${
+                  m.id === session.model ? "bg-purple-100 text-purple-800" : "text-gray-700"
+                }`}
+                onClick={async () => {
+                  setOpen(false);
+                  if (m.id === session.model || switching) return;
+                  setSwitching(true);
+                  try {
+                    await api.updateSessionModel(session.id, m.id);
+                    onSwitched(m.id);
+                  } catch {
+                    onError();
+                  } finally {
+                    setSwitching(false);
+                  }
+                }}
+              >
+                {m.name}
+              </button>
+            ))
+          ) : (
+            <div className="px-3 py-2 text-xs text-gray-400">No models available</div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -139,6 +247,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
   const [restartToast, setRestartToast] = useState<"success" | "error" | null>(null);
   const [disconnectToast, setDisconnectToast] = useState(false);
   const [clearToast, setClearToast] = useState<"success" | "error" | null>(null);
+  const [modelToast, setModelToast] = useState<"success" | "error" | null>(null);
   const [copiedToast, setCopiedToast] = useState(false);
   const [showSlashMenu, setShowSlashMenu] = useState(false);
   const [showActionMenu, setShowActionMenu] = useState(false);
@@ -702,6 +811,8 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
       {restartToast === "error" && <Toast message="再起動に失敗しました" variant="error" />}
       {clearToast === "success" && <Toast message="セッションをクリアしました" />}
       {clearToast === "error" && <Toast message="クリアに失敗しました" variant="error" />}
+      {modelToast === "success" && <Toast message="モデルを切り替えました" />}
+      {modelToast === "error" && <Toast message="モデルの切替に失敗しました" variant="error" />}
       {copiedToast && <Toast message="セッション名をコピーしました" />}
       <div className="flex flex-wrap items-center gap-2 sm:gap-3 mb-3 shrink-0">
         {!isDesktopPane && (
@@ -756,7 +867,19 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
               return chip;
             })()}
             {session.model && (
-              <span className="inline-flex items-center"><Chip color="purple">{session.model}</Chip></span>
+              <ModelSwitcher
+                session={session}
+                onSwitched={(model) => {
+                  setSession((prev) => (prev ? { ...prev, model } : prev));
+                  api.getSession(session.id).then(setSession).catch(() => {});
+                  setModelToast("success");
+                  setTimeout(() => setModelToast(null), 3000);
+                }}
+                onError={() => {
+                  setModelToast("error");
+                  setTimeout(() => setModelToast(null), 3000);
+                }}
+              />
             )}
             {session.roleTemplate && (
               <span className="inline-flex items-center" style={{ viewTransitionName: `session-role-${session.id}` }}><Chip color="orange">{session.roleTemplate}</Chip></span>

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -137,6 +137,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/stop", s.stopSession)
 		r.Post("/sessions/{id}/send", s.sendToSession)
 		r.Put("/sessions/{id}/context", s.updateSessionContext)
+		r.Put("/sessions/{id}/model", s.updateSessionModel)
 		r.Get("/sessions/{id}/goals", s.getGoals)
 		r.Post("/sessions/{id}/goals", s.createGoal)
 		r.Post("/sessions/{id}/goals/complete", s.completeGoal)
@@ -540,6 +541,29 @@ func (s *Server) updateSessionContext(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+type updateModelRequest struct {
+	Model string `json:"model"`
+}
+
+func (s *Server) updateSessionModel(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req updateModelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Model == "" {
+		writeError(w, http.StatusBadRequest, "model is required")
+		return
+	}
+	if err := s.sessions.SwitchModel(id, req.Model); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.recordSessionAction(id, "model_switch", req.Model)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -758,7 +758,10 @@ func (sp *HolderStreamProcess) sendCodex(message string) error {
 
 // restartForCodex spawns a new holder for a Codex followup message.
 func (sp *HolderStreamProcess) restartForCodex(message, cliSessionID string) error {
+	// Copy under lock: SetModel mutates streamOpts.Model concurrently.
+	sp.mu.RLock()
 	opts := sp.streamOpts
+	sp.mu.RUnlock()
 	opts.Resume = true
 	opts.CLISessionID = cliSessionID
 	opts.InitialPrompt = message

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -504,6 +504,23 @@ func (sp *HolderStreamProcess) HolderPID() int {
 	return sp.holderPID
 }
 
+// SetModel updates the model used when re-spawning the CLI process.
+// One-shot providers (codex/cursor) reuse streamOpts on every followup turn
+// (see restartForCodex), so updating it here makes the next turn use the
+// new model.
+func (sp *HolderStreamProcess) SetModel(model string) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.streamOpts.Model = model
+}
+
+// Model returns the model currently set in the stream options.
+func (sp *HolderStreamProcess) Model() string {
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+	return sp.streamOpts.Model
+}
+
 // SetOnSessionID sets a callback for CLI session ID capture.
 func (sp *HolderStreamProcess) SetOnSessionID(fn func(cliSessionID string)) {
 	sp.mu.Lock()

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1690,6 +1690,59 @@ func (m *Manager) UpdateModel(id string, model string) error {
 	return err
 }
 
+// SwitchModel updates the session's model and applies it to any running CLI
+// process. For resident providers (claude), the holder is restarted with
+// --resume so the new model takes effect immediately while preserving the
+// conversation history. For one-shot providers (codex/cursor), the in-memory
+// stream options are updated so the next turn re-spawns with the new model.
+func (m *Manager) SwitchModel(id string, model string) error {
+	s, err := m.Get(id)
+	if err != nil {
+		return err
+	}
+
+	if s.Status == StatusWorking {
+		return fmt.Errorf("session %s is working; cannot switch model while a turn is in progress", id)
+	}
+
+	if err := m.UpdateModel(id, model); err != nil {
+		return fmt.Errorf("update model: %w", err)
+	}
+
+	// If no conversation has started yet, the next spawn reads the model
+	// from the DB, so updating the DB is sufficient.
+	if !s.ConversationStarted {
+		return nil
+	}
+
+	if m.getProvider(s.Provider).IsOneShot() {
+		// One-shot providers re-spawn the CLI on every turn. Spawning a
+		// prompt-less resume process here would exit immediately (#643), so
+		// only update the in-memory stream options that restartForCodex
+		// reuses for the next turn.
+		m.streamMu.Lock()
+		sp, ok := m.streamProcesses[id]
+		m.streamMu.Unlock()
+		if ok {
+			sp.SetModel(model)
+		}
+		return nil
+	}
+
+	// Resident provider (claude): restart the holder with --resume and the
+	// new model only if one is active. Without an active holder, the next
+	// spawn (reconnect / auto-recovery) picks up the new model from the DB.
+	m.streamMu.Lock()
+	_, hasProcess := m.streamProcesses[id]
+	m.streamMu.Unlock()
+	if !hasProcess && !IsHolderAlive(s.HolderPID) {
+		return nil
+	}
+
+	m.logger.Info("switching model via holder restart", "sessionId", id, "model", model)
+	return m.Restart(id)
+}
+
 func (m *Manager) UpdateContext(id string, currentTask, goal string) error {
 	_, err := m.db.Exec("UPDATE sessions SET current_task = ?, goal = ?, updated_at = ? WHERE id = ?", currentTask, goal, time.Now(), id)
 	return err

--- a/internal/session/manager_switch_model_test.go
+++ b/internal/session/manager_switch_model_test.go
@@ -1,0 +1,144 @@
+package session
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+)
+
+// insertSwitchModelSession inserts a session row for SwitchModel tests.
+func insertSwitchModelSession(t *testing.T, db *sql.DB, id, provider, status, model string, conversationStarted int) {
+	t.Helper()
+	now := time.Now()
+	_, err := db.Exec(
+		`INSERT INTO sessions (id, name, project_path, tmux_session, status, type, output_mode, provider, model, conversation_started, holder_pid, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, "test", "/tmp", "", status, "worker", "stream", provider, model, conversationStarted, 0, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+}
+
+func querySessionModel(t *testing.T, db *sql.DB, id string) string {
+	t.Helper()
+	var model string
+	if err := db.QueryRow("SELECT model FROM sessions WHERE id = ?", id).Scan(&model); err != nil {
+		t.Fatalf("query model: %v", err)
+	}
+	return model
+}
+
+// TestSwitchModel_UpdatesDB verifies that SwitchModel persists the new model
+// to the database when the conversation has not started yet (DB update only).
+func TestSwitchModel_UpdatesDB(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	id := "switch-db-only"
+	insertSwitchModelSession(t, db, id, "claude", "idle", "claude-sonnet-4-5", 0)
+
+	m := newTestManager(t, db)
+	if err := m.SwitchModel(id, "claude-opus-4-6"); err != nil {
+		t.Fatalf("SwitchModel: %v", err)
+	}
+
+	if got := querySessionModel(t, db, id); got != "claude-opus-4-6" {
+		t.Errorf("model = %q, want %q", got, "claude-opus-4-6")
+	}
+}
+
+// TestSwitchModel_WorkingReturnsError verifies that SwitchModel refuses to
+// switch while a turn is in progress (status = working) and leaves the DB
+// model unchanged.
+func TestSwitchModel_WorkingReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	id := "switch-working"
+	insertSwitchModelSession(t, db, id, "claude", "working", "claude-sonnet-4-5", 1)
+
+	m := newTestManager(t, db)
+	err := m.SwitchModel(id, "claude-opus-4-6")
+	if err == nil {
+		t.Fatal("SwitchModel should return an error while the session is working")
+	}
+	if !strings.Contains(err.Error(), "working") {
+		t.Errorf("error = %q, want mention of working state", err.Error())
+	}
+
+	if got := querySessionModel(t, db, id); got != "claude-sonnet-4-5" {
+		t.Errorf("model = %q, want unchanged %q", got, "claude-sonnet-4-5")
+	}
+}
+
+// TestSwitchModel_OneShotUpdatesStreamOpts verifies that for one-shot
+// providers (codex/cursor) the in-memory streamOpts.Model is updated so the
+// next followup turn re-spawns the CLI with the new model.
+func TestSwitchModel_OneShotUpdatesStreamOpts(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	id := "switch-oneshot"
+	insertSwitchModelSession(t, db, id, "codex", "idle", "gpt-5", 1)
+
+	m := newTestManager(t, db)
+	sp := &HolderStreamProcess{
+		streamOpts: StreamOpts{SessionID: id, Model: "gpt-5"},
+	}
+	m.streamProcesses = map[string]*HolderStreamProcess{id: sp}
+
+	if err := m.SwitchModel(id, "gpt-5-codex"); err != nil {
+		t.Fatalf("SwitchModel: %v", err)
+	}
+
+	if got := querySessionModel(t, db, id); got != "gpt-5-codex" {
+		t.Errorf("model = %q, want %q", got, "gpt-5-codex")
+	}
+	if got := sp.Model(); got != "gpt-5-codex" {
+		t.Errorf("streamOpts.Model = %q, want %q", got, "gpt-5-codex")
+	}
+}
+
+// TestSwitchModel_OneShotWithoutStreamProcess verifies that one-shot sessions
+// without an in-memory stream process still get the DB update (the next
+// auto-recovery spawn reads the model from the DB).
+func TestSwitchModel_OneShotWithoutStreamProcess(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	id := "switch-oneshot-no-sp"
+	insertSwitchModelSession(t, db, id, "codex", "idle", "gpt-5", 1)
+
+	m := newTestManager(t, db)
+	m.streamProcesses = map[string]*HolderStreamProcess{}
+
+	if err := m.SwitchModel(id, "gpt-5-codex"); err != nil {
+		t.Fatalf("SwitchModel: %v", err)
+	}
+	if got := querySessionModel(t, db, id); got != "gpt-5-codex" {
+		t.Errorf("model = %q, want %q", got, "gpt-5-codex")
+	}
+}
+
+// TestSwitchModel_ResidentNoActiveHolder verifies that a claude session with
+// a started conversation but no active holder gets only the DB update (no
+// restart attempt, which would fail without a real holder binary).
+func TestSwitchModel_ResidentNoActiveHolder(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	id := "switch-claude-no-holder"
+	insertSwitchModelSession(t, db, id, "claude", "idle", "claude-sonnet-4-5", 1)
+
+	m := newTestManager(t, db)
+	m.streamProcesses = map[string]*HolderStreamProcess{}
+
+	if err := m.SwitchModel(id, "claude-opus-4-6"); err != nil {
+		t.Fatalf("SwitchModel: %v", err)
+	}
+	if got := querySessionModel(t, db, id); got != "claude-opus-4-6" {
+		t.Errorf("model = %q, want %q", got, "claude-opus-4-6")
+	}
+}

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -36,6 +36,9 @@ type SessionService interface {
 	UpdateStatus(id string, status Status) error
 	// UpdateContext updates the session's current task and goal.
 	UpdateContext(id string, currentTask, goal string) error
+	// SwitchModel updates the session's model and applies it to any running
+	// CLI process.
+	SwitchModel(id string, model string) error
 
 	// CreateGoal creates a new goal for a session.
 	CreateGoal(id string, currentTask, goal string, subgoal bool) error


### PR DESCRIPTION
Closes #660

## 概要

セッション作成後にモデルを切り替えられるようにしました。Issue コメントの調査レポートで推奨されていた **案A（DB のモデルを更新 + 既存の再スポーン経路に乗せる）** で実装しています。

## 変更内容

### Manager (`internal/session/manager.go`)
- `SwitchModel(id, model string) error` を追加
  - `UpdateModel` で DB の `sessions.model` を更新
  - status が `working`（実行中ターンあり）の場合はエラーを返し、進行中処理の中断を防止
  - `ConversationStarted == false` の場合は DB 更新のみ（次回スポーン時に新モデルが使われる）
  - **claude（常駐型）**: アクティブな holder / stream process があれば既存の `Restart` を実行（holder kill → `--resume <cliSessionID> --model <新model>` で再スポーン、会話履歴は resume で維持）。アクティブな holder がなければ DB 更新のみ
  - **codex / cursor（ワンショット型）**: prompt なし resume 起動は即 exit するため（#643）即時再スポーンはせず、メモリ上の `HolderStreamProcess.streamOpts.Model` を更新（`restartForCodex` が `streamOpts` を使い回すため、次ターンから新モデルで再スポーンされる）

### holder (`internal/session/holder_stream.go`)
- `HolderStreamProcess.SetModel` / `Model` を追加（ワンショット型の次ターン用 streamOpts 更新）

### API (`internal/server/server.go`)
- `PUT /sessions/{id}/model` を追加（body: `{"model": "..."}`、空文字は 400）
- 既存パターンに合わせて `recordSessionAction(id, "model_switch", model)` でアクションログを記録

### frontend (`frontend/src/pages/SessionPage.tsx`, `frontend/src/api/client.ts`)
- セッション詳細ヘッダのモデル Chip をクリッカブル化し、モデル選択ドロップダウンを表示
- モデル一覧は provider に応じて既存の `/api/claude/models` / `/api/codex/models` を使用
- cursor はモデル一覧 API がないため切替 UI 対象外（Chip は非クリッカブルのまま）
- status が `working` のときは切替無効（非クリッカブル表示）
- `api.updateSessionModel(id, model)` を追加

### テスト (`internal/session/manager_switch_model_test.go`)
- DB 更新（conversation 未開始時は DB のみ）
- working 中のエラー（DB 不変も検証）
- ワンショット型の streamOpts 更新
- ワンショット型 stream process なし / claude アクティブ holder なしの DB のみ更新

## テスト結果

- `make build`: ✅ 通過（frontend tsc + vite build / go build）
- `make test` (`go test ./...`): ✅ 全パッケージ通過
- `eslint`（変更ファイル）: ✅ 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)