### PR TITLE
fix: cursor provider の edit/read ツール表示に filepath を出す (#665)

### DIFF
--- a/internal/session/provider_cursor.go
+++ b/internal/session/provider_cursor.go
@@ -317,6 +317,7 @@ func (p *CursorProvider) normalizeToolCall(line []byte, subtype string) []byte {
 		// Always emit an object so the frontend can render an empty input.
 		args = json.RawMessage(`{}`)
 	}
+	args = cursorToolArgsToClaudeInput(name, args)
 
 	tu := toolUseBlock{Type: "tool_use", ID: msg.CallID, Name: name, Input: args}
 
@@ -336,6 +337,37 @@ func (p *CursorProvider) normalizeToolCall(line []byte, subtype string) []byte {
 	wrapper.Message.Role = "assistant"
 	wrapper.Message.Content = []json.RawMessage{tuJSON, trJSON}
 	b, _ := json.Marshal(wrapper)
+	return b
+}
+
+// cursorToolArgsToClaudeInput converts Cursor tool args into the
+// Claude-compatible tool_use input shape. Cursor's read/edit/write tools put
+// the target file in args.path, while the Claude format (which the frontend
+// renders) expects input.file_path. The key is renamed for those tools so the
+// frontend shows the file path next to the tool name; other tools pass
+// through unchanged.
+func cursorToolArgsToClaudeInput(name string, args json.RawMessage) json.RawMessage {
+	switch name {
+	case "Read", "Edit", "Write":
+	default:
+		return args
+	}
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(args, &obj) != nil {
+		return args
+	}
+	path, ok := obj["path"]
+	if !ok {
+		return args
+	}
+	if _, exists := obj["file_path"]; !exists {
+		obj["file_path"] = path
+	}
+	delete(obj, "path")
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return args
+	}
 	return b
 }
 

--- a/internal/session/provider_cursor_test.go
+++ b/internal/session/provider_cursor_test.go
@@ -332,6 +332,76 @@ func TestCursorProvider_cursorToolKindToName(t *testing.T) {
 	}
 }
 
+func TestCursorToolArgsToClaudeInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		args     string
+		want     string
+	}{
+		{
+			name:     "read renames path to file_path",
+			toolName: "Read",
+			args:     `{"path":"/x.md"}`,
+			want:     `{"file_path":"/x.md"}`,
+		},
+		{
+			name:     "edit renames path and keeps other keys",
+			toolName: "Edit",
+			args:     `{"path":"a.go","streamContent":"x"}`,
+			want:     `{"file_path":"a.go","streamContent":"x"}`,
+		},
+		{
+			name:     "write renames path to file_path",
+			toolName: "Write",
+			args:     `{"path":"b.go"}`,
+			want:     `{"file_path":"b.go"}`,
+		},
+		{
+			name:     "non-file tool passes through unchanged",
+			toolName: "Bash",
+			args:     `{"path":"/tmp","command":"ls"}`,
+			want:     `{"path":"/tmp","command":"ls"}`,
+		},
+		{
+			name:     "args without path pass through unchanged",
+			toolName: "Read",
+			args:     `{"offset":1}`,
+			want:     `{"offset":1}`,
+		},
+		{
+			name:     "existing file_path is not overwritten",
+			toolName: "Read",
+			args:     `{"path":"/a","file_path":"/b"}`,
+			want:     `{"file_path":"/b"}`,
+		},
+		{
+			name:     "non-object args pass through unchanged",
+			toolName: "Read",
+			args:     `"not an object"`,
+			want:     `"not an object"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cursorToolArgsToClaudeInput(tt.toolName, json.RawMessage(tt.args))
+			var gotV, wantV interface{}
+			if err := json.Unmarshal(got, &gotV); err != nil {
+				t.Fatalf("failed to parse result JSON: %v\nresult: %s", err, string(got))
+			}
+			if err := json.Unmarshal([]byte(tt.want), &wantV); err != nil {
+				t.Fatalf("failed to parse expected JSON: %v", err)
+			}
+			gotBytes, _ := json.Marshal(gotV)
+			wantBytes, _ := json.Marshal(wantV)
+			if string(gotBytes) != string(wantBytes) {
+				t.Errorf("got %s, want %s", string(gotBytes), string(wantBytes))
+			}
+		})
+	}
+}
+
 func TestCursorProvider_NormalizeToolCall_MoreKinds(t *testing.T) {
 	p := NewCursorProvider("")
 
@@ -460,7 +530,12 @@ func TestCursorProvider_NormalizeStreamLine(t *testing.T) {
 		{
 			name:     "tool_call completed (read) becomes assistant tool_use+tool_result",
 			input:    `{"type":"tool_call","subtype":"completed","call_id":"tool_r1","tool_call":{"readToolCall":{"args":{"path":"/x.md"},"result":{"success":{"content":"hello","path":"/x.md","fileSize":5}}}}}`,
-			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tool_r1","name":"Read","input":{"path":"/x.md"}},{"type":"tool_result","tool_use_id":"tool_r1","content":"{\"content\":\"hello\",\"path\":\"/x.md\",\"fileSize\":5}"}]}}`,
+			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tool_r1","name":"Read","input":{"file_path":"/x.md"}},{"type":"tool_result","tool_use_id":"tool_r1","content":"{\"content\":\"hello\",\"path\":\"/x.md\",\"fileSize\":5}"}]}}`,
+		},
+		{
+			name:     "tool_call completed (edit) renames path to file_path",
+			input:    `{"type":"tool_call","subtype":"completed","call_id":"tool_e1","tool_call":{"editToolCall":{"args":{"path":"a.go","streamContent":"x"},"result":{"success":{"path":"a.go","linesAdded":1,"linesRemoved":0,"diffString":"--- a/a.go"}}}}}`,
+			wantJSON: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tool_e1","name":"Edit","input":{"file_path":"a.go","streamContent":"x"}},{"type":"tool_result","tool_use_id":"tool_e1","content":"{\"path\":\"a.go\",\"linesAdded\":1,\"linesRemoved\":0,\"diffString\":\"--- a/a.go\"}"}]}}`,
 		},
 		{
 			name:     "tool_call completed (shell) maps to Bash",


### PR DESCRIPTION
Closes #665

## 変更概要

cursor provider のセッションで Read / Edit のツール実行表示にファイルパスが出ず、ツール名だけが表示されていた問題の修正。

- 原因: Cursor CLI の tool_call args はファイルパスを `path` キーで持つが、frontend の表示ロジック（`toolDescription` / `ToolCallView`）は Claude 形式の `file_path` を参照している
- 対応: `normalizeToolCall` で tool_use input を生成する際、Read / Edit / Write について `path` を `file_path` にリネームする `cursorToolArgsToClaudeInput` を追加（Claude 互換形式に正規化）
- frontend は provider 共通の表示ロジックのため変更不要。`lastToolName` / `lastToolInput`（background_task）も正規化後の stream を参照するためそのまま反映される

## テスト

- `TestCursorToolArgsToClaudeInput` を追加（rename・既存 file_path 優先・非対象ツール pass-through 等 7 ケース）
- `TestCursorProvider_NormalizeStreamLine` に edit completed のケースを追加、read のケースの期待値を `file_path` に更新
- `make build` / `make test` 通過（`go test ./...` 全 OK）

🤖 Generated with [Claude Code](https://claude.com/claude-code)