### PR TITLE
feat: system:thinking_tokens イベントに対応する

### DIFF
--- a/frontend/src/components/session/StreamOutputView.tsx
+++ b/frontend/src/components/session/StreamOutputView.tsx
@@ -7,7 +7,7 @@ import { StreamDisplayItemView } from "./StreamDisplayItemView";
 import { toolIcon, toolDescription } from "../../models/tool";
 import { Modal } from "../ui/Modal";
 import { ToolInputView } from "./ToolInputView";
-import { RefreshCw } from "lucide-react";
+import { Brain, RefreshCw } from "lucide-react";
 import { motion } from "motion/react";
 import { api } from "../../api/client";
 
@@ -48,8 +48,11 @@ function summarizeEntry(line: unknown): { type: string; subtype?: string; summar
           const c = block.content;
           if (typeof c === "string") parts.push(`[tool_result: ${c.slice(0, 40)}]`);
           else parts.push("[tool_result]");
-        } else if (bt === "thinking" && typeof block.thinking === "string") {
-          parts.push(`[thinking: ${block.thinking}]`);
+        } else if (bt === "thinking") {
+          // Suppress empty thinking (signature-only blocks from redacted-thinking models)
+          if (typeof block.thinking === "string" && block.thinking) {
+            parts.push(`[thinking: ${block.thinking}]`);
+          }
         } else if (bt === "image") {
           parts.push("[image]");
         } else if (typeof bt === "string") {
@@ -68,6 +71,10 @@ function summarizeEntry(line: unknown): { type: string; subtype?: string; summar
     if (typeof raw.status === "string") extras.push(`status=${raw.status}`);
     if (typeof raw.task_id === "string") extras.push(`task_id=${(raw.task_id as string).slice(0, 8)}`);
     if (typeof raw.task_type === "string") extras.push(`task_type=${raw.task_type}`);
+    if (typeof raw.estimated_tokens === "number") {
+      const delta = typeof raw.estimated_tokens_delta === "number" ? ` (+${raw.estimated_tokens_delta})` : "";
+      extras.push(`estimated_tokens=${raw.estimated_tokens}${delta}`);
+    }
     return { type, subtype, summary: extras.join(" "), isUnknown };
   }
 
@@ -101,9 +108,10 @@ function summarizeEntry(line: unknown): { type: string; subtype?: string; summar
   return { type, summary: hintParts.join(" "), isUnknown };
 }
 
-export function StreamOutputView({ lines, partialText, className, onAnswer, sessionId, pendingPermission, onPermissionResponded, provider }: {
+export function StreamOutputView({ lines, partialText, thinkingTokens, className, onAnswer, sessionId, pendingPermission, onPermissionResponded, provider }: {
   lines: unknown[];
   partialText?: string;
+  thinkingTokens?: number | null;
   className?: string;
   onAnswer?: (text: string) => void;
   sessionId?: string;
@@ -250,6 +258,13 @@ export function StreamOutputView({ lines, partialText, className, onAnswer, sess
               </motion.div>
             );
           })
+        )}
+        {thinkingTokens != null && (
+          <div className="flex items-center gap-2 py-1.5 px-3 text-xs text-purple-600 bg-purple-50 border-y border-dashed border-purple-200">
+            <Brain className="w-3.5 h-3.5 shrink-0 animate-pulse" />
+            <span className="font-medium shrink-0">思考中...</span>
+            <span className="shrink-0 text-purple-400 ml-auto">~{thinkingTokens.toLocaleString()} tokens</span>
+          </div>
         )}
         {trailingRetry && (
           <div className="flex items-center gap-2 py-1.5 px-3 text-xs text-amber-600 bg-amber-50 border-y border-dashed border-amber-200">

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -231,6 +231,8 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
   const [message, setMessage] = useState("");
   const [streamLines, setStreamLines] = useState<unknown[]>(deferred.streamOutput.lines);
   const [partialText, setPartialText] = useState("");
+  // Latest estimated thinking tokens (system:thinking_tokens live events); null when not thinking
+  const [thinkingTokens, setThinkingTokens] = useState<number | null>(null);
   const [diffFiles, setDiffFiles] = useState<DiffFile[]>(deferred.diff.files);
 
 
@@ -355,10 +357,21 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
             if (evt?.type === "content_block_delta" && evt.delta?.type === "text_delta" && evt.delta.text) {
               setPartialText((prev) => prev + evt.delta!.text!);
             }
+          } else if (entry.type === "system" && entry.subtype === "thinking_tokens") {
+            // Transient thinking progress meter: keep only the latest count,
+            // never push to streamLines (see issue #675)
+            if (typeof entry.estimated_tokens === "number") {
+              setThinkingTokens(entry.estimated_tokens);
+            }
           } else {
-            // Clear partial text when a complete assistant message arrives
+            // Clear partial text and thinking indicator when a complete assistant message arrives
             if (entry.type === "assistant") {
               setPartialText("");
+              setThinkingTokens(null);
+            }
+            // Also clear the thinking indicator at turn end
+            if (entry.type === "result") {
+              setThinkingTokens(null);
             }
             regular.push(line);
           }
@@ -1012,7 +1025,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
         </div>
       ) : (
         <div className="flex flex-col flex-1 min-h-0">
-          <StreamOutputView lines={streamLines} partialText={partialText} className="flex-1 min-h-0" sessionId={sessionId} pendingPermission={pendingPermission ?? undefined} onPermissionResponded={() => { setPendingPermission(null); }} provider={session?.provider ?? undefined} onAnswer={async (text) => {
+          <StreamOutputView lines={streamLines} partialText={partialText} thinkingTokens={thinkingTokens} className="flex-1 min-h-0" sessionId={sessionId} pendingPermission={pendingPermission ?? undefined} onPermissionResponded={() => { setPendingPermission(null); }} provider={session?.provider ?? undefined} onAnswer={async (text) => {
             if (!sessionId) return;
             await api.sendToSession(sessionId, text);
           }} />

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -343,6 +343,11 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
       const data = msg.data as { sessionId: string; status: Session["status"]; lastError?: string };
       if (data.sessionId === sessionId) {
         setSession(prev => prev ? { ...prev, status: data.status, ...(data.lastError !== undefined ? { lastError: data.lastError } : {}) } : prev);
+        // Clear the thinking indicator when the turn ends without an
+        // assistant/result event (e.g. the CLI process died mid-thinking)
+        if (data.status !== "working") {
+          setThinkingTokens(null);
+        }
       }
     }
     if (msg.type === "stream_update") {
@@ -393,6 +398,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
       api.getStreamOutput(sessionId).then((resp) => {
         setStreamLines(resp.lines);
         setPartialText("");
+        setThinkingTokens(null);
         streamCursorRef.current = resp.total;
       }).catch(() => {});
       api.getSession(sessionId).then(setSession).catch(() => {});

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -262,14 +262,9 @@ func (sp *HolderStreamProcess) loadExistingLines(sessionID string, clearOffset i
 			}
 			normalizedStr := string(normalized)
 
-			// Skip stream_events (transient, not for history)
-			if len(normalized) > 0 && normalized[0] == '{' {
-				var peek struct {
-					Type string `json:"type"`
-				}
-				if json.Unmarshal(normalized, &peek) == nil && peek.Type == "stream_event" {
-					continue
-				}
+			// Skip transient lines (stream_event, thinking_tokens): not for history
+			if isTransientStreamLine(normalized) {
+				continue
 			}
 
 			sp.lines = append(sp.lines, normalizedStr)
@@ -454,19 +449,11 @@ func (sp *HolderStreamProcess) readLoop() {
 			}
 			normalizedStr := string(normalized)
 
-			// Check for stream_event (real-time only, not persisted)
-			isStreamEvent := false
-			if len(normalized) > 0 && normalized[0] == '{' {
-				var peek struct {
-					Type string `json:"type"`
-				}
-				if json.Unmarshal(normalized, &peek) == nil && peek.Type == "stream_event" {
-					isStreamEvent = true
-				}
-			}
+			// Check for transient lines (real-time only, not persisted)
+			isTransient := isTransientStreamLine(normalized)
 
 			sp.mu.Lock()
-			if !isStreamEvent {
+			if !isTransient {
 				sp.lines = append(sp.lines, normalizedStr)
 				// Note: holder already writes to JSONL file, so we don't write here
 			}
@@ -479,6 +466,30 @@ func (sp *HolderStreamProcess) readLoop() {
 			}
 		}
 	}
+}
+
+// isTransientStreamLine reports whether a normalized stream line is
+// real-time only and should not be persisted to history (sp.lines):
+//   - type == "stream_event" (partial text deltas etc.)
+//   - type == "system" && subtype == "thinking_tokens" (thinking progress
+//     meter emitted by the claude provider; 100+ lines per session)
+//
+// These lines are still broadcast to live subscribers.
+func isTransientStreamLine(normalized []byte) bool {
+	if len(normalized) == 0 || normalized[0] != '{' {
+		return false
+	}
+	var peek struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+	}
+	if json.Unmarshal(normalized, &peek) != nil {
+		return false
+	}
+	if peek.Type == "stream_event" {
+		return true
+	}
+	return peek.Type == "system" && peek.Subtype == "thinking_tokens"
 }
 
 // SessionID returns the CLI session ID.

--- a/internal/session/holder_stream_test.go
+++ b/internal/session/holder_stream_test.go
@@ -138,6 +138,78 @@ func TestLoadExistingLines_ClaudeProviderResetBuffers_NoOp(t *testing.T) {
 	}
 }
 
+// TestLoadExistingLines_ThinkingTokensNotPersisted verifies that
+// system/thinking_tokens progress events (emitted by the claude provider for
+// models with redacted thinking, 100+ lines per session) are treated as
+// transient during replay: they must NOT be loaded into sp.lines, while
+// surrounding non-transient lines are preserved.
+//
+// Regression for issue #675.
+func TestLoadExistingLines_ThinkingTokensNotPersisted(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "test-thinking-tokens"
+	jsonlPath := filepath.Join(streamsDir, sessionID+".jsonl")
+
+	content := `{"type":"system","subtype":"init","session_id":"c-1"}
+{"type":"system","subtype":"thinking_tokens","estimated_tokens":50,"estimated_tokens_delta":50,"session_id":"c-1"}
+{"type":"system","subtype":"thinking_tokens","estimated_tokens":128,"estimated_tokens_delta":78,"session_id":"c-1"}
+{"type":"system","subtype":"thinking_tokens","estimated_tokens":250,"estimated_tokens_delta":122,"session_id":"c-1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}
+{"type":"result","subtype":"success","is_error":false,"result":"ok","session_id":"c-1"}
+`
+	if err := os.WriteFile(jsonlPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sp := &HolderStreamProcess{
+		provider: NewClaudeProvider("", ""),
+	}
+
+	sp.loadExistingLines(sessionID, 0)
+
+	if len(sp.lines) != 3 {
+		t.Errorf("expected 3 replayed lines (init, assistant, result), got %d: %v", len(sp.lines), sp.lines)
+	}
+	for _, l := range sp.lines {
+		if strings.Contains(l, "thinking_tokens") {
+			t.Errorf("thinking_tokens event leaked into replayed history: %s", l)
+		}
+	}
+}
+
+// TestIsTransientStreamLine covers the transient-line classification used by
+// both replay and live processing.
+func TestIsTransientStreamLine(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"stream_event", `{"type":"stream_event","event":{"type":"content_block_delta"}}`, true},
+		{"thinking_tokens", `{"type":"system","subtype":"thinking_tokens","estimated_tokens":50}`, true},
+		{"system_init", `{"type":"system","subtype":"init","session_id":"c-1"}`, false},
+		{"assistant", `{"type":"assistant","message":{"content":[]}}`, false},
+		{"result", `{"type":"result","subtype":"success"}`, false},
+		{"non_json", `plain text`, false},
+		{"empty", ``, false},
+		{"invalid_json", `{broken`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTransientStreamLine([]byte(tc.line)); got != tc.want {
+				t.Errorf("isTransientStreamLine(%q) = %v, want %v", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestReadLoop_EOFTriggersOnProcessExit verifies the follow-up fix: when the
 // holder socket reaches EOF (= the holder process died unexpectedly without
 // sending a control "exited" event), the readLoop must fire the

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1482,6 +1482,12 @@ func (m *Manager) readStreamFile(id string, limit int, clearOffset int64) ([]str
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	for scanner.Scan() {
+		// Skip transient lines (stream_event, thinking_tokens): the raw JSONL
+		// file contains everything the holder wrote, but history readers must
+		// apply the same filter as the live path (HolderStreamProcess).
+		if isTransientStreamLine(scanner.Bytes()) {
+			continue
+		}
 		lines = append(lines, scanner.Text())
 	}
 
@@ -1542,6 +1548,11 @@ func (m *Manager) readStreamFileAfter(id string, after int, clearOffset int64) (
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	lineIdx := 0
 	for scanner.Scan() {
+		// Skip transient lines so the `after` cursor counts the same filtered
+		// history as the live path (HolderStreamProcess.lines).
+		if isTransientStreamLine(scanner.Bytes()) {
+			continue
+		}
 		if lineIdx >= after {
 			lines = append(lines, scanner.Text())
 		}

--- a/internal/session/manager_stream_file_test.go
+++ b/internal/session/manager_stream_file_test.go
@@ -1,0 +1,116 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/myuon/agmux/internal/db"
+)
+
+// writeStreamFixture writes a JSONL stream file for the given session ID into
+// db.StreamsDir() (HOME must already point at a temp dir) and returns its path.
+func writeStreamFixture(t *testing.T, sessionID, content string) {
+	t.Helper()
+	streamsDir, err := db.StreamsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(streamsDir, sessionID+".jsonl"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const streamFixtureWithTransients = `{"type":"system","subtype":"init","session_id":"chat-1","model":"sonnet-4"}
+{"type":"system","subtype":"thinking_tokens","estimated_tokens":100,"session_id":"chat-1"}
+{"type":"system","subtype":"thinking_tokens","estimated_tokens":250,"session_id":"chat-1"}
+{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"par"}},"session_id":"chat-1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"answer"}]},"session_id":"chat-1"}
+{"type":"system","subtype":"thinking_tokens","estimated_tokens":400,"session_id":"chat-1"}
+{"type":"result","subtype":"success","is_error":false,"result":"ok","session_id":"chat-1"}
+`
+
+// TestReadStreamFile_FiltersTransientLines verifies the fallback history path
+// (used when no live HolderStreamProcess exists, e.g. after the holder exited)
+// applies the same transient-line filter as the live path so thinking_tokens
+// and stream_event lines never reach the frontend.
+//
+// Regression for PR #679 review comment 4886401099 (issue 1).
+func TestReadStreamFile_FiltersTransientLines(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	sessionID := "test-fallback-filter"
+	writeStreamFixture(t, sessionID, streamFixtureWithTransients)
+
+	m := &Manager{}
+	lines, err := m.readStreamFile(sessionID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 non-transient lines, got %d: %v", len(lines), lines)
+	}
+	for _, l := range lines {
+		if strings.Contains(l, "thinking_tokens") {
+			t.Errorf("thinking_tokens line leaked through fallback read: %s", l)
+		}
+		if strings.Contains(l, "stream_event") {
+			t.Errorf("stream_event line leaked through fallback read: %s", l)
+		}
+	}
+
+	// The limit must apply to the filtered lines, not the raw file lines.
+	limited, err := m.readStreamFile(sessionID, 2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(limited) != 2 {
+		t.Fatalf("expected 2 lines with limit=2, got %d: %v", len(limited), limited)
+	}
+	if !strings.Contains(limited[0], `"type":"assistant"`) || !strings.Contains(limited[1], `"type":"result"`) {
+		t.Errorf("expected last 2 filtered lines (assistant, result), got %v", limited)
+	}
+}
+
+// TestReadStreamFileAfter_FiltersTransientLines verifies the delta fallback
+// path filters transient lines and counts the `after` cursor over filtered
+// lines (matching the live path's sp.lines indexing).
+func TestReadStreamFileAfter_FiltersTransientLines(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	sessionID := "test-fallback-filter-after"
+	writeStreamFixture(t, sessionID, streamFixtureWithTransients)
+
+	m := &Manager{}
+
+	// after=0 returns all filtered lines
+	all, err := m.readStreamFileAfter(sessionID, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 non-transient lines, got %d: %v", len(all), all)
+	}
+
+	// after=1 skips the filtered init line and returns assistant + result;
+	// transient lines must not consume cursor positions.
+	rest, err := m.readStreamFileAfter(sessionID, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rest) != 2 {
+		t.Fatalf("expected 2 lines after cursor 1, got %d: %v", len(rest), rest)
+	}
+	if !strings.Contains(rest[0], `"type":"assistant"`) || !strings.Contains(rest[1], `"type":"result"`) {
+		t.Errorf("expected (assistant, result) after cursor 1, got %v", rest)
+	}
+	for _, l := range rest {
+		if strings.Contains(l, "thinking_tokens") || strings.Contains(l, "stream_event") {
+			t.Errorf("transient line leaked through delta fallback read: %s", l)
+		}
+	}
+}


### PR DESCRIPTION
## 概要

claude provider が redacted thinking モデル（claude-fable-5 等）で大量に emit する `system:thinking_tokens` イベント（1セッション100〜400行）が履歴に永続化され、JSONビューに空内容の行として大量表示される問題への対応。

Closes #675

## 変更内容

### (a) バックエンド: thinking_tokens を transient 扱いに
- `internal/session/holder_stream.go`: リプレイ・ライブ処理の2箇所の peek を共通ヘルパー `isTransientStreamLine` に統合し、`subtype` も読むよう拡張
- `type=="system" && subtype=="thinking_tokens"` を `stream_event` と同様に履歴 (`sp.lines`) に積まない・リプレイで除外（既存セッションの蓄積分もリロードで消える）
- ライブのブロードキャストは継続（フロントの進捗表示に利用）

### (b) フロントエンド: 思考中インジケータ化
- `frontend/src/pages/SessionPage.tsx`: `handleWsMessage` で thinking_tokens を streamLines に push せず、最新の `estimated_tokens` を state に保持。assistant / result 到着でリセット
- `frontend/src/components/session/StreamOutputView.tsx`: 既存の `trailingRetry` と同型の trailing インジケータ「思考中... (~N tokens)」を追加

### (c) JSONビューの保険修正
- `summarizeEntry`: 空文字 thinking（signature のみのブロック）の `[thinking: ]` 表示を抑止
- system 分岐に `estimated_tokens=N (+M)` の summary を追加

## テスト
- `TestLoadExistingLines_ThinkingTokensNotPersisted`: thinking_tokens がリプレイで履歴に載らないことを検証
- `TestIsTransientStreamLine`: transient 判定のテーブルテスト
- `make build` / `make test` 通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)