### PR TITLE
feat: Automation の API と Web UI 専用設定画面を追加 (#668)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -162,6 +162,11 @@ function AppHeaderButtons({
           </svg>
         </IconButton>
       )}
+      <IconButton shape="rounded" to="/automations" title="Automations">
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
+        </svg>
+      </IconButton>
       <IconButton shape="rounded" to="/metrics" title="Metrics">
         <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
           <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -200,7 +200,66 @@ export const api = {
       `/sessions/${sessionId}/background-tasks`
     ),
 
+  listAutomations: () => request<Automation[]>("/automations"),
+
+  getAutomation: (id: string) => request<Automation>(`/automations/${id}`),
+
+  createAutomation: (data: AutomationInput) =>
+    request<Automation>("/automations", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+
+  updateAutomation: (id: string, data: AutomationInput) =>
+    request<Automation>(`/automations/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
+
+  deleteAutomation: (id: string) =>
+    request<{ status: string }>(`/automations/${id}`, { method: "DELETE" }),
+
+  setAutomationEnabled: (id: string, enabled: boolean) =>
+    request<Automation>(`/automations/${id}/enabled`, {
+      method: "PUT",
+      body: JSON.stringify({ enabled }),
+    }),
+
+  listAutomationRuns: (id: string, limit = 50) =>
+    request<AutomationRun[]>(`/automations/${id}/runs?limit=${limit}`),
+
 };
+
+export interface Automation {
+  id: string;
+  name: string;
+  prompt: string;
+  triggerType: "interval" | "cron";
+  triggerValue: string;
+  projectPath?: string;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AutomationInput {
+  name: string;
+  prompt: string;
+  triggerType: "interval" | "cron";
+  triggerValue: string;
+  projectPath?: string;
+  enabled: boolean;
+}
+
+export interface AutomationRun {
+  id: number;
+  automationId: string;
+  firedAt: string;
+  sessionId?: string;
+  status: "success" | "skipped" | "error";
+  message?: string;
+  createdAt: string;
+}
 
 // BackgroundTaskDTO mirrors `internal/session.BackgroundTask` (Go).
 export interface BackgroundTaskDTO {

--- a/frontend/src/models/automation.ts
+++ b/frontend/src/models/automation.ts
@@ -1,0 +1,9 @@
+import type { Automation } from "../api/client";
+
+export function formatTrigger(
+  a: Pick<Automation, "triggerType" | "triggerValue">
+): string {
+  return a.triggerType === "interval"
+    ? `${a.triggerValue} ごと`
+    : `cron: ${a.triggerValue}`;
+}

--- a/frontend/src/pages/AutomationDetailPage.tsx
+++ b/frontend/src/pages/AutomationDetailPage.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { useNavigate, useLoaderData, Link } from "react-router-dom";
+import { api } from "../api/client";
+import type { Automation, AutomationRun } from "../api/client";
+import { Section, Field } from "../components/ui/Section";
+import { ToggleButton } from "../components/ui/ToggleButton";
+import { AlertBanner } from "../components/ui/AlertBanner";
+import { formatTrigger } from "../models/automation";
+
+const RUN_STATUS_STYLES: Record<AutomationRun["status"], string> = {
+  success: "bg-green-50 border-green-300 text-green-700",
+  skipped: "bg-yellow-50 border-yellow-300 text-yellow-700",
+  error: "bg-red-50 border-red-300 text-red-700",
+};
+
+function RunStatusBadge({ status }: { status: AutomationRun["status"] }) {
+  return (
+    <span
+      className={`px-2 py-0.5 text-xs font-medium rounded-full border ${RUN_STATUS_STYLES[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+export function AutomationDetailPage() {
+  const navigate = useNavigate();
+  const { automation: initial, runs } = useLoaderData<{
+    automation: Automation;
+    runs: AutomationRun[];
+  }>();
+  const [automation, setAutomation] = useState<Automation>(initial);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleToggle = async () => {
+    setError(null);
+    try {
+      setAutomation(await api.setAutomationEnabled(automation.id, !automation.enabled));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "切替に失敗しました");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <header className="bg-white border-b border-gray-200 px-6 py-3 flex items-center gap-4">
+        <button
+          onClick={() => navigate("/automations")}
+          className="text-gray-500 hover:text-gray-700 text-sm"
+        >
+          ← Back
+        </button>
+        <h1 className="text-lg font-bold">{automation.name}</h1>
+      </header>
+
+      <div className="max-w-2xl mx-auto p-6 space-y-6">
+        {error && <AlertBanner variant="error">{error}</AlertBanner>}
+
+        <Section title="Automation">
+          <Field label="Trigger">
+            <span className="text-sm text-gray-800">{formatTrigger(automation)}</span>
+          </Field>
+          <Field label="Project">
+            <span className="text-sm text-gray-800 font-mono break-all">
+              {automation.projectPath || "(controller)"}
+            </span>
+          </Field>
+          <Field label="有効">
+            <ToggleButton enabled={automation.enabled} onClick={handleToggle}>
+              {automation.enabled ? "ON" : "OFF"}
+            </ToggleButton>
+          </Field>
+          <div>
+            <label className="text-sm text-gray-600 block mb-1">Prompt</label>
+            <pre className="bg-gray-50 border border-gray-200 rounded px-3 py-2 text-xs text-gray-700 whitespace-pre-wrap">
+              {automation.prompt}
+            </pre>
+          </div>
+        </Section>
+
+        <Section title="実行履歴">
+          {runs.length === 0 ? (
+            <div className="text-sm text-gray-400">まだ実行されていません</div>
+          ) : (
+            <div className="divide-y divide-gray-100">
+              {runs.map((run) => (
+                <div key={run.id} className="py-2.5 flex items-start gap-3">
+                  <RunStatusBadge status={run.status} />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm text-gray-800">
+                      {new Date(run.firedAt).toLocaleString()}
+                    </div>
+                    {run.message && (
+                      <div className="text-xs text-gray-500 break-all">{run.message}</div>
+                    )}
+                  </div>
+                  {run.sessionId && (
+                    <Link
+                      to={`/sessions/${run.sessionId}`}
+                      className="text-xs text-blue-600 hover:underline shrink-0"
+                    >
+                      セッションを開く
+                    </Link>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AutomationsPage.tsx
+++ b/frontend/src/pages/AutomationsPage.tsx
@@ -1,0 +1,296 @@
+import { useState } from "react";
+import { useNavigate, useLoaderData, Link } from "react-router-dom";
+import { api } from "../api/client";
+import type { Automation, AutomationInput } from "../api/client";
+import { ToggleButton } from "../components/ui/ToggleButton";
+import { AlertBanner } from "../components/ui/AlertBanner";
+import { formatTrigger } from "../models/automation";
+
+const EMPTY_INPUT: AutomationInput = {
+  name: "",
+  prompt: "",
+  triggerType: "interval",
+  triggerValue: "",
+  projectPath: "",
+  enabled: true,
+};
+
+// AutomationForm is the create / edit form. API-side validation errors
+// (e.g. invalid cron expressions) are surfaced via the error banner.
+export function AutomationForm({
+  initial,
+  onSubmit,
+  onCancel,
+  submitLabel,
+}: {
+  initial: AutomationInput;
+  onSubmit: (input: AutomationInput) => Promise<void>;
+  onCancel: () => void;
+  submitLabel: string;
+}) {
+  const [input, setInput] = useState<AutomationInput>(initial);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(input);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "保存に失敗しました");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const inputClass =
+    "bg-white border border-gray-300 rounded px-3 py-1.5 text-sm w-full focus:outline-none focus:border-blue-500";
+
+  return (
+    <div className="space-y-3">
+      {error && <AlertBanner variant="error">{error}</AlertBanner>}
+      <div>
+        <label className="text-sm text-gray-600 block mb-1">Name</label>
+        <input
+          type="text"
+          value={input.name}
+          onChange={(e) => setInput({ ...input, name: e.target.value })}
+          placeholder="e.g. daily report"
+          className={inputClass}
+        />
+      </div>
+      <div>
+        <label className="text-sm text-gray-600 block mb-1">Prompt</label>
+        <textarea
+          value={input.prompt}
+          onChange={(e) => setInput({ ...input, prompt: e.target.value })}
+          placeholder="発動時にエージェントへ渡す指示文"
+          rows={4}
+          className={inputClass}
+        />
+      </div>
+      <div className="flex gap-3">
+        <div>
+          <label className="text-sm text-gray-600 block mb-1">Trigger</label>
+          <select
+            value={input.triggerType}
+            onChange={(e) =>
+              setInput({ ...input, triggerType: e.target.value as AutomationInput["triggerType"] })
+            }
+            className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:border-blue-500"
+          >
+            <option value="interval">Interval</option>
+            <option value="cron">Cron</option>
+          </select>
+        </div>
+        <div className="flex-1">
+          <label className="text-sm text-gray-600 block mb-1">
+            {input.triggerType === "interval" ? "Interval（Go duration）" : "Cron 式（5フィールド）"}
+          </label>
+          <input
+            type="text"
+            value={input.triggerValue}
+            onChange={(e) => setInput({ ...input, triggerValue: e.target.value })}
+            placeholder={input.triggerType === "interval" ? "30m" : "0 9 * * 1-5"}
+            className={inputClass}
+          />
+        </div>
+      </div>
+      <div>
+        <label className="text-sm text-gray-600 block mb-1">Project Path (optional)</label>
+        <input
+          type="text"
+          value={input.projectPath || ""}
+          onChange={(e) => setInput({ ...input, projectPath: e.target.value })}
+          placeholder="未指定なら controller 領域で起動"
+          className={inputClass}
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="text-sm text-gray-600">有効</label>
+        <ToggleButton
+          enabled={input.enabled}
+          onClick={() => setInput({ ...input, enabled: !input.enabled })}
+        >
+          {input.enabled ? "ON" : "OFF"}
+        </ToggleButton>
+      </div>
+      <div className="flex gap-2 pt-1">
+        <button
+          onClick={handleSubmit}
+          disabled={submitting}
+          className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white px-4 py-1.5 rounded text-sm font-medium transition-colors"
+        >
+          {submitLabel}
+        </button>
+        <button
+          onClick={onCancel}
+          className="bg-gray-100 hover:bg-gray-200 text-gray-700 px-4 py-1.5 rounded text-sm transition-colors"
+        >
+          キャンセル
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function AutomationsPage() {
+  const navigate = useNavigate();
+  const { automations: initial } = useLoaderData<{ automations: Automation[] }>();
+  const [automations, setAutomations] = useState<Automation[]>(initial);
+  const [creating, setCreating] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = async () => {
+    try {
+      setAutomations(await api.listAutomations());
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Automation の取得に失敗しました");
+    }
+  };
+
+  const handleCreate = async (input: AutomationInput) => {
+    await api.createAutomation(input);
+    setCreating(false);
+    await reload();
+  };
+
+  const handleUpdate = async (id: string, input: AutomationInput) => {
+    await api.updateAutomation(id, input);
+    setEditingId(null);
+    await reload();
+  };
+
+  const handleToggle = async (a: Automation) => {
+    setError(null);
+    try {
+      const updated = await api.setAutomationEnabled(a.id, !a.enabled);
+      setAutomations((prev) => prev.map((x) => (x.id === updated.id ? updated : x)));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "切替に失敗しました");
+    }
+  };
+
+  const handleDelete = async (a: Automation) => {
+    if (!confirm(`Automation「${a.name}」を削除しますか？実行履歴も削除されます。`)) return;
+    setError(null);
+    try {
+      await api.deleteAutomation(a.id);
+      await reload();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "削除に失敗しました");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <header className="bg-white border-b border-gray-200 px-6 py-3 flex items-center gap-4">
+        <button
+          onClick={() => navigate("/")}
+          className="text-gray-500 hover:text-gray-700 text-sm"
+        >
+          ← Back
+        </button>
+        <h1 className="text-lg font-bold">Automations</h1>
+        <div className="ml-auto">
+          {!creating && (
+            <button
+              onClick={() => {
+                setCreating(true);
+                setEditingId(null);
+              }}
+              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-1.5 rounded text-sm font-medium transition-colors"
+            >
+              + New Automation
+            </button>
+          )}
+        </div>
+      </header>
+
+      <div className="max-w-2xl mx-auto p-6 space-y-4">
+        {error && <AlertBanner variant="error">{error}</AlertBanner>}
+
+        {creating && (
+          <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
+            <h2 className="text-sm font-semibold text-gray-700 mb-3">New Automation</h2>
+            <AutomationForm
+              initial={EMPTY_INPUT}
+              onSubmit={handleCreate}
+              onCancel={() => setCreating(false)}
+              submitLabel="作成"
+            />
+          </div>
+        )}
+
+        {automations.length === 0 && !creating ? (
+          <div className="text-center text-sm text-gray-400 py-12">
+            Automation はまだありません
+          </div>
+        ) : (
+          automations.map((a) => (
+            <div key={a.id} className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
+              {editingId === a.id ? (
+                <>
+                  <h2 className="text-sm font-semibold text-gray-700 mb-3">Edit Automation</h2>
+                  <AutomationForm
+                    initial={{
+                      name: a.name,
+                      prompt: a.prompt,
+                      triggerType: a.triggerType,
+                      triggerValue: a.triggerValue,
+                      projectPath: a.projectPath || "",
+                      enabled: a.enabled,
+                    }}
+                    onSubmit={(input) => handleUpdate(a.id, input)}
+                    onCancel={() => setEditingId(null)}
+                    submitLabel="保存"
+                  />
+                </>
+              ) : (
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <Link
+                      to={`/automations/${a.id}`}
+                      className="text-sm font-semibold text-blue-600 hover:underline"
+                    >
+                      {a.name}
+                    </Link>
+                    <div className="text-xs text-gray-500 mt-1">{formatTrigger(a)}</div>
+                    <div className="text-xs text-gray-500 font-mono truncate">
+                      {a.projectPath || "(controller)"}
+                    </div>
+                    <div className="text-xs text-gray-400 mt-1 line-clamp-2 whitespace-pre-wrap">
+                      {a.prompt}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <ToggleButton enabled={a.enabled} onClick={() => handleToggle(a)}>
+                      {a.enabled ? "ON" : "OFF"}
+                    </ToggleButton>
+                    <button
+                      onClick={() => {
+                        setEditingId(a.id);
+                        setCreating(false);
+                      }}
+                      className="text-xs text-gray-500 hover:text-gray-700 px-2 py-1 rounded hover:bg-gray-100"
+                    >
+                      編集
+                    </button>
+                    <button
+                      onClick={() => handleDelete(a)}
+                      className="text-xs text-red-500 hover:text-red-700 px-2 py-1 rounded hover:bg-red-50"
+                    >
+                      削除
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,6 +5,8 @@ import { ConfigPage } from "./pages/ConfigPage";
 import { MetricsPage } from "./pages/MetricsPage";
 import { PreviewPage } from "./pages/PreviewPage";
 import { ScenarioTestPage } from "./pages/ScenarioTestPage";
+import { AutomationsPage } from "./pages/AutomationsPage";
+import { AutomationDetailPage } from "./pages/AutomationDetailPage";
 import { api } from "./api/client";
 import { RouteErrorBoundary } from "./components/RouteErrorBoundary";
 
@@ -55,6 +57,26 @@ export const router = createBrowserRouter([
             },
           },
         ],
+      },
+      {
+        path: "automations",
+        element: <AutomationsPage />,
+        loader: async () => {
+          const automations = await api.listAutomations();
+          return { automations };
+        },
+      },
+      {
+        path: "automations/:id",
+        element: <AutomationDetailPage />,
+        loader: async ({ params }: LoaderFunctionArgs) => {
+          const id = params.id!;
+          const [automation, runs] = await Promise.all([
+            api.getAutomation(id),
+            api.listAutomationRuns(id),
+          ]);
+          return { automation, runs };
+        },
       },
       {
         path: "config",

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -9,6 +9,7 @@ export interface Session {
   model?: string;
   parentSessionId?: string;
   roleTemplate?: string;
+  automationId?: string;
   currentTask?: string;
   goal?: string;
   goals?: { currentTask: string; goal: string }[];

--- a/internal/server/automation.go
+++ b/internal/server/automation.go
@@ -1,0 +1,155 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/myuon/agmux/internal/automation"
+)
+
+// automationRequest is the request body for creating / updating an automation.
+type automationRequest struct {
+	Name         string `json:"name"`
+	Prompt       string `json:"prompt"`
+	TriggerType  string `json:"triggerType"`
+	TriggerValue string `json:"triggerValue"`
+	ProjectPath  string `json:"projectPath,omitempty"`
+	Enabled      bool   `json:"enabled"`
+}
+
+func (s *Server) listAutomations(w http.ResponseWriter, r *http.Request) {
+	automations, err := s.automations.List()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if automations == nil {
+		automations = []automation.Automation{}
+	}
+	writeJSON(w, http.StatusOK, automations)
+}
+
+func (s *Server) createAutomation(w http.ResponseWriter, r *http.Request) {
+	var req automationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	a, err := s.automations.Create(automation.CreateParams{
+		Name:         req.Name,
+		Prompt:       req.Prompt,
+		TriggerType:  automation.TriggerType(req.TriggerType),
+		TriggerValue: req.TriggerValue,
+		ProjectPath:  req.ProjectPath,
+		Enabled:      req.Enabled,
+	})
+	if err != nil {
+		// Store.Create only fails on validation errors or DB errors; treat
+		// validation as the common case.
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, a)
+}
+
+func (s *Server) getAutomation(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	a, err := s.automations.Get(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, a)
+}
+
+func (s *Server) updateAutomation(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if _, err := s.automations.Get(id); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	var req automationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	a, err := s.automations.Update(id, automation.UpdateParams{
+		Name:         req.Name,
+		Prompt:       req.Prompt,
+		TriggerType:  automation.TriggerType(req.TriggerType),
+		TriggerValue: req.TriggerValue,
+		ProjectPath:  req.ProjectPath,
+		Enabled:      req.Enabled,
+	})
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, a)
+}
+
+func (s *Server) deleteAutomation(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if _, err := s.automations.Get(id); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	if err := s.automations.Delete(id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+type setAutomationEnabledRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+func (s *Server) setAutomationEnabled(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req setAutomationEnabledRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if err := s.automations.SetEnabled(id, req.Enabled); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+		} else {
+			writeError(w, http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+	a, err := s.automations.Get(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, a)
+}
+
+func (s *Server) listAutomationRuns(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if _, err := s.automations.Get(id); err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	limit := 0
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			limit = n
+		}
+	}
+	runs, err := s.automations.ListRuns(id, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if runs == nil {
+		runs = []automation.Run{}
+	}
+	writeJSON(w, http.StatusOK, runs)
+}

--- a/internal/server/automation_test.go
+++ b/internal/server/automation_test.go
@@ -1,0 +1,253 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/myuon/agmux/internal/automation"
+	"github.com/myuon/agmux/internal/db"
+	"github.com/myuon/agmux/internal/session"
+)
+
+// newAutomationTestServer builds a Server with a real SQLite-backed automation
+// store and the full route table, without requiring a session manager.
+func newAutomationTestServer(t *testing.T) *Server {
+	t.Helper()
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	s := &Server{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		automations: automation.NewStore(sqlDB),
+		startTime:   time.Now(),
+	}
+	s.setupRoutes()
+	return s
+}
+
+func doJSON(t *testing.T, s *Server, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestAutomationCRUD(t *testing.T) {
+	s := newAutomationTestServer(t)
+
+	// Initially the list is an empty (non-null) array.
+	rec := doJSON(t, s, http.MethodGet, "/api/automations", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "[]" {
+		t.Errorf("empty list body = %q, want []", got)
+	}
+
+	// Create
+	rec = doJSON(t, s, http.MethodPost, "/api/automations",
+		`{"name":"daily report","prompt":"summarize","triggerType":"interval","triggerValue":"30m","enabled":true}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want %d (body: %s)", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var created automation.Automation
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created automation: %v", err)
+	}
+	if created.ID == "" || created.Name != "daily report" || !created.Enabled {
+		t.Errorf("unexpected created automation: %+v", created)
+	}
+
+	// Get
+	rec = doJSON(t, s, http.MethodGet, "/api/automations/"+created.ID, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	// List contains the new automation
+	rec = doJSON(t, s, http.MethodGet, "/api/automations", "")
+	var list []automation.Automation
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode automation list: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != created.ID {
+		t.Errorf("list = %+v, want 1 automation with id %s", list, created.ID)
+	}
+
+	// Update
+	rec = doJSON(t, s, http.MethodPut, "/api/automations/"+created.ID,
+		`{"name":"daily report v2","prompt":"summarize all","triggerType":"cron","triggerValue":"0 9 * * 1-5","projectPath":"/tmp/proj","enabled":false}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var updated automation.Automation
+	if err := json.Unmarshal(rec.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode updated automation: %v", err)
+	}
+	if updated.Name != "daily report v2" || updated.TriggerType != automation.TriggerCron ||
+		updated.ProjectPath != "/tmp/proj" || updated.Enabled {
+		t.Errorf("unexpected updated automation: %+v", updated)
+	}
+
+	// Toggle enabled
+	rec = doJSON(t, s, http.MethodPut, "/api/automations/"+created.ID+"/enabled", `{"enabled":true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set enabled status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var toggled automation.Automation
+	if err := json.Unmarshal(rec.Body.Bytes(), &toggled); err != nil {
+		t.Fatalf("decode toggled automation: %v", err)
+	}
+	if !toggled.Enabled {
+		t.Errorf("automation should be enabled after toggle: %+v", toggled)
+	}
+
+	// Runs are empty (non-null) for a fresh automation
+	rec = doJSON(t, s, http.MethodGet, "/api/automations/"+created.ID+"/runs", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list runs status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "[]" {
+		t.Errorf("empty runs body = %q, want []", got)
+	}
+
+	// Delete
+	rec = doJSON(t, s, http.MethodDelete, "/api/automations/"+created.ID, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	rec = doJSON(t, s, http.MethodGet, "/api/automations/"+created.ID, "")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("get after delete status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestAutomationRunsReturned(t *testing.T) {
+	s := newAutomationTestServer(t)
+
+	a, err := s.automations.Create(automation.CreateParams{
+		Name: "a", Prompt: "p", TriggerType: automation.TriggerInterval, TriggerValue: "30m", Enabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.automations.InsertRun(automation.Run{
+		AutomationID: a.ID, FiredAt: time.Now(), SessionID: "sess1", Status: automation.RunSuccess,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.automations.InsertRun(automation.Run{
+		AutomationID: a.ID, FiredAt: time.Now().Add(time.Minute), Status: automation.RunSkipped,
+		Message: "previous run session sess1 is still active",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := doJSON(t, s, http.MethodGet, "/api/automations/"+a.ID+"/runs", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list runs status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var runs []automation.Run
+	if err := json.Unmarshal(rec.Body.Bytes(), &runs); err != nil {
+		t.Fatalf("decode runs: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("len(runs) = %d, want 2", len(runs))
+	}
+	// Newest first
+	if runs[0].Status != automation.RunSkipped || runs[1].SessionID != "sess1" {
+		t.Errorf("unexpected runs order/content: %+v", runs)
+	}
+}
+
+func TestCreateAutomationValidation(t *testing.T) {
+	s := newAutomationTestServer(t)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"invalid cron", `{"name":"a","prompt":"p","triggerType":"cron","triggerValue":"not a cron","enabled":true}`},
+		{"invalid interval", `{"name":"a","prompt":"p","triggerType":"interval","triggerValue":"abc","enabled":true}`},
+		{"unknown trigger type", `{"name":"a","prompt":"p","triggerType":"weird","triggerValue":"30m","enabled":true}`},
+		{"missing name", `{"name":"","prompt":"p","triggerType":"interval","triggerValue":"30m","enabled":true}`},
+		{"missing prompt", `{"name":"a","prompt":"","triggerType":"interval","triggerValue":"30m","enabled":true}`},
+		{"invalid json", `{`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := doJSON(t, s, http.MethodPost, "/api/automations", tt.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d (body: %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			var resp map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("error response is not JSON: %v", err)
+			}
+			if resp["error"] == "" {
+				t.Errorf("error response missing error message: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestAutomationNotFound(t *testing.T) {
+	s := newAutomationTestServer(t)
+
+	paths := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodGet, "/api/automations/missing", ""},
+		{http.MethodPut, "/api/automations/missing", `{"name":"a","prompt":"p","triggerType":"interval","triggerValue":"30m"}`},
+		{http.MethodDelete, "/api/automations/missing", ""},
+		{http.MethodPut, "/api/automations/missing/enabled", `{"enabled":true}`},
+		{http.MethodGet, "/api/automations/missing/runs", ""},
+	}
+	for _, p := range paths {
+		rec := doJSON(t, s, p.method, p.path, p.body)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s %s status = %d, want %d", p.method, p.path, rec.Code, http.StatusNotFound)
+		}
+	}
+}
+
+func TestFilterAutomationSessions(t *testing.T) {
+	sessions := []session.Session{
+		{ID: "manual-null"},                              // automation_id was NULL in DB
+		{ID: "manual-empty", AutomationID: ""},           // automation_id stored as ''
+		{ID: "automated", AutomationID: "auto1"},         // created by an automation
+		{ID: "controller", Type: session.TypeController}, // controller stays
+	}
+	got := filterAutomationSessions(sessions)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3 (%+v)", len(got), got)
+	}
+	for _, s := range got {
+		if s.ID == "automated" {
+			t.Errorf("automation session should be filtered out: %+v", got)
+		}
+	}
+
+	// nil input yields a non-nil empty slice (serializes as []).
+	if got := filterAutomationSessions(nil); got == nil || len(got) != 0 {
+		t.Errorf("filterAutomationSessions(nil) = %+v, want empty non-nil slice", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	"github.com/gorilla/websocket"
+	"github.com/myuon/agmux/internal/automation"
 	"github.com/myuon/agmux/internal/config"
 	"github.com/myuon/agmux/internal/db"
 	"github.com/myuon/agmux/internal/mcp"
@@ -40,6 +41,7 @@ type Server struct {
 	permissions      *PermissionStore
 	otelReceiver     *otel.Receiver
 	sqlDB            *sql.DB
+	automations      *automation.Store
 	externalDetector *session.ExternalDetector
 	version          string
 	commit           string
@@ -60,6 +62,7 @@ func New(sessions session.SessionService, hub *Hub, devMode bool, logger *slog.L
 		permissions:      NewPermissionStore(),
 		otelReceiver:     otel.NewReceiver(sqlDB, logger),
 		sqlDB:            sqlDB,
+		automations:      automation.NewStore(sqlDB),
 		externalDetector: extDetector,
 		startTime:        time.Now(),
 	}
@@ -162,6 +165,13 @@ func (s *Server) setupRoutes() {
 		r.Post("/sessions/{id}/notify", s.sendNotification)
 		r.Post("/sessions/broadcast", s.broadcastToSessions)
 		r.Post("/sessions/controller/restart", s.restartController)
+		r.Get("/automations", s.listAutomations)
+		r.Post("/automations", s.createAutomation)
+		r.Get("/automations/{id}", s.getAutomation)
+		r.Put("/automations/{id}", s.updateAutomation)
+		r.Delete("/automations/{id}", s.deleteAutomation)
+		r.Put("/automations/{id}/enabled", s.setAutomationEnabled)
+		r.Get("/automations/{id}/runs", s.listAutomationRuns)
 		r.Get("/projects/recent", s.getRecentProjects)
 		r.Get("/claude/models", s.getClaudeModels)
 		r.Get("/claude/version", s.getClaudeVersion)
@@ -260,9 +270,7 @@ func (s *Server) broadcastSessionUpdate() {
 		s.logger.Error("broadcastSessionUpdate: failed to list sessions", "error", err)
 		return
 	}
-	if sessions == nil {
-		sessions = []session.Session{}
-	}
+	sessions = filterAutomationSessions(sessions)
 	if s.externalDetector != nil {
 		external := s.externalDetector.Sessions()
 		sessions = append(sessions, external...)
@@ -273,15 +281,28 @@ func (s *Server) broadcastSessionUpdate() {
 	})
 }
 
+// filterAutomationSessions removes sessions created by automations from the
+// default session list; they are reachable via the automation run history
+// instead. Manual sessions may have automation_id stored as either NULL or ''
+// (see #671 review), but both deserialize to an empty string, so a non-empty
+// check covers both. Always returns a non-nil slice.
+func filterAutomationSessions(sessions []session.Session) []session.Session {
+	filtered := make([]session.Session, 0, len(sessions))
+	for _, sess := range sessions {
+		if sess.AutomationID == "" {
+			filtered = append(filtered, sess)
+		}
+	}
+	return filtered
+}
+
 func (s *Server) listSessions(w http.ResponseWriter, r *http.Request) {
 	sessions, err := s.sessions.List()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	if sessions == nil {
-		sessions = []session.Session{}
-	}
+	sessions = filterAutomationSessions(sessions)
 
 	// Merge external (non-agmux) Claude sessions
 	if s.externalDetector != nil {


### PR DESCRIPTION
Closes #668

親イシュー: #663（このPRでは close しない）

## 変更概要

#671 の基盤実装（`internal/automation` の Store / Scheduler / Runner）の上に、API と Web UI を追加する。

### API（`internal/server`）

| Method | Path | 内容 |
|---|---|---|
| GET | `/api/automations` | 一覧 |
| POST | `/api/automations` | 作成（バリデーションエラーは 400 + メッセージ） |
| GET | `/api/automations/{id}` | 取得 |
| PUT | `/api/automations/{id}` | 更新 |
| DELETE | `/api/automations/{id}` | 削除（実行履歴も削除） |
| PUT | `/api/automations/{id}/enabled` | 有効/無効切替 |
| GET | `/api/automations/{id}/runs` | 実行履歴一覧（`?limit=`、新しい順） |

- ハンドラは既存パターン（chi ルート + `writeJSON` / `writeError`）に準拠。`internal/server/automation.go` に分離
- 不正な cron 式 / interval は `automation.Store` のバリデーションエラーをそのまま 400 で返す

### Web UI（frontend）

- **`/automations`（一覧画面）**: 一覧・作成・編集・削除・有効/無効トグル。トリガーは Interval / Cron の選択式で、API のバリデーションエラー（不正 cron 式等）をフォーム内のエラーバナーに表示
- **`/automations/:id`（詳細画面）**: Automation 定義の表示 + 有効/無効トグル + 実行履歴（status バッジ / 発動時刻 / message / 「セッションを開く」リンク → セッション詳細ページ）
- ヘッダーのナビゲーションに Automations アイコン（時計）を追加

### セッション一覧のフィルタ

- `GET /api/sessions` と WS の `session_update` broadcast から `automation_id` が非空のセッションをサーバー側で除外（`filterAutomationSessions`）
- #671 レビューの申し送り（手動セッションの `automation_id` が NULL と `''` の混在）は、Go では両方とも空文字にデシリアライズされるため非空チェックで両対応
- `GET /api/sessions/{id}` は無変更なので、Automation 詳細の実行履歴からセッション詳細ページへ辿れる

## 画面

- 一覧画面: Automation カード（名前 / トリガー / project / prompt 冒頭）+ ON/OFF トグル + 編集/削除。ヘッダー右上に「+ New Automation」
- 作成/編集フォーム: Name / Prompt / Trigger（Interval・Cron 選択 + 値）/ Project Path（未指定なら controller 領域）/ 有効トグル
- 詳細画面: 定義表示 + 実行履歴リスト（success=緑 / skipped=黄 / error=赤 のバッジ、セッションリンク付き）

## テスト結果

- `make build` ✅ / `make test`（`go test ./...`）✅ 全パッケージ green
- 追加テスト（`internal/server/automation_test.go`）: CRUD 一連 / runs 返却（新しい順・skipped含む）/ バリデーション 400（不正 cron・interval・必須項目欠落）/ 404 系 / `filterAutomationSessions`（NULL・`''` 両対応、automation セッション除外、controller 残留）
- 動作確認（isolated HOME でビルド済みバイナリを起動し、agent-browser で確認）:
  - 一覧表示 → 作成（不正 cron でエラーバナー表示 → 修正して作成成功）→ トグル OFF（API で `enabled: false` を確認）
  - 詳細画面で実行履歴 + 「セッションを開く」リンク表示
  - automation 由来セッション（`automation_id` 付き）が `/api/sessions` とホーム画面の一覧に出ず、`/api/sessions/{id}` では取得できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)