### PR TITLE
feat: agmux automation サブコマンドを追加 (#669)

### DIFF
--- a/cmd/agmux/automation.go
+++ b/cmd/agmux/automation.go
@@ -1,0 +1,385 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/myuon/agmux/internal/automation"
+	"github.com/myuon/agmux/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// automationAPI is a minimal HTTP client for the daemon's /api/automations
+// endpoints. All automation CLI commands go through the HTTP API so that the
+// running daemon (scheduler) always sees up-to-date data.
+type automationAPI struct {
+	baseURL string
+	client  *http.Client
+}
+
+func newAutomationAPI() (*automationAPI, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	return &automationAPI{
+		baseURL: fmt.Sprintf("http://localhost:%d", cfg.Server.Port),
+		client:  http.DefaultClient,
+	}, nil
+}
+
+// do sends an HTTP request to the daemon API. body (if non-nil) is encoded as
+// JSON; out (if non-nil) receives the decoded JSON response. Non-2xx responses
+// are returned as errors using the server's {"error": "..."} payload.
+func (a *automationAPI) do(method, path string, body interface{}, out interface{}) error {
+	var reqBody io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("encode request: %w", err)
+		}
+		reqBody = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, a.baseURL+path, reqBody)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s %s: %w (is the agmux server running?)", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		data, _ := io.ReadAll(resp.Body)
+		if err := json.Unmarshal(data, &errResp); err == nil && errResp.Error != "" {
+			return fmt.Errorf("%s", errResp.Error)
+		}
+		return fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+func (a *automationAPI) list() ([]automation.Automation, error) {
+	var automations []automation.Automation
+	if err := a.do(http.MethodGet, "/api/automations", nil, &automations); err != nil {
+		return nil, err
+	}
+	return automations, nil
+}
+
+// automationCreateRequest mirrors the server's automationRequest body.
+type automationCreateRequest struct {
+	Name         string `json:"name"`
+	Prompt       string `json:"prompt"`
+	TriggerType  string `json:"triggerType"`
+	TriggerValue string `json:"triggerValue"`
+	ProjectPath  string `json:"projectPath,omitempty"`
+	Enabled      bool   `json:"enabled"`
+}
+
+func (a *automationAPI) create(req automationCreateRequest) (*automation.Automation, error) {
+	var created automation.Automation
+	if err := a.do(http.MethodPost, "/api/automations", req, &created); err != nil {
+		return nil, err
+	}
+	return &created, nil
+}
+
+func (a *automationAPI) setEnabled(id string, enabled bool) (*automation.Automation, error) {
+	var updated automation.Automation
+	body := map[string]bool{"enabled": enabled}
+	if err := a.do(http.MethodPut, "/api/automations/"+id+"/enabled", body, &updated); err != nil {
+		return nil, err
+	}
+	return &updated, nil
+}
+
+func (a *automationAPI) delete(id string) error {
+	return a.do(http.MethodDelete, "/api/automations/"+id, nil, nil)
+}
+
+func (a *automationAPI) listRuns(id string, limit int) ([]automation.Run, error) {
+	path := "/api/automations/" + id + "/runs"
+	if limit > 0 {
+		path += fmt.Sprintf("?limit=%d", limit)
+	}
+	var runs []automation.Run
+	if err := a.do(http.MethodGet, path, nil, &runs); err != nil {
+		return nil, err
+	}
+	return runs, nil
+}
+
+// resolveAutomationID resolves a (possibly shortened) automation ID prefix to
+// the full ID, mirroring the prefix matching used by `session history/info`.
+func (a *automationAPI) resolveAutomationID(prefix string) (string, error) {
+	automations, err := a.list()
+	if err != nil {
+		return "", err
+	}
+	matched := ""
+	for _, au := range automations {
+		if strings.HasPrefix(au.ID, prefix) {
+			if matched != "" {
+				return "", fmt.Errorf("ambiguous automation prefix %q: matches %s and %s", prefix, matched, au.ID)
+			}
+			matched = au.ID
+		}
+	}
+	if matched == "" {
+		return "", fmt.Errorf("no automation found matching prefix: %s", prefix)
+	}
+	return matched, nil
+}
+
+func automationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "automation",
+		Short: "Manage automations (scheduled prompts)",
+	}
+
+	cmd.AddCommand(automationListCmd())
+	cmd.AddCommand(automationCreateCmd())
+	cmd.AddCommand(automationEnableCmd())
+	cmd.AddCommand(automationDisableCmd())
+	cmd.AddCommand(automationDeleteCmd())
+	cmd.AddCommand(automationRunsCmd())
+
+	return cmd
+}
+
+func formatTrigger(a automation.Automation) string {
+	return fmt.Sprintf("%s(%s)", a.TriggerType, a.TriggerValue)
+}
+
+func automationListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all automations",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			api, err := newAutomationAPI()
+			if err != nil {
+				return err
+			}
+			automations, err := api.list()
+			if err != nil {
+				return err
+			}
+			if len(automations) == 0 {
+				fmt.Println("No automations found.")
+				return nil
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "ID\tNAME\tTRIGGER\tPROJECT\tENABLED")
+			for _, a := range automations {
+				id := a.ID
+				if len(id) > 8 {
+					id = id[:8]
+				}
+				project := a.ProjectPath
+				if project == "" {
+					project = "(controller)"
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%v\n",
+					id, a.Name, formatTrigger(a), project, a.Enabled)
+			}
+			w.Flush()
+			return nil
+		},
+	}
+}
+
+func automationCreateCmd() *cobra.Command {
+	var name string
+	var prompt string
+	var interval string
+	var cron string
+	var projectPath string
+	var disabled bool
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new automation",
+		Long: `Create a new automation that fires on a schedule and creates a session with the given prompt.
+
+Specify exactly one of --interval (Go duration, e.g. "30m") or --cron (5-field cron expression, e.g. "0 9 * * 1-5").
+If --project is omitted, the automation runs in the controller area.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if name == "" {
+				return fmt.Errorf("--name is required")
+			}
+			if prompt == "" {
+				return fmt.Errorf("--prompt is required")
+			}
+			if (interval == "") == (cron == "") {
+				return fmt.Errorf("specify exactly one of --interval or --cron")
+			}
+
+			triggerType := string(automation.TriggerInterval)
+			triggerValue := interval
+			if cron != "" {
+				triggerType = string(automation.TriggerCron)
+				triggerValue = cron
+			}
+
+			if projectPath != "" {
+				abs, err := filepath.Abs(projectPath)
+				if err != nil {
+					return fmt.Errorf("resolve project path: %w", err)
+				}
+				projectPath = abs
+			}
+
+			api, err := newAutomationAPI()
+			if err != nil {
+				return err
+			}
+			created, err := api.create(automationCreateRequest{
+				Name:         name,
+				Prompt:       prompt,
+				TriggerType:  triggerType,
+				TriggerValue: triggerValue,
+				ProjectPath:  projectPath,
+				Enabled:      !disabled,
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Created automation: %s (id: %s)\n", created.Name, created.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Automation name (required)")
+	cmd.Flags().StringVarP(&prompt, "prompt", "m", "", "Prompt sent to the agent when the automation fires (required)")
+	cmd.Flags().StringVar(&interval, "interval", "", "Fire at a fixed interval (Go duration, e.g. 30m, 1h)")
+	cmd.Flags().StringVar(&cron, "cron", "", "Fire on a cron schedule (5-field expression, e.g. \"0 9 * * 1-5\")")
+	cmd.Flags().StringVarP(&projectPath, "project", "p", "", "Project directory path (default: controller area)")
+	cmd.Flags().BoolVar(&disabled, "disabled", false, "Create the automation in disabled state")
+
+	return cmd
+}
+
+func automationEnableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enable <id>",
+		Short: "Enable an automation",
+		Args:  cobra.ExactArgs(1),
+		RunE:  setAutomationEnabledRunE(true, "Automation enabled."),
+	}
+}
+
+func automationDisableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable <id>",
+		Short: "Disable an automation",
+		Args:  cobra.ExactArgs(1),
+		RunE:  setAutomationEnabledRunE(false, "Automation disabled."),
+	}
+}
+
+func setAutomationEnabledRunE(enabled bool, doneMsg string) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		api, err := newAutomationAPI()
+		if err != nil {
+			return err
+		}
+		id, err := api.resolveAutomationID(args[0])
+		if err != nil {
+			return err
+		}
+		if _, err := api.setEnabled(id, enabled); err != nil {
+			return err
+		}
+		fmt.Println(doneMsg)
+		return nil
+	}
+}
+
+func automationDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete an automation",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			api, err := newAutomationAPI()
+			if err != nil {
+				return err
+			}
+			id, err := api.resolveAutomationID(args[0])
+			if err != nil {
+				return err
+			}
+			if err := api.delete(id); err != nil {
+				return err
+			}
+			fmt.Println("Automation deleted.")
+			return nil
+		},
+	}
+}
+
+func automationRunsCmd() *cobra.Command {
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "runs <id>",
+		Short: "Show execution history of an automation",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			api, err := newAutomationAPI()
+			if err != nil {
+				return err
+			}
+			id, err := api.resolveAutomationID(args[0])
+			if err != nil {
+				return err
+			}
+			runs, err := api.listRuns(id, limit)
+			if err != nil {
+				return err
+			}
+			if len(runs) == 0 {
+				fmt.Println("No runs found.")
+				return nil
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "FIRED_AT\tSTATUS\tSESSION\tMESSAGE")
+			for _, r := range runs {
+				sessionID := r.SessionID
+				if len(sessionID) > 8 {
+					sessionID = sessionID[:8]
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+					r.FiredAt.Local().Format("2006-01-02 15:04:05"), r.Status, sessionID, r.Message)
+			}
+			w.Flush()
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVarP(&limit, "limit", "n", 50, "Max number of runs to show")
+
+	return cmd
+}

--- a/cmd/agmux/automation_test.go
+++ b/cmd/agmux/automation_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/myuon/agmux/internal/automation"
+)
+
+func newTestAPI(t *testing.T, handler http.Handler) (*automationAPI, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return &automationAPI{baseURL: srv.URL, client: srv.Client()}, srv
+}
+
+func TestAutomationAPIList(t *testing.T) {
+	api, _ := newTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/automations" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]automation.Automation{
+			{ID: "auto-1", Name: "daily-report", TriggerType: automation.TriggerCron, TriggerValue: "0 9 * * *", Enabled: true},
+		})
+	}))
+
+	automations, err := api.list()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(automations) != 1 {
+		t.Fatalf("expected 1 automation, got %d", len(automations))
+	}
+	if automations[0].ID != "auto-1" || automations[0].Name != "daily-report" {
+		t.Errorf("unexpected automation: %+v", automations[0])
+	}
+}
+
+func TestAutomationAPICreate(t *testing.T) {
+	var gotBody automationCreateRequest
+	api, _ := newTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/automations" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %q", ct)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(automation.Automation{ID: "auto-new", Name: gotBody.Name})
+	}))
+
+	created, err := api.create(automationCreateRequest{
+		Name:         "nightly",
+		Prompt:       "run nightly checks",
+		TriggerType:  "interval",
+		TriggerValue: "30m",
+		ProjectPath:  "/tmp/proj",
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.ID != "auto-new" {
+		t.Errorf("expected id auto-new, got %s", created.ID)
+	}
+	if gotBody.Name != "nightly" || gotBody.TriggerType != "interval" || gotBody.TriggerValue != "30m" || !gotBody.Enabled {
+		t.Errorf("unexpected request body: %+v", gotBody)
+	}
+}
+
+func TestAutomationAPISetEnabled(t *testing.T) {
+	var gotBody map[string]bool
+	api, _ := newTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/automations/auto-1/enabled" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(automation.Automation{ID: "auto-1", Enabled: gotBody["enabled"]})
+	}))
+
+	updated, err := api.setEnabled("auto-1", false)
+	if err != nil {
+		t.Fatalf("setEnabled: %v", err)
+	}
+	if updated.Enabled {
+		t.Error("expected enabled=false in response")
+	}
+	if v, ok := gotBody["enabled"]; !ok || v {
+		t.Errorf("expected request body {\"enabled\": false}, got %+v", gotBody)
+	}
+}
+
+func TestAutomationAPIDelete(t *testing.T) {
+	called := false
+	api, _ := newTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodDelete || r.URL.Path != "/api/automations/auto-1" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
+	}))
+
+	if err := api.delete("auto-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !called {
+		t.Error("expected DELETE request to be sent")
+	}
+}
+
+func TestAutomationAPIListRuns(t *testing.T) {
+	api, _ := newTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/automations/auto-1/runs" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "10" {
+			t.Errorf("expected limit=10, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]automation.Run{
+			{ID: 1, AutomationID: "auto-1", FiredAt: time.Now(), Status: automation.RunSuccess, SessionID: "sess-1"},
+			{ID: 2, AutomationID: "auto-1", FiredAt: time.Now(), Status: automation.RunSkipped, Message: "previous run still working"},
+		})
+	}))
+
+	runs, err := api.listRuns("auto-1", 10)
+	if err != nil {
+		t.Fatalf("listRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 runs, got %d", len(runs))
+	}
+	if runs[0].Status != automation.RunSuccess || runs[1].Status != automation.RunSkipped {
+		t.Errorf("unexpected run statuses: %+v", runs)
+	}
+}
+
+func TestAutomationAPIErrorResponse(t *testing.T) {
+	api, _ := newTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid cron expression"})
+	}))
+
+	_, err := api.create(automationCreateRequest{Name: "bad"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid cron expression") {
+		t.Errorf("expected server error message, got: %v", err)
+	}
+}
+
+func TestAutomationAPIErrorWithoutJSONBody(t *testing.T) {
+	api, _ := newTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("boom"))
+	}))
+
+	err := api.delete("auto-1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected status code in error, got: %v", err)
+	}
+}
+
+func TestResolveAutomationID(t *testing.T) {
+	api, _ := newTestAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]automation.Automation{
+			{ID: "abcd1234efgh", Name: "one"},
+			{ID: "abxy9999zzzz", Name: "two"},
+		})
+	}))
+
+	t.Run("unique prefix", func(t *testing.T) {
+		id, err := api.resolveAutomationID("abcd")
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if id != "abcd1234efgh" {
+			t.Errorf("expected abcd1234efgh, got %s", id)
+		}
+	})
+
+	t.Run("full id", func(t *testing.T) {
+		id, err := api.resolveAutomationID("abxy9999zzzz")
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if id != "abxy9999zzzz" {
+			t.Errorf("expected abxy9999zzzz, got %s", id)
+		}
+	})
+
+	t.Run("ambiguous prefix", func(t *testing.T) {
+		_, err := api.resolveAutomationID("ab")
+		if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+			t.Errorf("expected ambiguous error, got: %v", err)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		_, err := api.resolveAutomationID("zzzz")
+		if err == nil || !strings.Contains(err.Error(), "no automation found") {
+			t.Errorf("expected not found error, got: %v", err)
+		}
+	})
+}

--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -55,6 +55,7 @@ func main() {
 	rootCmd.AddCommand(daemonCmd())
 	rootCmd.AddCommand(holderCmd())
 	rootCmd.AddCommand(templateCmd())
+	rootCmd.AddCommand(automationCmd())
 	rootCmd.AddCommand(updateCmd())
 	rootCmd.AddCommand(versionCmd())
 


### PR DESCRIPTION
Closes #669

親イシュー: #663（このPRではcloseしない）

## 変更概要

`agmux automation` サブコマンドを追加。すべて HTTP API（PR #672 で追加された `/api/automations` エンドポイント）経由で daemon と通信する（DB 直接アクセスなし）。

- `agmux automation list` — 一覧表示（ID / NAME / TRIGGER / PROJECT / ENABLED）。project 未指定は `(controller)` と表示
- `agmux automation create` — 作成。`--name` / `--prompt`(`-m`) / `--interval` または `--cron`（排他必須）/ `--project`(`-p`) / `--disabled` フラグ
- `agmux automation enable <id>` / `disable <id>` — `PUT /api/automations/{id}/enabled` で有効/無効切替
- `agmux automation delete <id>` — 削除
- `agmux automation runs <id>` — 実行履歴表示（FIRED_AT / STATUS / SESSION / MESSAGE、`-n` で件数指定）

ID は `session history/info` と同様にプレフィックスマッチに対応（一覧取得後にクライアント側で解決）。出力フォーマット（tabwriter、ID 8文字切り詰め）・エラー処理は既存 CLI コマンドのパターンに合わせた。

## テスト

`cmd/agmux/automation_test.go` を追加（httptest による API クライアントの単体テスト）:
- list / create / setEnabled / delete / listRuns の リクエスト・レスポンス検証
- サーバーの `{"error": ...}` エラーレスポンスのデコード、JSON でないエラーボディのフォールバック
- ID プレフィックス解決（一意マッチ / 完全一致 / 曖昧 / 不一致）

## 動作確認

- `make build` / `make test` 通過（全パッケージ ok）
- 一時 HOME + 別ポート(43219)でローカル daemon を起動し、実機確認:
  - `create`（interval / cron、`--disabled`、`-p` 指定）→ `list` に反映
  - `enable` / `disable`（プレフィックス ID）→ ENABLED 列が切替
  - 10秒 interval の automation を作成しスケジューラ発火後、`runs` に `success` の実行履歴とセッション ID が表示されることを確認
  - エラー系: `--interval` と `--cron` 同時指定、不正な cron 式（API のバリデーションエラーがそのまま表示）、存在しない ID
  - 本番 daemon (port 4321) には影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)