### PR TITLE
feat: Automation のデータモデル・スケジューラ・実行エンジンを追加 (#667)

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -247,6 +247,10 @@ func serveCmd() *cobra.Command {
 			autoRunner := automation.NewRunner(autoStore, mgr, logger)
 			autoScheduler := automation.NewScheduler(autoStore, autoRunner, logger)
 			autoScheduler.Start()
+			// Stop is idempotent; the defer covers error-return paths (frontend
+			// load / listen / Serve errors) that bypass the graceful-shutdown
+			// branch below.
+			defer autoScheduler.Stop()
 
 			if !devMode {
 				// Resolve frontend directory: CLI flag > config > embedded

--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	agmux "github.com/myuon/agmux"
+	"github.com/myuon/agmux/internal/automation"
 	"github.com/myuon/agmux/internal/config"
 	"github.com/myuon/agmux/internal/daemon"
 	"github.com/myuon/agmux/internal/db"
@@ -240,6 +241,13 @@ func serveCmd() *cobra.Command {
 				logger.Info("controller session ready", "id", controllerSess.ID)
 			}
 
+			// Start automation scheduler (fires enabled automations on
+			// interval / cron triggers and creates sessions via the manager).
+			autoStore := automation.NewStore(database)
+			autoRunner := automation.NewRunner(autoStore, mgr, logger)
+			autoScheduler := automation.NewScheduler(autoStore, autoRunner, logger)
+			autoScheduler.Start()
+
 			if !devMode {
 				// Resolve frontend directory: CLI flag > config > embedded
 				if frontendDir == "" {
@@ -300,6 +308,7 @@ func serveCmd() *cobra.Command {
 				return err
 			case sig := <-shutdownCh:
 				logger.Info(fmt.Sprintf("Received %s, shutting down gracefully...", sig))
+				autoScheduler.Stop()
 				mgr.StopAllStreamProcesses()
 				if extDet := srv.ExternalDetector(); extDet != nil {
 					extDet.Stop()

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/go-chi/cors v1.2.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/matoous/go-nanoid/v2 v2.1.0
 	github.com/mattn/go-sqlite3 v1.14.34
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/proto/otlp v1.9.0
@@ -20,7 +22,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/matoous/go-nanoid/v2 v2.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/mattn/go-sqlite3 v1.14.34 h1:3NtcvcUnFBPsuRcno8pUtupspG/GM+9nZ88zgJcp
 github.com/mattn/go-sqlite3 v1.14.34/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/automation/automation_test.go
+++ b/internal/automation/automation_test.go
@@ -1,0 +1,513 @@
+package automation
+
+import (
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/myuon/agmux/internal/db"
+	"github.com/myuon/agmux/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	sqlDB, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return NewStore(sqlDB)
+}
+
+// fakeSessions is a SessionCreator test double. It records Create calls and
+// serves Get from a status map.
+type fakeSessions struct {
+	mu        sync.Mutex
+	created   []fakeCreateCall
+	statuses  map[string]session.Status
+	createErr error
+}
+
+type fakeCreateCall struct {
+	name        string
+	projectPath string
+	prompt      string
+	opts        session.CreateOpts
+}
+
+func newFakeSessions() *fakeSessions {
+	return &fakeSessions{statuses: map[string]session.Status{}}
+}
+
+func (f *fakeSessions) Create(name, projectPath, prompt string, worktree bool, opts ...session.CreateOpts) (*session.Session, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	var o session.CreateOpts
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	f.created = append(f.created, fakeCreateCall{name: name, projectPath: projectPath, prompt: prompt, opts: o})
+	id := fmt.Sprintf("sess-%d", len(f.created))
+	f.statuses[id] = session.StatusWorking
+	return &session.Session{ID: id, Name: name, ProjectPath: projectPath, Status: session.StatusWorking}, nil
+}
+
+func (f *fakeSessions) Get(id string) (*session.Session, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	st, ok := f.statuses[id]
+	if !ok {
+		return nil, fmt.Errorf("session not found: %s", id)
+	}
+	return &session.Session{ID: id, Status: st}, nil
+}
+
+func (f *fakeSessions) setStatus(id string, st session.Status) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statuses[id] = st
+}
+
+func newTestRunner(t *testing.T, store *Store, sessions *fakeSessions) *Runner {
+	t.Helper()
+	r := NewRunner(store, sessions, slog.Default())
+	r.controllerDir = func() (string, error) { return "/tmp/controller-test", nil }
+	return r
+}
+
+// --- trigger / due-time logic -----------------------------------------------
+
+func TestValidateTrigger(t *testing.T) {
+	assert.NoError(t, ValidateTrigger(TriggerInterval, "30m"))
+	assert.NoError(t, ValidateTrigger(TriggerCron, "0 9 * * 1-5"))
+	assert.Error(t, ValidateTrigger(TriggerInterval, "not-a-duration"))
+	assert.Error(t, ValidateTrigger(TriggerInterval, "-5m"))
+	assert.Error(t, ValidateTrigger(TriggerInterval, "0s"))
+	assert.Error(t, ValidateTrigger(TriggerCron, "every day"))
+	assert.Error(t, ValidateTrigger(TriggerType("unknown"), "30m"))
+}
+
+func TestIsDue_Interval(t *testing.T) {
+	created := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	a := Automation{TriggerType: TriggerInterval, TriggerValue: "30m", CreatedAt: created}
+
+	// Never fired: baseline is CreatedAt, so it does not fire immediately.
+	due, err := IsDue(a, time.Time{}, created.Add(10*time.Minute))
+	require.NoError(t, err)
+	assert.False(t, due)
+
+	due, err = IsDue(a, time.Time{}, created.Add(30*time.Minute))
+	require.NoError(t, err)
+	assert.True(t, due)
+
+	// After a fire, the next fire is interval after the last fire.
+	last := created.Add(30 * time.Minute)
+	due, err = IsDue(a, last, last.Add(29*time.Minute))
+	require.NoError(t, err)
+	assert.False(t, due)
+
+	due, err = IsDue(a, last, last.Add(31*time.Minute))
+	require.NoError(t, err)
+	assert.True(t, due)
+}
+
+func TestIsDue_Cron(t *testing.T) {
+	created := time.Date(2026, 1, 1, 8, 0, 0, 0, time.UTC)
+	a := Automation{TriggerType: TriggerCron, TriggerValue: "0 9 * * *", CreatedAt: created}
+
+	// Before 09:00: not due.
+	due, err := IsDue(a, time.Time{}, time.Date(2026, 1, 1, 8, 30, 0, 0, time.UTC))
+	require.NoError(t, err)
+	assert.False(t, due)
+
+	// At 09:00: due.
+	due, err = IsDue(a, time.Time{}, time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	assert.True(t, due)
+
+	// Fired at 09:00: not due again until the next day.
+	last := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	due, err = IsDue(a, last, time.Date(2026, 1, 1, 23, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	assert.False(t, due)
+
+	due, err = IsDue(a, last, time.Date(2026, 1, 2, 9, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	assert.True(t, due)
+
+	// Daemon down across several occurrences: fires (once) on the next check.
+	due, err = IsDue(a, last, time.Date(2026, 1, 5, 12, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	assert.True(t, due)
+}
+
+func TestIsDue_InvalidTrigger(t *testing.T) {
+	a := Automation{TriggerType: TriggerInterval, TriggerValue: "bogus", CreatedAt: time.Now()}
+	_, err := IsDue(a, time.Time{}, time.Now())
+	assert.Error(t, err)
+}
+
+// --- store -------------------------------------------------------------------
+
+func TestStore_CRUD(t *testing.T) {
+	store := newTestStore(t)
+
+	a, err := store.Create(CreateParams{
+		Name:         "daily-report",
+		Prompt:       "write the daily report",
+		TriggerType:  TriggerCron,
+		TriggerValue: "0 9 * * *",
+		ProjectPath:  "/tmp/proj",
+		Enabled:      true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, a.ID)
+
+	got, err := store.Get(a.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "daily-report", got.Name)
+	assert.Equal(t, TriggerCron, got.TriggerType)
+	assert.Equal(t, "0 9 * * *", got.TriggerValue)
+	assert.Equal(t, "/tmp/proj", got.ProjectPath)
+	assert.True(t, got.Enabled)
+
+	// Update
+	updated, err := store.Update(a.ID, UpdateParams{
+		Name:         "daily-report-v2",
+		Prompt:       "write the daily report v2",
+		TriggerType:  TriggerInterval,
+		TriggerValue: "1h",
+		ProjectPath:  "",
+		Enabled:      false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "daily-report-v2", updated.Name)
+	assert.Equal(t, TriggerInterval, updated.TriggerType)
+	assert.Equal(t, "", updated.ProjectPath)
+	assert.False(t, updated.Enabled)
+
+	// SetEnabled
+	require.NoError(t, store.SetEnabled(a.ID, true))
+	got, err = store.Get(a.ID)
+	require.NoError(t, err)
+	assert.True(t, got.Enabled)
+
+	// List / ListEnabled
+	all, err := store.List()
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+	enabled, err := store.ListEnabled()
+	require.NoError(t, err)
+	assert.Len(t, enabled, 1)
+
+	require.NoError(t, store.SetEnabled(a.ID, false))
+	enabled, err = store.ListEnabled()
+	require.NoError(t, err)
+	assert.Len(t, enabled, 0)
+
+	// Delete
+	require.NoError(t, store.Delete(a.ID))
+	_, err = store.Get(a.ID)
+	assert.Error(t, err)
+}
+
+func TestStore_CreateValidatesTrigger(t *testing.T) {
+	store := newTestStore(t)
+	_, err := store.Create(CreateParams{
+		Name: "bad", Prompt: "p", TriggerType: TriggerInterval, TriggerValue: "bogus", Enabled: true,
+	})
+	assert.Error(t, err)
+}
+
+// --- runner ------------------------------------------------------------------
+
+func TestRunner_CreatesSessionAndRecordsSuccess(t *testing.T) {
+	store := newTestStore(t)
+	sessions := newFakeSessions()
+	r := newTestRunner(t, store, sessions)
+
+	a, err := store.Create(CreateParams{
+		Name: "auto1", Prompt: "do the thing", TriggerType: TriggerInterval, TriggerValue: "30m",
+		ProjectPath: "/tmp/proj", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	firedAt := time.Now()
+	run := r.Run(*a, firedAt)
+	assert.Equal(t, RunSuccess, run.Status)
+	assert.Equal(t, "sess-1", run.SessionID)
+
+	require.Len(t, sessions.created, 1)
+	assert.Equal(t, "/tmp/proj", sessions.created[0].projectPath)
+	assert.Equal(t, "do the thing", sessions.created[0].prompt)
+	assert.Equal(t, a.ID, sessions.created[0].opts.AutomationID)
+
+	runs, err := store.ListRuns(a.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	assert.Equal(t, RunSuccess, runs[0].Status)
+	assert.Equal(t, "sess-1", runs[0].SessionID)
+}
+
+func TestRunner_NoProjectUsesControllerDir(t *testing.T) {
+	store := newTestStore(t)
+	sessions := newFakeSessions()
+	r := newTestRunner(t, store, sessions)
+
+	a, err := store.Create(CreateParams{
+		Name: "auto1", Prompt: "p", TriggerType: TriggerInterval, TriggerValue: "30m", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	run := r.Run(*a, time.Now())
+	assert.Equal(t, RunSuccess, run.Status)
+	require.Len(t, sessions.created, 1)
+	assert.Equal(t, "/tmp/controller-test", sessions.created[0].projectPath)
+}
+
+func TestRunner_SkipsWhilePreviousRunActive(t *testing.T) {
+	store := newTestStore(t)
+	sessions := newFakeSessions()
+	r := newTestRunner(t, store, sessions)
+
+	a, err := store.Create(CreateParams{
+		Name: "auto1", Prompt: "p", TriggerType: TriggerInterval, TriggerValue: "30m", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	// First fire: creates sess-1 which stays in "working".
+	run1 := r.Run(*a, time.Now())
+	require.Equal(t, RunSuccess, run1.Status)
+
+	// Second fire while sess-1 is still working: skipped, no new session.
+	run2 := r.Run(*a, time.Now())
+	assert.Equal(t, RunSkipped, run2.Status)
+	assert.Empty(t, run2.SessionID)
+	assert.Contains(t, run2.Message, "sess-1")
+	assert.Len(t, sessions.created, 1)
+
+	// waiting_input also counts as active.
+	sessions.setStatus("sess-1", session.StatusWaitingInput)
+	run3 := r.Run(*a, time.Now())
+	assert.Equal(t, RunSkipped, run3.Status)
+
+	// Once the previous session is idle, the next fire goes through.
+	sessions.setStatus("sess-1", session.StatusIdle)
+	run4 := r.Run(*a, time.Now())
+	assert.Equal(t, RunSuccess, run4.Status)
+	assert.Equal(t, "sess-2", run4.SessionID)
+	assert.Len(t, sessions.created, 2)
+
+	// History records every firing including the skips.
+	runs, err := store.ListRuns(a.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, runs, 4)
+	statuses := []RunStatus{runs[3].Status, runs[2].Status, runs[1].Status, runs[0].Status}
+	assert.Equal(t, []RunStatus{RunSuccess, RunSkipped, RunSkipped, RunSuccess}, statuses)
+}
+
+func TestRunner_PreviousSessionDeletedDoesNotBlock(t *testing.T) {
+	store := newTestStore(t)
+	sessions := newFakeSessions()
+	r := newTestRunner(t, store, sessions)
+
+	a, err := store.Create(CreateParams{
+		Name: "auto1", Prompt: "p", TriggerType: TriggerInterval, TriggerValue: "30m", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	run1 := r.Run(*a, time.Now())
+	require.Equal(t, RunSuccess, run1.Status)
+
+	// Session deleted: Get fails, runner must not treat it as active.
+	sessions.mu.Lock()
+	delete(sessions.statuses, "sess-1")
+	sessions.mu.Unlock()
+
+	run2 := r.Run(*a, time.Now())
+	assert.Equal(t, RunSuccess, run2.Status)
+}
+
+func TestRunner_RecordsError(t *testing.T) {
+	store := newTestStore(t)
+	sessions := newFakeSessions()
+	sessions.createErr = fmt.Errorf("spawn failed")
+	r := newTestRunner(t, store, sessions)
+
+	a, err := store.Create(CreateParams{
+		Name: "auto1", Prompt: "p", TriggerType: TriggerInterval, TriggerValue: "30m", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	run := r.Run(*a, time.Now())
+	assert.Equal(t, RunError, run.Status)
+	assert.Contains(t, run.Message, "spawn failed")
+
+	runs, err := store.ListRuns(a.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	assert.Equal(t, RunError, runs[0].Status)
+}
+
+// --- scheduler ---------------------------------------------------------------
+
+func newTestScheduler(t *testing.T, store *Store, sessions *fakeSessions) *Scheduler {
+	t.Helper()
+	return NewScheduler(store, newTestRunner(t, store, sessions), slog.Default())
+}
+
+func TestScheduler_Tick_FiresIntervalWhenDue(t *testing.T) {
+	store := newTestStore(t)
+	sessions := newFakeSessions()
+	sched := newTestScheduler(t, store, sessions)
+
+	a, err := store.Create(CreateParams{
+		Name: "auto1", Prompt: "p", TriggerType: TriggerInterval, TriggerValue: "30m",
+		ProjectPath: "/tmp/proj", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	// Not yet due.
+	sched.Tick(a.CreatedAt.Add(10 * time.Minute))
+	assert.Len(t, sessions.created, 0)
+
+	// Due: fires and records a run.
+	sched.Tick(a.CreatedAt.Add(31 * time.Minute))
+	assert.Len(t, sessions.created, 1)
+	runs, err := store.ListRuns(a.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	assert.Equal(t, RunSuccess, runs[0].Status)
+
+	// Same tick time again: the recorded run prevents a double fire.
+	sched.Tick(a.CreatedAt.Add(31 * time.Minute))
+	assert.Len(t, sessions.created, 1)
+}
+
+func TestScheduler_Tick_FiresCronWhenDue(t *testing.T) {
+	store := newTestStore(t)
+	sessions := newFakeSessions()
+	sched := newTestScheduler(t, store, sessions)
+
+	a, err := store.Create(CreateParams{
+		// Every minute, so the next occurrence after CreatedAt is < 1 minute away.
+		Name: "auto-cron", Prompt: "p", TriggerType: TriggerCron, TriggerValue: "* * * * *",
+		Enabled: true,
+	})
+	require.NoError(t, err)
+
+	// Before the next minute boundary relative to creation: not due.
+	sched.Tick(a.CreatedAt)
+	assert.Len(t, sessions.created, 0)
+
+	// Two minutes later a minute boundary has definitely passed: due.
+	sched.Tick(a.CreatedAt.Add(2 * time.Minute))
+	assert.Len(t, sessions.created, 1)
+}
+
+func TestScheduler_Tick_IgnoresDisabled(t *testing.T) {
+	store := newTestStore(t)
+	sessions := newFakeSessions()
+	sched := newTestScheduler(t, store, sessions)
+
+	a, err := store.Create(CreateParams{
+		Name: "auto1", Prompt: "p", TriggerType: TriggerInterval, TriggerValue: "30m", Enabled: false,
+	})
+	require.NoError(t, err)
+
+	sched.Tick(a.CreatedAt.Add(2 * time.Hour))
+	assert.Len(t, sessions.created, 0)
+}
+
+func TestScheduler_Tick_SkipRecordedAdvancesSchedule(t *testing.T) {
+	store := newTestStore(t)
+	sessions := newFakeSessions()
+	sched := newTestScheduler(t, store, sessions)
+
+	a, err := store.Create(CreateParams{
+		Name: "auto1", Prompt: "p", TriggerType: TriggerInterval, TriggerValue: "30m", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	// First fire creates sess-1 (stays working).
+	sched.Tick(a.CreatedAt.Add(30 * time.Minute))
+	require.Len(t, sessions.created, 1)
+
+	// Next interval boundary while sess-1 is still working: skipped.
+	sched.Tick(a.CreatedAt.Add(60 * time.Minute))
+	assert.Len(t, sessions.created, 1)
+
+	// A skipped run also counts as fired: the very next tick (still within the
+	// interval after the skip) must not fire again.
+	sched.Tick(a.CreatedAt.Add(61 * time.Minute))
+	assert.Len(t, sessions.created, 1)
+	runs, err := store.ListRuns(a.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, runs, 2)
+	assert.Equal(t, RunSkipped, runs[0].Status)
+	assert.Equal(t, RunSuccess, runs[1].Status)
+
+	// Session finished: the next interval after the skip fires again.
+	sessions.setStatus("sess-1", session.StatusIdle)
+	sched.Tick(a.CreatedAt.Add(90 * time.Minute))
+	assert.Len(t, sessions.created, 2)
+}
+
+func TestScheduler_Tick_InvalidTriggerDoesNotPanic(t *testing.T) {
+	store := newTestStore(t)
+	sessions := newFakeSessions()
+	sched := newTestScheduler(t, store, sessions)
+
+	// Bypass Create validation by writing an invalid trigger directly.
+	a, err := store.Create(CreateParams{
+		Name: "auto1", Prompt: "p", TriggerType: TriggerInterval, TriggerValue: "30m", Enabled: true,
+	})
+	require.NoError(t, err)
+	_, err = store.db.Exec(`UPDATE automations SET trigger_value = 'bogus' WHERE id = ?`, a.ID)
+	require.NoError(t, err)
+
+	sched.Tick(time.Now().Add(24 * time.Hour))
+	assert.Len(t, sessions.created, 0)
+}
+
+func TestScheduler_StartStop(t *testing.T) {
+	store := newTestStore(t)
+	sessions := newFakeSessions()
+	sched := newTestScheduler(t, store, sessions)
+	sched.SetTickInterval(10 * time.Millisecond)
+
+	a, err := store.Create(CreateParams{
+		Name: "auto1", Prompt: "p", TriggerType: TriggerInterval, TriggerValue: "1ms", Enabled: true,
+	})
+	require.NoError(t, err)
+	_ = a
+
+	sched.Start()
+	// Wait until the loop has fired at least once.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		sessions.mu.Lock()
+		n := len(sessions.created)
+		sessions.mu.Unlock()
+		if n >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	sched.Stop()
+
+	sessions.mu.Lock()
+	n := len(sessions.created)
+	sessions.mu.Unlock()
+	assert.GreaterOrEqual(t, n, 1)
+
+	// Stop is idempotent.
+	sched.Stop()
+}

--- a/internal/automation/automation_test.go
+++ b/internal/automation/automation_test.go
@@ -55,8 +55,11 @@ func (f *fakeSessions) Create(name, projectPath, prompt string, worktree bool, o
 	}
 	f.created = append(f.created, fakeCreateCall{name: name, projectPath: projectPath, prompt: prompt, opts: o})
 	id := fmt.Sprintf("sess-%d", len(f.created))
-	f.statuses[id] = session.StatusWorking
-	return &session.Session{ID: id, Name: name, ProjectPath: projectPath, Status: session.StatusWorking}, nil
+	// Mirror session.Manager.Create: sessions are INSERTed with StatusIdle.
+	// The runner is responsible for promoting them to working via
+	// UpdateStatus — otherwise the multi-run guard never engages.
+	f.statuses[id] = session.StatusIdle
+	return &session.Session{ID: id, Name: name, ProjectPath: projectPath, Status: session.StatusIdle}, nil
 }
 
 func (f *fakeSessions) Get(id string) (*session.Session, error) {
@@ -67,6 +70,16 @@ func (f *fakeSessions) Get(id string) (*session.Session, error) {
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
 	return &session.Session{ID: id, Status: st}, nil
+}
+
+func (f *fakeSessions) UpdateStatus(id string, st session.Status) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.statuses[id]; !ok {
+		return fmt.Errorf("session not found: %s", id)
+	}
+	f.statuses[id] = st
+	return nil
 }
 
 func (f *fakeSessions) setStatus(id string, st session.Status) {
@@ -248,6 +261,12 @@ func TestRunner_CreatesSessionAndRecordsSuccess(t *testing.T) {
 	assert.Equal(t, "/tmp/proj", sessions.created[0].projectPath)
 	assert.Equal(t, "do the thing", sessions.created[0].prompt)
 	assert.Equal(t, a.ID, sessions.created[0].opts.AutomationID)
+
+	// The runner must promote the created session to working (Manager.Create
+	// inserts idle); without this the multi-run guard can never engage.
+	sess, err := sessions.Get("sess-1")
+	require.NoError(t, err)
+	assert.Equal(t, session.StatusWorking, sess.Status)
 
 	runs, err := store.ListRuns(a.ID, 10)
 	require.NoError(t, err)

--- a/internal/automation/model.go
+++ b/internal/automation/model.go
@@ -1,0 +1,119 @@
+package automation
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// TriggerType identifies how an automation is scheduled.
+type TriggerType string
+
+const (
+	// TriggerInterval fires at a fixed interval. TriggerValue is a Go
+	// duration string (e.g. "30m", "1h").
+	TriggerInterval TriggerType = "interval"
+	// TriggerCron fires according to a standard 5-field cron expression
+	// stored in TriggerValue (e.g. "0 9 * * 1-5").
+	TriggerCron TriggerType = "cron"
+)
+
+// RunStatus is the outcome of a single automation firing.
+type RunStatus string
+
+const (
+	RunSuccess RunStatus = "success" // session was created and the prompt was sent
+	RunSkipped RunStatus = "skipped" // previous run was still working, firing skipped
+	RunError   RunStatus = "error"   // session creation / prompt send failed
+)
+
+// Automation is a scheduled prompt that creates a new session when fired.
+type Automation struct {
+	ID           string      `json:"id"`
+	Name         string      `json:"name"`
+	Prompt       string      `json:"prompt"`
+	TriggerType  TriggerType `json:"triggerType"`
+	TriggerValue string      `json:"triggerValue"`
+	// ProjectPath is the project working directory the created session runs
+	// in. Empty means the controller area (~/.agmux/controller).
+	ProjectPath string    `json:"projectPath,omitempty"`
+	Enabled     bool      `json:"enabled"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+// Run is one entry in the execution history of an automation.
+type Run struct {
+	ID           int64     `json:"id"`
+	AutomationID string    `json:"automationId"`
+	FiredAt      time.Time `json:"firedAt"`
+	// SessionID is the session created by this run. Empty for skipped /
+	// error runs.
+	SessionID string    `json:"sessionId,omitempty"`
+	Status    RunStatus `json:"status"`
+	Message   string    `json:"message,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// ValidateTrigger checks that the trigger type / value combination is parseable.
+func ValidateTrigger(triggerType TriggerType, triggerValue string) error {
+	switch triggerType {
+	case TriggerInterval:
+		d, err := time.ParseDuration(triggerValue)
+		if err != nil {
+			return fmt.Errorf("invalid interval %q: %w", triggerValue, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("interval must be positive, got %q", triggerValue)
+		}
+		return nil
+	case TriggerCron:
+		if _, err := cron.ParseStandard(triggerValue); err != nil {
+			return fmt.Errorf("invalid cron expression %q: %w", triggerValue, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown trigger type %q", triggerType)
+	}
+}
+
+// NextFireTime returns the next time the automation should fire strictly
+// after the given reference time (the last fire time, or the creation time
+// when the automation has never fired).
+func NextFireTime(a Automation, after time.Time) (time.Time, error) {
+	switch a.TriggerType {
+	case TriggerInterval:
+		d, err := time.ParseDuration(a.TriggerValue)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid interval %q: %w", a.TriggerValue, err)
+		}
+		if d <= 0 {
+			return time.Time{}, fmt.Errorf("interval must be positive, got %q", a.TriggerValue)
+		}
+		return after.Add(d), nil
+	case TriggerCron:
+		sched, err := cron.ParseStandard(a.TriggerValue)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid cron expression %q: %w", a.TriggerValue, err)
+		}
+		return sched.Next(after), nil
+	default:
+		return time.Time{}, fmt.Errorf("unknown trigger type %q", a.TriggerType)
+	}
+}
+
+// IsDue reports whether the automation should fire at `now`, given the last
+// fire time (zero value means never fired; the automation's CreatedAt is used
+// as the baseline so a fresh automation does not fire immediately).
+func IsDue(a Automation, lastFiredAt, now time.Time) (bool, error) {
+	base := lastFiredAt
+	if base.IsZero() {
+		base = a.CreatedAt
+	}
+	next, err := NextFireTime(a, base)
+	if err != nil {
+		return false, err
+	}
+	return !next.After(now), nil
+}

--- a/internal/automation/runner.go
+++ b/internal/automation/runner.go
@@ -1,0 +1,120 @@
+package automation
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/myuon/agmux/internal/db"
+	"github.com/myuon/agmux/internal/session"
+)
+
+// SessionCreator is the subset of session.SessionService the runner needs.
+// session.Manager satisfies it.
+type SessionCreator interface {
+	Create(name, projectPath, prompt string, worktree bool, opts ...session.CreateOpts) (*session.Session, error)
+	Get(id string) (*session.Session, error)
+}
+
+// Runner executes a fired automation: it creates a new session and sends the
+// automation prompt to it. When the session created by the previous run is
+// still active, the firing is skipped and recorded as such.
+type Runner struct {
+	store    *Store
+	sessions SessionCreator
+	logger   *slog.Logger
+	// controllerDir resolves the working directory for automations without a
+	// project. Defaults to db.ControllerDir; injectable for tests.
+	controllerDir func() (string, error)
+}
+
+// NewRunner creates a Runner backed by the given store and session service.
+func NewRunner(store *Store, sessions SessionCreator, logger *slog.Logger) *Runner {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Runner{
+		store:         store,
+		sessions:      sessions,
+		logger:        logger.With("component", "automation_runner"),
+		controllerDir: db.ControllerDir,
+	}
+}
+
+// Run executes one firing of the automation and records the outcome in the
+// run history. It never returns an error: failures are recorded as error
+// runs and logged.
+func (r *Runner) Run(a Automation, firedAt time.Time) *Run {
+	run := Run{AutomationID: a.ID, FiredAt: firedAt}
+
+	// Multi-run guard: skip when the session created by the previous run is
+	// still active.
+	if sessID, active := r.previousRunActive(a.ID); active {
+		run.Status = RunSkipped
+		run.Message = fmt.Sprintf("previous run session %s is still active", sessID)
+		r.logger.Info("automation skipped: previous run still active",
+			"automationId", a.ID, "name", a.Name, "sessionId", sessID)
+		return r.record(run)
+	}
+
+	projectPath := a.ProjectPath
+	if projectPath == "" {
+		dir, err := r.controllerDir()
+		if err != nil {
+			run.Status = RunError
+			run.Message = fmt.Sprintf("resolve controller dir: %v", err)
+			r.logger.Error("automation failed: controller dir", "automationId", a.ID, "error", err)
+			return r.record(run)
+		}
+		projectPath = dir
+	}
+
+	name := fmt.Sprintf("%s (auto)", a.Name)
+	sess, err := r.sessions.Create(name, projectPath, a.Prompt, false, session.CreateOpts{
+		AutomationID: a.ID,
+	})
+	if err != nil {
+		run.Status = RunError
+		run.Message = err.Error()
+		r.logger.Error("automation failed: create session",
+			"automationId", a.ID, "name", a.Name, "error", err)
+		return r.record(run)
+	}
+
+	run.Status = RunSuccess
+	run.SessionID = sess.ID
+	r.logger.Info("automation fired: session created",
+		"automationId", a.ID, "name", a.Name, "sessionId", sess.ID, "projectPath", projectPath)
+	return r.record(run)
+}
+
+// previousRunActive reports whether the session created by the most recent
+// run of the automation is still in progress (working or waiting for input).
+func (r *Runner) previousRunActive(automationID string) (string, bool) {
+	prev, err := r.store.LatestSessionRun(automationID)
+	if err != nil {
+		r.logger.Warn("automation: query latest session run failed", "automationId", automationID, "error", err)
+		return "", false
+	}
+	if prev == nil {
+		return "", false
+	}
+	sess, err := r.sessions.Get(prev.SessionID)
+	if err != nil {
+		// Session was deleted or cannot be loaded: treat as not running.
+		return "", false
+	}
+	if sess.Status == session.StatusWorking || sess.Status == session.StatusWaitingInput {
+		return sess.ID, true
+	}
+	return "", false
+}
+
+func (r *Runner) record(run Run) *Run {
+	saved, err := r.store.InsertRun(run)
+	if err != nil {
+		r.logger.Error("automation: record run failed", "automationId", run.AutomationID, "error", err)
+		return &run
+	}
+	return saved
+}

--- a/internal/automation/runner.go
+++ b/internal/automation/runner.go
@@ -14,6 +14,7 @@ import (
 type SessionCreator interface {
 	Create(name, projectPath, prompt string, worktree bool, opts ...session.CreateOpts) (*session.Session, error)
 	Get(id string) (*session.Session, error)
+	UpdateStatus(id string, status session.Status) error
 }
 
 // Runner executes a fired automation: it creates a new session and sends the
@@ -79,6 +80,16 @@ func (r *Runner) Run(a Automation, firedAt time.Time) *Run {
 		r.logger.Error("automation failed: create session",
 			"automationId", a.ID, "name", a.Name, "error", err)
 		return r.record(run)
+	}
+
+	// Manager.Create inserts the session with status idle; promote it to
+	// working so the multi-run guard above can detect it as still active
+	// (same pattern as the send endpoint after SendKeys). The turn-complete
+	// callback wired in Manager.Create sets it back to idle when the CLI
+	// finishes the turn.
+	if err := r.sessions.UpdateStatus(sess.ID, session.StatusWorking); err != nil {
+		r.logger.Warn("automation: failed to mark session as working; the multi-run guard may not engage for this run",
+			"automationId", a.ID, "sessionId", sess.ID, "error", err)
 	}
 
 	run.Status = RunSuccess

--- a/internal/automation/scheduler.go
+++ b/internal/automation/scheduler.go
@@ -1,0 +1,133 @@
+package automation
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// DefaultTickInterval is how often the scheduler checks for due automations.
+// Cron expressions have minute resolution, so 30s keeps firing latency low
+// without busy-polling SQLite.
+const DefaultTickInterval = 30 * time.Second
+
+// runner abstracts Runner for tests.
+type runner interface {
+	Run(a Automation, firedAt time.Time) *Run
+}
+
+// Scheduler periodically checks enabled automations and fires the ones that
+// are due. The last fire time is derived from the run history (skipped and
+// error runs count as fired), which makes the scheduler restart-safe: after
+// a daemon restart a missed schedule fires at most once.
+type Scheduler struct {
+	store    *Store
+	runner   runner
+	logger   *slog.Logger
+	interval time.Duration
+	now      func() time.Time
+
+	mu     sync.Mutex
+	stopCh chan struct{}
+	doneCh chan struct{}
+}
+
+// NewScheduler creates a scheduler with the default tick interval.
+func NewScheduler(store *Store, r *Runner, logger *slog.Logger) *Scheduler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Scheduler{
+		store:    store,
+		runner:   r,
+		logger:   logger.With("component", "automation_scheduler"),
+		interval: DefaultTickInterval,
+		now:      time.Now,
+	}
+}
+
+// SetTickInterval overrides the tick interval. Must be called before Start.
+func (s *Scheduler) SetTickInterval(d time.Duration) {
+	if d > 0 {
+		s.interval = d
+	}
+}
+
+// Start launches the scheduler loop in a goroutine. Calling Start on a
+// running scheduler is a no-op.
+func (s *Scheduler) Start() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopCh != nil {
+		return
+	}
+	s.stopCh = make(chan struct{})
+	s.doneCh = make(chan struct{})
+	s.logger.Info("automation scheduler started", "tickInterval", s.interval)
+
+	go func(stopCh, doneCh chan struct{}) {
+		defer close(doneCh)
+		ticker := time.NewTicker(s.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopCh:
+				return
+			case <-ticker.C:
+				s.Tick(s.now())
+			}
+		}
+	}(s.stopCh, s.doneCh)
+}
+
+// Stop terminates the scheduler loop and waits for it to exit.
+func (s *Scheduler) Stop() {
+	s.mu.Lock()
+	stopCh, doneCh := s.stopCh, s.doneCh
+	s.stopCh, s.doneCh = nil, nil
+	s.mu.Unlock()
+	if stopCh == nil {
+		return
+	}
+	close(stopCh)
+	<-doneCh
+	s.logger.Info("automation scheduler stopped")
+}
+
+// Tick checks all enabled automations and fires the due ones. Exposed for
+// tests; the Start loop calls it on every tick.
+func (s *Scheduler) Tick(now time.Time) {
+	automations, err := s.store.ListEnabled()
+	if err != nil {
+		s.logger.Error("automation scheduler: list enabled failed", "error", err)
+		return
+	}
+	for _, a := range automations {
+		due, err := s.isDue(a, now)
+		if err != nil {
+			s.logger.Warn("automation scheduler: invalid trigger, skipping",
+				"automationId", a.ID, "name", a.Name,
+				"triggerType", a.TriggerType, "triggerValue", a.TriggerValue, "error", err)
+			continue
+		}
+		if !due {
+			continue
+		}
+		// Runs are executed synchronously: the runner records the outcome
+		// (success / skipped / error) before the next automation is checked,
+		// so a single tick can never double-fire the same automation.
+		s.runner.Run(a, now)
+	}
+}
+
+func (s *Scheduler) isDue(a Automation, now time.Time) (bool, error) {
+	last, err := s.store.LatestRun(a.ID)
+	if err != nil {
+		return false, err
+	}
+	var lastFiredAt time.Time
+	if last != nil {
+		lastFiredAt = last.FiredAt
+	}
+	return IsDue(a, lastFiredAt, now)
+}

--- a/internal/automation/scheduler.go
+++ b/internal/automation/scheduler.go
@@ -1,6 +1,7 @@
 package automation
 
 import (
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -105,7 +106,9 @@ func (s *Scheduler) Tick(now time.Time) {
 	for _, a := range automations {
 		due, err := s.isDue(a, now)
 		if err != nil {
-			s.logger.Warn("automation scheduler: invalid trigger, skipping",
+			// The wrapped error explains the cause (query latest run failed
+			// vs. invalid trigger definition).
+			s.logger.Warn("automation scheduler: due check failed, skipping",
 				"automationId", a.ID, "name", a.Name,
 				"triggerType", a.TriggerType, "triggerValue", a.TriggerValue, "error", err)
 			continue
@@ -123,11 +126,15 @@ func (s *Scheduler) Tick(now time.Time) {
 func (s *Scheduler) isDue(a Automation, now time.Time) (bool, error) {
 	last, err := s.store.LatestRun(a.ID)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("query latest run: %w", err)
 	}
 	var lastFiredAt time.Time
 	if last != nil {
 		lastFiredAt = last.FiredAt
 	}
-	return IsDue(a, lastFiredAt, now)
+	due, err := IsDue(a, lastFiredAt, now)
+	if err != nil {
+		return false, fmt.Errorf("invalid trigger: %w", err)
+	}
+	return due, nil
 }

--- a/internal/automation/store.go
+++ b/internal/automation/store.go
@@ -1,0 +1,312 @@
+package automation
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	gonanoid "github.com/matoous/go-nanoid/v2"
+)
+
+const nanoidAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
+
+func newAutomationID() (string, error) {
+	return gonanoid.Generate(nanoidAlphabet, 8)
+}
+
+// Store manages automations / automation_runs rows in SQLite.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore creates a store backed by the given SQLite DB.
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// CreateParams holds the fields required to create an automation.
+type CreateParams struct {
+	Name         string
+	Prompt       string
+	TriggerType  TriggerType
+	TriggerValue string
+	ProjectPath  string // empty = controller area
+	Enabled      bool
+}
+
+// Create inserts a new automation and returns it.
+func (s *Store) Create(p CreateParams) (*Automation, error) {
+	if p.Name == "" {
+		return nil, fmt.Errorf("automation name is required")
+	}
+	if p.Prompt == "" {
+		return nil, fmt.Errorf("automation prompt is required")
+	}
+	if err := ValidateTrigger(p.TriggerType, p.TriggerValue); err != nil {
+		return nil, err
+	}
+
+	id, err := newAutomationID()
+	if err != nil {
+		return nil, fmt.Errorf("generate automation id: %w", err)
+	}
+
+	now := time.Now()
+	a := &Automation{
+		ID:           id,
+		Name:         p.Name,
+		Prompt:       p.Prompt,
+		TriggerType:  p.TriggerType,
+		TriggerValue: p.TriggerValue,
+		ProjectPath:  p.ProjectPath,
+		Enabled:      p.Enabled,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO automations (id, name, prompt, trigger_type, trigger_value, project_path, enabled, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		a.ID, a.Name, a.Prompt, string(a.TriggerType), a.TriggerValue, a.ProjectPath, boolToInt(a.Enabled), a.CreatedAt, a.UpdatedAt,
+	); err != nil {
+		return nil, fmt.Errorf("insert automation: %w", err)
+	}
+	return a, nil
+}
+
+// UpdateParams holds the editable fields of an automation.
+type UpdateParams struct {
+	Name         string
+	Prompt       string
+	TriggerType  TriggerType
+	TriggerValue string
+	ProjectPath  string
+	Enabled      bool
+}
+
+// Update replaces the editable fields of an automation.
+func (s *Store) Update(id string, p UpdateParams) (*Automation, error) {
+	if p.Name == "" {
+		return nil, fmt.Errorf("automation name is required")
+	}
+	if p.Prompt == "" {
+		return nil, fmt.Errorf("automation prompt is required")
+	}
+	if err := ValidateTrigger(p.TriggerType, p.TriggerValue); err != nil {
+		return nil, err
+	}
+	res, err := s.db.Exec(
+		`UPDATE automations SET name = ?, prompt = ?, trigger_type = ?, trigger_value = ?, project_path = ?, enabled = ?, updated_at = ? WHERE id = ?`,
+		p.Name, p.Prompt, string(p.TriggerType), p.TriggerValue, p.ProjectPath, boolToInt(p.Enabled), time.Now(), id,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update automation: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return nil, fmt.Errorf("automation not found: %s", id)
+	}
+	return s.Get(id)
+}
+
+// SetEnabled toggles the enabled flag of an automation.
+func (s *Store) SetEnabled(id string, enabled bool) error {
+	res, err := s.db.Exec(
+		`UPDATE automations SET enabled = ?, updated_at = ? WHERE id = ?`,
+		boolToInt(enabled), time.Now(), id,
+	)
+	if err != nil {
+		return fmt.Errorf("update automation enabled: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("automation not found: %s", id)
+	}
+	return nil
+}
+
+// Delete removes an automation and its run history.
+func (s *Store) Delete(id string) error {
+	res, err := s.db.Exec(`DELETE FROM automations WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete automation: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("automation not found: %s", id)
+	}
+	if _, err := s.db.Exec(`DELETE FROM automation_runs WHERE automation_id = ?`, id); err != nil {
+		return fmt.Errorf("delete automation runs: %w", err)
+	}
+	return nil
+}
+
+// Get returns an automation by ID.
+func (s *Store) Get(id string) (*Automation, error) {
+	row := s.db.QueryRow(
+		`SELECT id, name, prompt, trigger_type, trigger_value, project_path, enabled, created_at, updated_at
+		 FROM automations WHERE id = ?`, id,
+	)
+	a, err := scanAutomation(row)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("automation not found: %s", id)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query automation: %w", err)
+	}
+	return a, nil
+}
+
+// List returns all automations ordered by creation time (newest first).
+func (s *Store) List() ([]Automation, error) {
+	return s.list(`SELECT id, name, prompt, trigger_type, trigger_value, project_path, enabled, created_at, updated_at
+		FROM automations ORDER BY created_at DESC`)
+}
+
+// ListEnabled returns all enabled automations.
+func (s *Store) ListEnabled() ([]Automation, error) {
+	return s.list(`SELECT id, name, prompt, trigger_type, trigger_value, project_path, enabled, created_at, updated_at
+		FROM automations WHERE enabled = 1 ORDER BY created_at DESC`)
+}
+
+func (s *Store) list(query string) ([]Automation, error) {
+	rows, err := s.db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("query automations: %w", err)
+	}
+	defer rows.Close()
+
+	var automations []Automation
+	for rows.Next() {
+		a, err := scanAutomation(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan automation: %w", err)
+		}
+		automations = append(automations, *a)
+	}
+	return automations, rows.Err()
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAutomation(row rowScanner) (*Automation, error) {
+	var a Automation
+	var triggerType string
+	var projectPath sql.NullString
+	var enabledInt int
+	if err := row.Scan(&a.ID, &a.Name, &a.Prompt, &triggerType, &a.TriggerValue, &projectPath, &enabledInt, &a.CreatedAt, &a.UpdatedAt); err != nil {
+		return nil, err
+	}
+	a.TriggerType = TriggerType(triggerType)
+	if projectPath.Valid {
+		a.ProjectPath = projectPath.String
+	}
+	a.Enabled = enabledInt != 0
+	return &a, nil
+}
+
+// InsertRun appends an execution history entry and returns it with its ID set.
+func (s *Store) InsertRun(run Run) (*Run, error) {
+	now := time.Now()
+	res, err := s.db.Exec(
+		`INSERT INTO automation_runs (automation_id, fired_at, session_id, status, message, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		run.AutomationID, run.FiredAt, run.SessionID, string(run.Status), run.Message, now,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert automation run: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("automation run last insert id: %w", err)
+	}
+	run.ID = id
+	run.CreatedAt = now
+	return &run, nil
+}
+
+// ListRuns returns the execution history of an automation, newest first.
+func (s *Store) ListRuns(automationID string, limit int) ([]Run, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.Query(
+		`SELECT id, automation_id, fired_at, session_id, status, message, created_at
+		 FROM automation_runs WHERE automation_id = ? ORDER BY fired_at DESC, id DESC LIMIT ?`,
+		automationID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query automation runs: %w", err)
+	}
+	defer rows.Close()
+
+	var runs []Run
+	for rows.Next() {
+		r, err := scanRun(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan automation run: %w", err)
+		}
+		runs = append(runs, *r)
+	}
+	return runs, rows.Err()
+}
+
+// LatestRun returns the most recent run of an automation regardless of
+// status, or nil if the automation has never fired.
+func (s *Store) LatestRun(automationID string) (*Run, error) {
+	row := s.db.QueryRow(
+		`SELECT id, automation_id, fired_at, session_id, status, message, created_at
+		 FROM automation_runs WHERE automation_id = ? ORDER BY fired_at DESC, id DESC LIMIT 1`,
+		automationID,
+	)
+	r, err := scanRun(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query latest automation run: %w", err)
+	}
+	return r, nil
+}
+
+// LatestSessionRun returns the most recent run that created a session, or
+// nil if no run has created a session yet. Used for the multi-run skip check.
+func (s *Store) LatestSessionRun(automationID string) (*Run, error) {
+	row := s.db.QueryRow(
+		`SELECT id, automation_id, fired_at, session_id, status, message, created_at
+		 FROM automation_runs
+		 WHERE automation_id = ? AND session_id IS NOT NULL AND session_id != ''
+		 ORDER BY fired_at DESC, id DESC LIMIT 1`,
+		automationID,
+	)
+	r, err := scanRun(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query latest session run: %w", err)
+	}
+	return r, nil
+}
+
+func scanRun(row rowScanner) (*Run, error) {
+	var r Run
+	var sessionID, message sql.NullString
+	var status string
+	if err := row.Scan(&r.ID, &r.AutomationID, &r.FiredAt, &sessionID, &status, &message, &r.CreatedAt); err != nil {
+		return nil, err
+	}
+	if sessionID.Valid {
+		r.SessionID = sessionID.String
+	}
+	if message.Valid {
+		r.Message = message.String
+	}
+	r.Status = RunStatus(status)
+	return &r, nil
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/db/sqlite.go
+++ b/internal/db/sqlite.go
@@ -369,6 +369,53 @@ func migrate(db *sql.DB) error {
 		return err
 	}
 
+	// Migration: add automation_id column to sessions (marks sessions created by an automation)
+	_, err = db.Exec(`ALTER TABLE sessions ADD COLUMN automation_id TEXT`)
+	if err != nil && !isAlterTableDuplicate(err) {
+		return err
+	}
+
+	// Migration: create automations table
+	// trigger_type is 'interval' (trigger_value = Go duration, e.g. "30m")
+	// or 'cron' (trigger_value = standard 5-field cron expression).
+	// project_path is NULL/'' for automations that run in the controller area.
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS automations (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			prompt TEXT NOT NULL,
+			trigger_type TEXT NOT NULL,
+			trigger_value TEXT NOT NULL,
+			project_path TEXT,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		return err
+	}
+
+	// Migration: create automation_runs table (execution history)
+	// status: 'success' | 'skipped' | 'error'. session_id is set on success.
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS automation_runs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			automation_id TEXT NOT NULL,
+			fired_at DATETIME NOT NULL,
+			session_id TEXT,
+			status TEXT NOT NULL,
+			message TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		return err
+	}
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_automation_runs_automation ON automation_runs(automation_id)`)
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_automation_runs_fired ON automation_runs(fired_at)`)
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_sessions_automation ON sessions(automation_id)`)
+
 	return nil
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -474,6 +474,7 @@ type CreateOpts struct {
 	RoleTemplate            string // name of the role template used to create this session
 	Ephemeral               bool   // create as ephemeral session
 	EphemeralTimeoutSeconds *int   // timeout in seconds for ephemeral sessions
+	AutomationID            string // ID of the automation that created this session (empty for manual sessions)
 }
 
 func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts ...CreateOpts) (*Session, error) {
@@ -485,6 +486,7 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	roleTemplate := ""
 	ephemeral := false
 	var ephemeralTimeoutSeconds *int
+	automationID := ""
 	if len(opts) > 0 {
 		if opts[0].Provider != "" {
 			pn = opts[0].Provider
@@ -496,6 +498,7 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		roleTemplate = opts[0].RoleTemplate
 		ephemeral = opts[0].Ephemeral
 		ephemeralTimeoutSeconds = opts[0].EphemeralTimeoutSeconds
+		automationID = opts[0].AutomationID
 	}
 
 	// Validate parent session exists when creating a sub-session
@@ -608,6 +611,7 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		Model:                   model,
 		ParentSessionID:         parentSessionID,
 		RoleTemplate:            roleTemplate,
+		AutomationID:            automationID,
 		EphemeralTimeoutSeconds: ephemeralTimeoutSeconds,
 		CreatedAt:               now,
 		UpdatedAt:               now,
@@ -618,9 +622,9 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 		holderPID = sp.HolderPID()
 	}
 	if _, err := m.db.Exec(
-		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, system_prompt, parent_session_id, role_template, holder_pid, ephemeral_timeout_seconds, completion_report, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, s.RoleTemplate, holderPID, s.EphemeralTimeoutSeconds, s.CompletionReport, s.CreatedAt, s.UpdatedAt,
+		`INSERT INTO sessions (id, name, project_path, initial_prompt, tmux_session, status, type, output_mode, provider, model, system_prompt, parent_session_id, role_template, automation_id, holder_pid, ephemeral_timeout_seconds, completion_report, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Name, s.ProjectPath, s.InitialPrompt, "", string(s.Status), string(s.Type), "stream", string(s.Provider), s.Model, s.SystemPrompt, s.ParentSessionID, s.RoleTemplate, s.AutomationID, holderPID, s.EphemeralTimeoutSeconds, s.CompletionReport, s.CreatedAt, s.UpdatedAt,
 	); err != nil {
 		return nil, fmt.Errorf("insert session: %w", err)
 	}
@@ -722,7 +726,7 @@ func (m *Manager) UpdateStatusWithHolderPIDClear(id string, status Status) error
 
 func (m *Manager) List() ([]Session, error) {
 	rows, err := m.db.Query(
-		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, ephemeral_timeout_seconds, completion_report, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, automation_id, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, ephemeral_timeout_seconds, completion_report, created_at, updated_at
 		 FROM sessions ORDER BY created_at DESC`,
 	)
 	if err != nil {
@@ -736,10 +740,10 @@ func (m *Manager) List() ([]Session, error) {
 		var status string
 		var sessionType string
 		var providerStr string
-		var prompt, systemPrompt, parentSessionID, roleTemplate, currentTask, goal, goalsJSON, lastError, completionReport sql.NullString
+		var prompt, systemPrompt, parentSessionID, roleTemplate, automationID, currentTask, goal, goalsJSON, lastError, completionReport sql.NullString
 		var conversationStartedInt int
 		var ephemeralTimeoutSeconds sql.NullInt64
-		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &ephemeralTimeoutSeconds, &completionReport, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		if err := rows.Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &automationID, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &ephemeralTimeoutSeconds, &completionReport, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		s.ConversationStarted = conversationStartedInt != 0
@@ -760,6 +764,9 @@ func (m *Manager) List() ([]Session, error) {
 		}
 		if roleTemplate.Valid {
 			s.RoleTemplate = roleTemplate.String
+		}
+		if automationID.Valid {
+			s.AutomationID = automationID.String
 		}
 		if currentTask.Valid {
 			s.CurrentTask = currentTask.String
@@ -792,13 +799,13 @@ func (m *Manager) Get(id string) (*Session, error) {
 	var status string
 	var sessionType string
 	var providerStr string
-	var prompt, systemPrompt, parentSessionID, roleTemplate, currentTask, goal, goalsJSON, lastError, completionReport sql.NullString
+	var prompt, systemPrompt, parentSessionID, roleTemplate, automationID, currentTask, goal, goalsJSON, lastError, completionReport sql.NullString
 	var conversationStartedInt int
 	var ephemeralTimeoutSeconds sql.NullInt64
 	err := m.db.QueryRow(
-		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, ephemeral_timeout_seconds, completion_report, created_at, updated_at
+		`SELECT id, name, project_path, initial_prompt, system_prompt, status, type, provider, cli_session_id, model, parent_session_id, role_template, automation_id, current_task, goal, goals, last_error, holder_pid, clear_offset, conversation_started, ephemeral_timeout_seconds, completion_report, created_at, updated_at
 		 FROM sessions WHERE id = ?`, id,
-	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &ephemeralTimeoutSeconds, &completionReport, &s.CreatedAt, &s.UpdatedAt)
+	).Scan(&s.ID, &s.Name, &s.ProjectPath, &prompt, &systemPrompt, &status, &sessionType, &providerStr, &s.CliSessionID, &s.Model, &parentSessionID, &roleTemplate, &automationID, &currentTask, &goal, &goalsJSON, &lastError, &s.HolderPID, &s.ClearOffset, &conversationStartedInt, &ephemeralTimeoutSeconds, &completionReport, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
@@ -823,6 +830,9 @@ func (m *Manager) Get(id string) (*Session, error) {
 	}
 	if roleTemplate.Valid {
 		s.RoleTemplate = roleTemplate.String
+	}
+	if automationID.Valid {
+		s.AutomationID = automationID.String
 	}
 	if currentTask.Valid {
 		s.CurrentTask = currentTask.String

--- a/internal/session/manager_holderPID_test.go
+++ b/internal/session/manager_holderPID_test.go
@@ -32,6 +32,7 @@ func newTestDB(t *testing.T) *sql.DB {
 			system_prompt TEXT,
 			parent_session_id TEXT,
 			role_template TEXT,
+			automation_id TEXT,
 			holder_pid INTEGER NOT NULL DEFAULT 0,
 			clear_offset INTEGER NOT NULL DEFAULT 0,
 			cli_session_id TEXT NOT NULL DEFAULT '',

--- a/internal/session/model.go
+++ b/internal/session/model.go
@@ -45,6 +45,7 @@ type Session struct {
 	Model           string       `json:"model,omitempty"`
 	ParentSessionID string       `json:"parentSessionId,omitempty"`
 	RoleTemplate    string       `json:"roleTemplate,omitempty"`
+	AutomationID    string       `json:"automationId,omitempty"`
 	CurrentTask     string       `json:"currentTask,omitempty"`
 	Goal            string       `json:"goal,omitempty"`
 	Goals           GoalStack    `json:"goals,omitempty"`


### PR DESCRIPTION
Closes #667

親イシュー: #663（仕様は親 issue body を参照。このPRでは close しない）

## 変更概要

Automation 機能のバックエンド基盤を追加する。

### データモデル / DB（`internal/db/sqlite.go`）
- `automations` テーブル: id, name, prompt, trigger_type (`interval` | `cron`), trigger_value, project_path (nullable), enabled, created_at, updated_at
- `automation_runs` テーブル: id, automation_id, fired_at, session_id (nullable), status (`success` | `skipped` | `error`), message
- `sessions.automation_id` カラムを追加し、Automation が作成したセッションを記録（`CreateOpts.AutomationID` 経由で INSERT、List/Get でも返却）

### `internal/automation` パッケージ（新設）
- **Store**: automations / automation_runs の CRUD・履歴取得（`ListRuns` / `LatestRun` / `LatestSessionRun`）。後続の API / CLI sub-issue から利用できるようメソッドを揃えてある
- **Scheduler**: daemon 内で 30 秒ごとに tick し、enabled な automation のみ発動判定。`agmux serve` 起動時に開始、graceful shutdown 時に停止
- **Runner**: 発動時に `Manager.Create` で新規セッションを作成して prompt を送信。project 未指定なら `db.ControllerDir()`（controller 領域）で起動

## 設計判断

- **トリガー表現**: `trigger_type` + `trigger_value` の2カラム。interval は Go duration 文字列（例 `30m`）、cron は標準5フィールド式。cron パーサは既存依存になかったため定番の `robfig/cron/v3` を追加
- **発動判定は run 履歴ベース（restart-safe）**: 最終発動時刻を `automation_runs` の最新 `fired_at`（なければ `created_at`）から導出し、`NextFireTime <= now` で発動。daemon 再起動を挟んでも二重発動せず、停止中に複数回分のスケジュールを逃した場合は再起動後に1回だけ発動する
- **多重起動スキップ**: 直近でセッションを作成した run のセッションが `working` / `waiting_input` の間は発動をスキップし、`skipped` として履歴に記録。skipped / error も「発動済み」として扱うため、次の周期までリトライ連打しない
- **セッションへの記録**: 関連テーブルではなく `sessions.automation_id` カラム追加を採用（`parent_session_id` / `role_template` 等の既存パターンに準拠）
- **エラーハンドリング**: Runner は失敗を `error` run として履歴に記録してログ出力し、スケジューラ本体は止めない

## スコープ外（#663 の別 sub-issue）

API エンドポイント、Web UI、セッション一覧フィルタ、CLI

## テスト結果

- `make build` ✅
- `make test`（`go test ./...`）✅ 全パッケージ green
- 追加ユニットテスト（`internal/automation/automation_test.go`）:
  - 発動判定（interval / cron、未発動時は created_at 基準、無効トリガー）
  - Store CRUD・バリデーション
  - Runner: セッション作成 + AutomationID 付与、controller 領域フォールバック、多重起動スキップ（working / waiting_input）、削除済みセッションでブロックしない、エラー記録
  - Scheduler: due 判定で発動・二重発動しない・disabled 無視・skip 後のスケジュール前進・Start/Stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)