### PR TITLE
feat: セッション途中のモデル変更でモデル名の自由入力に対応 (#674)

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -97,6 +97,7 @@ function ModelSwitcher({ session, onSwitched, onError }: {
     const handler = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setOpen(false);
+        setCustomModel("");
       }
     };
     document.addEventListener("mousedown", handler);
@@ -112,6 +113,7 @@ function ModelSwitcher({ session, onSwitched, onError }: {
   const toggleOpen = () => {
     if (open) {
       setOpen(false);
+      setCustomModel("");
       return;
     }
     setOpen(true);
@@ -164,7 +166,7 @@ function ModelSwitcher({ session, onSwitched, onError }: {
               value={customModel}
               onChange={(e) => setCustomModel(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter" && customModel.trim()) {
+                if (e.key === "Enter" && !e.nativeEvent.isComposing && customModel.trim()) {
                   void switchTo(customModel.trim());
                 }
               }}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -71,9 +71,10 @@ function ParentSessionLink({ parentId }: { parentId: string }) {
 
 // ModelSwitcher renders the model Chip in the session header. For providers
 // with a model list API (claude / codex), the Chip becomes clickable and shows
-// a dropdown to switch the session's model. Cursor has no model list API, so
-// its Chip stays non-clickable. Switching is disabled while a turn is in
-// progress (status = working).
+// a dropdown to switch the session's model. The dropdown also has a free-text
+// input so any model name can be entered (the candidate list may be outdated).
+// Cursor has no model list API, so its Chip stays non-clickable. Switching is
+// disabled while a turn is in progress (status = working).
 function ModelSwitcher({ session, onSwitched, onError }: {
   session: Session;
   onSwitched: (model: string) => void;
@@ -83,6 +84,7 @@ function ModelSwitcher({ session, onSwitched, onError }: {
   const [models, setModels] = useState<{ id: string; name: string }[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [switching, setSwitching] = useState(false);
+  const [customModel, setCustomModel] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
 
   const switchable =
@@ -125,6 +127,21 @@ function ModelSwitcher({ session, onSwitched, onError }: {
     }
   };
 
+  const switchTo = async (modelId: string) => {
+    setOpen(false);
+    setCustomModel("");
+    if (modelId === session.model || switching) return;
+    setSwitching(true);
+    try {
+      await api.updateSessionModel(session.id, modelId);
+      onSwitched(modelId);
+    } catch {
+      onError();
+    } finally {
+      setSwitching(false);
+    }
+  };
+
   return (
     <div ref={containerRef} className="relative inline-flex items-center">
       <button
@@ -141,6 +158,21 @@ function ModelSwitcher({ session, onSwitched, onError }: {
       </button>
       {open && (
         <div className="absolute top-full left-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto z-50 min-w-44">
+          <div className="px-2 py-2 border-b border-gray-100">
+            <input
+              type="text"
+              value={customModel}
+              onChange={(e) => setCustomModel(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && customModel.trim()) {
+                  void switchTo(customModel.trim());
+                }
+              }}
+              placeholder="モデル名を入力してEnter"
+              className="w-full px-2 py-1 text-xs border border-gray-200 rounded focus:outline-none focus:border-purple-400"
+              autoFocus
+            />
+          </div>
           {loading ? (
             <div className="px-3 py-2 text-xs text-gray-400">Loading models...</div>
           ) : models && models.length > 0 ? (
@@ -151,19 +183,7 @@ function ModelSwitcher({ session, onSwitched, onError }: {
                 className={`w-full text-left px-3 py-2 text-xs hover:bg-purple-50 ${
                   m.id === session.model ? "bg-purple-100 text-purple-800" : "text-gray-700"
                 }`}
-                onClick={async () => {
-                  setOpen(false);
-                  if (m.id === session.model || switching) return;
-                  setSwitching(true);
-                  try {
-                    await api.updateSessionModel(session.id, m.id);
-                    onSwitched(m.id);
-                  } catch {
-                    onError();
-                  } finally {
-                    setSwitching(false);
-                  }
-                }}
+                onClick={() => void switchTo(m.id)}
               >
                 {m.name}
               </button>


### PR DESCRIPTION
Closes #674

## 概要

セッション途中のモデル変更UI（#664 で追加）のドロップダウンに自由入力欄を追加し、候補リストにないモデル名でも切り替えられるようにしました。

## 変更内容

- `ModelSwitcher`（`frontend/src/pages/SessionPage.tsx`）のドロップダウン上部にテキスト入力欄を追加
  - 任意のモデル名を入力して Enter で切替（autoFocus 付き）
  - 既存の候補リストはそのまま下に表示
- 切替処理を `switchTo()` に共通化（リスト選択・自由入力の両方から利用）
- バックエンドは変更なし（`PUT /sessions/{id}/model` は元々空文字チェックのみで任意のモデル名を受け付ける）

## 動作確認

- `make build` 通過
- `make test` 通過（全パッケージ ok）

🤖 Generated with [Claude Code](https://claude.com/claude-code)