### PR TITLE
fix: サーバー再起動で孤児化した holder プロセスを起動時に回収する

### DIFF
--- a/.claude/skills/dev-verify/SKILL.md
+++ b/.claude/skills/dev-verify/SKILL.md
@@ -67,3 +67,15 @@ agent-browser close                # ブラウザ終了
 chmod -R +w /tmp/agmux-dev-home && rm -rf /tmp/agmux-dev-home /tmp/agmux-dev
 lsof -ti :4321 >/dev/null && echo "本番は無事"
 ```
+
+## 補足: holder の socket と TMPDIR（#685 以降）
+
+holder の Unix socket は `$TMPDIR/agmux/socks/` に置かれる。サーバー起動時の孤児 holder reaper は
+「自分の SocketDir に socket があるレガシー holder」を自インスタンス帰属とみなすため、
+**隔離バックエンドを起動するときは HOME に加えて TMPDIR も差し替えること**:
+
+```bash
+HOME=/tmp/agmux-dev-home TMPDIR=/tmp/agmux-dev-tmp /tmp/agmux-dev serve --dev --port 4322
+```
+
+TMPDIR を共有すると帰属判定が混ざり、隔離環境の reaper が本番の holder を回収してしまう恐れがある。

--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -229,6 +229,12 @@ func serveCmd() *cobra.Command {
 			// SetOnNewLines callback is already registered on the manager.
 			mgr.RecoverStreamProcesses()
 
+			// Reap orphan holders AFTER recovery: RecoverStreamProcesses first
+			// reconnects to (and re-references in the DB) every holder that is
+			// still usable; whatever holder remains unreferenced afterwards is
+			// a true orphan (#681) and can be terminated safely.
+			mgr.ReapOrphanHolders()
+
 			// Create controller session (singleton) AFTER recovery so that
 			// a surviving controller holder can be reconnected first.
 			controllerDir, err := db.ControllerDir()
@@ -1305,6 +1311,7 @@ func daemonCmd() *cobra.Command {
 func holderCmd() *cobra.Command {
 	var sessionID string
 	var projectPath string
+	var agmuxDir string
 
 	cmd := &cobra.Command{
 		Use:    "holder",
@@ -1333,6 +1340,10 @@ func holderCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&sessionID, "session-id", "", "Session ID")
 	cmd.Flags().StringVar(&projectPath, "project-path", "", "Project directory path")
+	// --agmux-dir is an identification marker only: it lets the orphan-holder
+	// reaper (ReapOrphanHolders) distinguish holders belonging to this agmux
+	// instance from those of another instance. The holder itself does not use it.
+	cmd.Flags().StringVar(&agmuxDir, "agmux-dir", "", "Agmux data directory of the owning instance (identification marker)")
 	// Allow passing arbitrary args after "--"
 	cmd.Flags().SetInterspersed(false)
 

--- a/internal/session/holder.go
+++ b/internal/session/holder.go
@@ -360,8 +360,15 @@ func SpawnHolder(sessionID string, cmdArgs []string, projectPath string, env []s
 		return 0, fmt.Errorf("get executable path: %w", err)
 	}
 
-	// Build holder command arguments
-	holderArgs := []string{"holder", "--session-id", sessionID, "--project-path", projectPath, "--"}
+	// Build holder command arguments.
+	// --agmux-dir is an identification marker so that a reaper of one agmux
+	// instance does not kill holders belonging to another instance (e.g. an
+	// isolated dev server running with a different HOME). See ReapOrphanHolders.
+	holderArgs := []string{"holder", "--session-id", sessionID, "--project-path", projectPath}
+	if agmuxDir, err := db.AgmuxDir(); err == nil {
+		holderArgs = append(holderArgs, "--agmux-dir", agmuxDir)
+	}
+	holderArgs = append(holderArgs, "--")
 	holderArgs = append(holderArgs, cmdArgs...)
 
 	cmd := exec.Command(agmuxBin, holderArgs...)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1999,6 +1999,17 @@ func (m *Manager) Restart(id string) error {
 
 	provider := m.getProvider(s.Provider)
 
+	// Hold spawnMu across the kill -> spawn -> DB update sequence so that the
+	// SendKeysWithImages auto-recovery path (which also takes spawnMu before
+	// spawning) cannot spawn a second holder for the same session while we are
+	// waiting for the old holder to exit. Without this, the DB holder_pid gets
+	// overwritten and the losing holder leaks as an orphan (#681).
+	//
+	// Lock order: spawnMu is the outermost lock; streamMu is only taken inside
+	// via helpers (stopStreamProcess etc.), matching SendKeysWithImages.
+	m.spawnMu.Lock()
+	defer m.spawnMu.Unlock()
+
 	// Stop existing stream process
 	m.stopStreamProcess(id)
 

--- a/internal/session/reaper.go
+++ b/internal/session/reaper.go
@@ -27,10 +27,26 @@ var (
 	// reaperIsAlive reports whether a PID is still running.
 	reaperIsAlive = IsHolderAlive
 
+	// reaperSocketExists reports whether this instance's socket dir contains a
+	// holder socket for the session. Used to attribute legacy holders (spawned
+	// before --agmux-dir existed) to an instance.
+	reaperSocketExists = defaultReaperSocketExists
+
 	// reaperTermWait is how long to wait for SIGTERM'd holders to exit
 	// before falling back to SIGKILL.
 	reaperTermWait = 5 * time.Second
 )
+
+// defaultReaperSocketExists checks for the holder's Unix socket file on disk.
+// A live holder listens on SocketPath(sessionID) for its whole lifetime (the
+// file is only removed by a newer holder's startup cleanup), so for a process
+// already confirmed alive via ps, the socket's presence in OUR SocketDir means
+// the holder was started by an instance sharing this socket dir. No stale-file
+// concern: only ps-confirmed-alive PIDs reach this check.
+func defaultReaperSocketExists(sessionID string) bool {
+	_, err := os.Stat(SocketPath(sessionID))
+	return err == nil
+}
 
 // orphanCandidate is a holder process found in the ps listing.
 type orphanCandidate struct {
@@ -143,11 +159,22 @@ func (m *Manager) ReapOrphanHolders() {
 			skipped++
 			continue
 		}
-		// Holders of another agmux instance must not be touched. Legacy holders
-		// without --agmux-dir are treated as belonging to this instance.
+		// Holders of another agmux instance must not be touched.
 		if c.agmuxDir != "" && c.agmuxDir != selfDir {
 			m.logger.Info("reaper: skipping holder of another agmux instance",
 				"sessionId", c.sessionID, "pid", c.pid, "agmuxDir", c.agmuxDir)
+			skipped++
+			continue
+		}
+		// Legacy holders (no --agmux-dir flag) carry no instance marker, so
+		// attribute them via their Unix socket: a live holder keeps listening on
+		// SocketPath(sessionID) in the SocketDir of the instance that spawned it.
+		// If OUR SocketDir has no socket for this session, the holder may belong
+		// to another instance (e.g. an isolated dev server with a different
+		// HOME/TMPDIR) — skip it rather than risk killing a foreign holder.
+		if c.agmuxDir == "" && !reaperSocketExists(c.sessionID) {
+			m.logger.Info("reaper: skipping legacy holder without a socket in this instance's socket dir (possibly another instance)",
+				"sessionId", c.sessionID, "pid", c.pid, "socketPath", SocketPath(c.sessionID))
 			skipped++
 			continue
 		}

--- a/internal/session/reaper.go
+++ b/internal/session/reaper.go
@@ -1,0 +1,215 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/myuon/agmux/internal/db"
+)
+
+// Injection points for tests. Production code always uses the defaults.
+var (
+	// reaperPSOutput lists all processes in "pid command" form.
+	reaperPSOutput = func() ([]byte, error) {
+		// -axo pid=,command= works on both macOS and Linux and suppresses headers.
+		return exec.Command("ps", "-axo", "pid=,command=").Output()
+	}
+
+	// reaperKill sends a signal to a PID (negative PID targets a process group).
+	reaperKill = func(pid int, sig syscall.Signal) error {
+		return syscall.Kill(pid, sig)
+	}
+
+	// reaperIsAlive reports whether a PID is still running.
+	reaperIsAlive = IsHolderAlive
+
+	// reaperTermWait is how long to wait for SIGTERM'd holders to exit
+	// before falling back to SIGKILL.
+	reaperTermWait = 5 * time.Second
+)
+
+// orphanCandidate is a holder process found in the ps listing.
+type orphanCandidate struct {
+	pid       int
+	sessionID string
+	agmuxDir  string // value of --agmux-dir, empty for legacy holders
+}
+
+// parseHolderProcesses extracts holder processes from `ps -axo pid=,command=` output.
+func parseHolderProcesses(psOut []byte) []orphanCandidate {
+	var out []orphanCandidate
+	for _, line := range strings.Split(string(psOut), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Fast filter: must look like an agmux holder invocation.
+		if !strings.Contains(line, " holder --session-id ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		// fields[1] is argv[0] (the binary); it must be an agmux binary.
+		if !strings.Contains(fields[1], "agmux") {
+			continue
+		}
+		cand := orphanCandidate{pid: pid}
+		// Scan flags up to the "--" separator (everything after it is the
+		// wrapped CLI command and must not be interpreted as holder flags).
+		args := fields[2:]
+		for i := 0; i < len(args); i++ {
+			if args[i] == "--" {
+				break
+			}
+			switch args[i] {
+			case "--session-id":
+				if i+1 < len(args) {
+					cand.sessionID = args[i+1]
+					i++
+				}
+			case "--agmux-dir":
+				if i+1 < len(args) {
+					cand.agmuxDir = args[i+1]
+					i++
+				}
+			}
+		}
+		if cand.sessionID == "" {
+			continue
+		}
+		out = append(out, cand)
+	}
+	return out
+}
+
+// ReapOrphanHolders finds holder processes that are no longer referenced by
+// this instance (not in the DB as any session's holder_pid and not managed by
+// the in-memory stream process map) and terminates them.
+//
+// Background (#681): sessions.holder_pid stores only the latest PID per
+// session. When a race (e.g. Restart vs SendKeys auto-recovery) overwrites the
+// DB with a new PID, the previous holder becomes an orphan that nothing ever
+// kills, accumulating across server restarts.
+//
+// ⚠️ CRITICAL kill ordering (see Delete() in manager.go and #441, #472, #502,
+// #529, #569, #574): holders must be terminated by sending SIGTERM to the
+// process group (-PID) first, waiting for graceful shutdown, and only then
+// falling back to SIGKILL on the group. The holder's SIGTERM handler closes
+// stdin so the child claude CLI exits cleanly; SIGKILL-first orphans the CLI.
+// Holders are spawned with Setsid: true, so PID == PGID.
+//
+// This should be called after RecoverStreamProcesses so that holders which can
+// be reconnected are re-referenced first and only truly orphaned ones remain.
+func (m *Manager) ReapOrphanHolders() {
+	selfDir, err := db.AgmuxDir()
+	if err != nil {
+		m.logger.Warn("reaper: cannot determine agmux dir; skipping orphan holder reaping", "error", err)
+		return
+	}
+
+	psOut, err := reaperPSOutput()
+	if err != nil {
+		m.logger.Warn("reaper: ps failed; skipping orphan holder reaping", "error", err)
+		return
+	}
+	candidates := parseHolderProcesses(psOut)
+	if len(candidates) == 0 {
+		return
+	}
+
+	// Holder PIDs currently managed in-memory (safety net in addition to the DB check).
+	managed := make(map[int]struct{})
+	m.streamMu.Lock()
+	for _, sp := range m.streamProcesses {
+		managed[sp.HolderPID()] = struct{}{}
+	}
+	m.streamMu.Unlock()
+
+	selfPID := os.Getpid()
+	var targets []orphanCandidate
+	skipped := 0
+	for _, c := range candidates {
+		if c.pid <= 1 || c.pid == selfPID {
+			skipped++
+			continue
+		}
+		// Holders of another agmux instance must not be touched. Legacy holders
+		// without --agmux-dir are treated as belonging to this instance.
+		if c.agmuxDir != "" && c.agmuxDir != selfDir {
+			m.logger.Info("reaper: skipping holder of another agmux instance",
+				"sessionId", c.sessionID, "pid", c.pid, "agmuxDir", c.agmuxDir)
+			skipped++
+			continue
+		}
+		// A holder referenced by the DB as the session's current holder is legitimate.
+		var dbPID int
+		if err := m.db.QueryRow("SELECT holder_pid FROM sessions WHERE id = ?", c.sessionID).Scan(&dbPID); err == nil && dbPID == c.pid {
+			skipped++
+			continue
+		}
+		// Safety net: never kill a holder the in-memory map still manages.
+		if _, ok := managed[c.pid]; ok {
+			skipped++
+			continue
+		}
+		targets = append(targets, c)
+	}
+
+	if len(targets) == 0 {
+		m.logger.Info("reaper: no orphan holders found", "candidates", len(candidates), "skipped", skipped)
+		return
+	}
+
+	// Batch phase 1: send SIGTERM to every orphan's process group first, then
+	// wait once for all of them. With 100+ orphans, waiting serially per
+	// process (3s each) would block startup for minutes.
+	for _, t := range targets {
+		m.logger.Info("reaper: terminating orphan holder (SIGTERM to process group)",
+			"sessionId", t.sessionID, "pid", t.pid)
+		if err := reaperKill(-t.pid, syscall.SIGTERM); err != nil {
+			m.logger.Warn("reaper: SIGTERM failed", "sessionId", t.sessionID, "pid", t.pid, "error", err)
+		}
+	}
+
+	// Batch phase 2: poll until all targets exit or the grace period expires.
+	deadline := time.Now().Add(reaperTermWait)
+	for time.Now().Before(deadline) {
+		anyAlive := false
+		for _, t := range targets {
+			if reaperIsAlive(t.pid) {
+				anyAlive = true
+				break
+			}
+		}
+		if !anyAlive {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Batch phase 3: SIGKILL the process groups of survivors.
+	reaped := 0
+	for _, t := range targets {
+		if reaperIsAlive(t.pid) {
+			m.logger.Info("reaper: holder survived SIGTERM, killing process group (SIGKILL fallback)",
+				"sessionId", t.sessionID, "pid", t.pid)
+			if err := reaperKill(-t.pid, syscall.SIGKILL); err != nil {
+				m.logger.Warn("reaper: SIGKILL failed", "sessionId", t.sessionID, "pid", t.pid, "error", err)
+			}
+		}
+		reaped++
+	}
+
+	m.logger.Info("reaper: orphan holder reaping done",
+		"reaped", reaped, "skipped", skipped, "candidates", len(candidates))
+}

--- a/internal/session/reaper_test.go
+++ b/internal/session/reaper_test.go
@@ -1,0 +1,264 @@
+package session
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// killCall records a single call to the injected kill function.
+type killCall struct {
+	pid int
+	sig syscall.Signal
+}
+
+// setupReaperTest swaps the reaper injection points for fakes and isolates
+// HOME so db.AgmuxDir() never touches the real ~/.agmux. It returns the
+// isolated agmux dir (the "self" instance dir) and a pointer to the recorded
+// kill calls.
+func setupReaperTest(t *testing.T, psLines string, alive func(pid int) bool) (selfDir string, calls *[]killCall) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	selfDir = filepath.Join(home, ".agmux")
+
+	origPS := reaperPSOutput
+	origKill := reaperKill
+	origAlive := reaperIsAlive
+	origWait := reaperTermWait
+	t.Cleanup(func() {
+		reaperPSOutput = origPS
+		reaperKill = origKill
+		reaperIsAlive = origAlive
+		reaperTermWait = origWait
+	})
+
+	reaperPSOutput = func() ([]byte, error) { return []byte(psLines), nil }
+
+	recorded := []killCall{}
+	calls = &recorded
+	reaperKill = func(pid int, sig syscall.Signal) error {
+		recorded = append(recorded, killCall{pid: pid, sig: sig})
+		return nil
+	}
+
+	if alive == nil {
+		// Default: every process dies immediately after SIGTERM.
+		alive = func(pid int) bool { return false }
+	}
+	reaperIsAlive = alive
+	reaperTermWait = 200 * time.Millisecond
+
+	return selfDir, calls
+}
+
+// insertReaperSession inserts a minimal session row with the given holder_pid.
+func insertReaperSession(t *testing.T, db *sql.DB, id string, holderPID int) {
+	t.Helper()
+	now := time.Now()
+	_, err := db.Exec(
+		`INSERT INTO sessions (id, name, project_path, tmux_session, status, type, output_mode, provider, model, holder_pid, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, "test", "/tmp", "", "idle", "worker", "stream", "claude", "", holderPID, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert session %s: %v", id, err)
+	}
+}
+
+// sigtermedPIDs returns the (positive) PIDs that received a process-group SIGTERM.
+func sigtermedPIDs(calls []killCall) map[int]bool {
+	out := map[int]bool{}
+	for _, c := range calls {
+		if c.sig == syscall.SIGTERM && c.pid < 0 {
+			out[-c.pid] = true
+		}
+	}
+	return out
+}
+
+func holderPSLine(pid int, sessionID, agmuxDir string) string {
+	if agmuxDir == "" {
+		return fmt.Sprintf("%5d /usr/local/bin/agmux holder --session-id %s --project-path /tmp/proj -- claude --model opus\n", pid, sessionID)
+	}
+	return fmt.Sprintf("%5d /usr/local/bin/agmux holder --session-id %s --project-path /tmp/proj --agmux-dir %s -- claude --model opus\n", pid, sessionID, agmuxDir)
+}
+
+// TestReapOrphanHolders_KeepsDBReferencedHolder: a holder whose PID matches
+// the session's holder_pid in the DB is the legitimate holder and must NOT be reaped.
+func TestReapOrphanHolders_KeepsDBReferencedHolder(t *testing.T) {
+	ps := holderPSLine(90001, "sessA", "") +
+		"  123 /sbin/launchd\n"
+	_, calls := setupReaperTest(t, ps, nil)
+
+	db := newTestDB(t)
+	defer db.Close()
+	insertReaperSession(t, db, "sessA", 90001)
+
+	m := newTestManager(t, db)
+	m.ReapOrphanHolders()
+
+	if len(*calls) != 0 {
+		t.Errorf("expected no kills for DB-referenced holder, got %v", *calls)
+	}
+}
+
+// TestReapOrphanHolders_ReapsUnknownSession: a holder whose session no longer
+// exists in the DB is an orphan and must be reaped via SIGTERM to its process group.
+func TestReapOrphanHolders_ReapsUnknownSession(t *testing.T) {
+	ps := holderPSLine(90002, "gone1", "")
+	_, calls := setupReaperTest(t, ps, nil)
+
+	db := newTestDB(t)
+	defer db.Close()
+
+	m := newTestManager(t, db)
+	m.ReapOrphanHolders()
+
+	termed := sigtermedPIDs(*calls)
+	if !termed[90002] {
+		t.Errorf("expected SIGTERM to process group -90002, got calls %v", *calls)
+	}
+	// SIGTERM must come first and target the process group (negative PID).
+	if len(*calls) == 0 || (*calls)[0].sig != syscall.SIGTERM || (*calls)[0].pid != -90002 {
+		t.Errorf("first kill must be SIGTERM to -90002, got %v", *calls)
+	}
+}
+
+// TestReapOrphanHolders_ReapsDuplicateHolder: when two holders exist for the
+// same session, only the one NOT referenced by the DB is reaped.
+func TestReapOrphanHolders_ReapsDuplicateHolder(t *testing.T) {
+	ps := holderPSLine(90010, "sessB", "") + // legitimate (matches DB)
+		holderPSLine(90011, "sessB", "") // duplicate orphan
+	_, calls := setupReaperTest(t, ps, nil)
+
+	db := newTestDB(t)
+	defer db.Close()
+	insertReaperSession(t, db, "sessB", 90010)
+
+	m := newTestManager(t, db)
+	m.ReapOrphanHolders()
+
+	termed := sigtermedPIDs(*calls)
+	if termed[90010] {
+		t.Errorf("DB-referenced holder 90010 must not be reaped; calls %v", *calls)
+	}
+	if !termed[90011] {
+		t.Errorf("duplicate orphan holder 90011 must be reaped; calls %v", *calls)
+	}
+}
+
+// TestReapOrphanHolders_SkipsOtherInstance: a holder started by another agmux
+// instance (different --agmux-dir) must never be touched, even if this
+// instance's DB does not know its session.
+func TestReapOrphanHolders_SkipsOtherInstance(t *testing.T) {
+	ps := holderPSLine(90020, "other", "/Users/someone/dev-home/.agmux")
+	_, calls := setupReaperTest(t, ps, nil)
+
+	db := newTestDB(t)
+	defer db.Close()
+
+	m := newTestManager(t, db)
+	m.ReapOrphanHolders()
+
+	if len(*calls) != 0 {
+		t.Errorf("holder of another instance must not be killed, got %v", *calls)
+	}
+}
+
+// TestReapOrphanHolders_ReapsOwnInstanceAndLegacy: holders whose --agmux-dir
+// matches this instance, and legacy holders without --agmux-dir, are both
+// reap targets when orphaned.
+func TestReapOrphanHolders_ReapsOwnInstanceAndLegacy(t *testing.T) {
+	// Set up first to learn the isolated self dir, then point the fake ps
+	// output at holders carrying that exact --agmux-dir value.
+	selfDir, calls := setupReaperTest(t, "", nil)
+	ps := holderPSLine(90030, "own01", selfDir) + // own instance, orphaned
+		holderPSLine(90031, "leg01", "") // legacy (no --agmux-dir), orphaned
+	reaperPSOutput = func() ([]byte, error) { return []byte(ps), nil }
+
+	db := newTestDB(t)
+	defer db.Close()
+
+	m := newTestManager(t, db)
+	m.ReapOrphanHolders()
+
+	termed := sigtermedPIDs(*calls)
+	if !termed[90030] {
+		t.Errorf("orphan holder with matching --agmux-dir must be reaped; calls %v", *calls)
+	}
+	if !termed[90031] {
+		t.Errorf("legacy orphan holder without --agmux-dir must be reaped; calls %v", *calls)
+	}
+}
+
+// TestReapOrphanHolders_SkipsManagedStreamProcess: a holder PID present in the
+// in-memory stream process map must not be reaped even if the DB row is missing.
+func TestReapOrphanHolders_SkipsManagedStreamProcess(t *testing.T) {
+	ps := holderPSLine(90040, "sessC", "")
+	_, calls := setupReaperTest(t, ps, nil)
+
+	db := newTestDB(t)
+	defer db.Close()
+
+	m := newTestManager(t, db)
+	m.streamProcesses = map[string]*HolderStreamProcess{
+		"sessC": {holderPID: 90040},
+	}
+	m.ReapOrphanHolders()
+
+	if len(*calls) != 0 {
+		t.Errorf("holder managed by streamProcesses must not be killed, got %v", *calls)
+	}
+}
+
+// TestReapOrphanHolders_SIGKILLFallback: a holder that survives SIGTERM gets
+// SIGKILL on its process group, and the ordering is SIGTERM first, SIGKILL last.
+func TestReapOrphanHolders_SIGKILLFallback(t *testing.T) {
+	ps := holderPSLine(90050, "stub1", "")
+	alwaysAlive := func(pid int) bool { return true }
+	_, calls := setupReaperTest(t, ps, alwaysAlive)
+
+	db := newTestDB(t)
+	defer db.Close()
+
+	m := newTestManager(t, db)
+	m.ReapOrphanHolders()
+
+	got := *calls
+	if len(got) != 2 {
+		t.Fatalf("expected SIGTERM then SIGKILL, got %v", got)
+	}
+	if got[0].sig != syscall.SIGTERM || got[0].pid != -90050 {
+		t.Errorf("first call must be SIGTERM to -90050, got %v", got[0])
+	}
+	if got[1].sig != syscall.SIGKILL || got[1].pid != -90050 {
+		t.Errorf("second call must be SIGKILL to -90050, got %v", got[1])
+	}
+}
+
+// TestParseHolderProcesses covers the ps output parsing edge cases.
+func TestParseHolderProcesses(t *testing.T) {
+	ps := "" +
+		"    1 /sbin/launchd\n" +
+		holderPSLine(101, "aaaaa", "") +
+		holderPSLine(102, "bbbbb", "/home/x/.agmux") +
+		"  300 grep agmux holder --session-id zzz\n" + // argv0 not agmux
+		"  400 /usr/local/bin/agmux serve --port 4321\n" + // not a holder
+		"  bad /usr/local/bin/agmux holder --session-id ccccc -- claude\n" // non-numeric pid
+
+	got := parseHolderProcesses([]byte(ps))
+	if len(got) != 2 {
+		t.Fatalf("expected 2 holders, got %d: %+v", len(got), got)
+	}
+	if got[0].pid != 101 || got[0].sessionID != "aaaaa" || got[0].agmuxDir != "" {
+		t.Errorf("holder[0] = %+v, want pid=101 session=aaaaa agmuxDir=\"\"", got[0])
+	}
+	if got[1].pid != 102 || got[1].sessionID != "bbbbb" || got[1].agmuxDir != "/home/x/.agmux" {
+		t.Errorf("holder[1] = %+v, want pid=102 session=bbbbb agmuxDir=/home/x/.agmux", got[1])
+	}
+}

--- a/internal/session/reaper_test.go
+++ b/internal/session/reaper_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"database/sql"
 	"fmt"
+	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -29,11 +30,13 @@ func setupReaperTest(t *testing.T, psLines string, alive func(pid int) bool) (se
 	origPS := reaperPSOutput
 	origKill := reaperKill
 	origAlive := reaperIsAlive
+	origSock := reaperSocketExists
 	origWait := reaperTermWait
 	t.Cleanup(func() {
 		reaperPSOutput = origPS
 		reaperKill = origKill
 		reaperIsAlive = origAlive
+		reaperSocketExists = origSock
 		reaperTermWait = origWait
 	})
 
@@ -51,6 +54,9 @@ func setupReaperTest(t *testing.T, psLines string, alive func(pid int) bool) (se
 		alive = func(pid int) bool { return false }
 	}
 	reaperIsAlive = alive
+	// Default: every legacy holder has a socket in our socket dir, i.e. it
+	// belongs to this instance. Tests for foreign legacy holders override this.
+	reaperSocketExists = func(sessionID string) bool { return true }
 	reaperTermWait = 200 * time.Millisecond
 
 	return selfDir, calls
@@ -193,6 +199,59 @@ func TestReapOrphanHolders_ReapsOwnInstanceAndLegacy(t *testing.T) {
 	}
 	if !termed[90031] {
 		t.Errorf("legacy orphan holder without --agmux-dir must be reaped; calls %v", *calls)
+	}
+}
+
+// TestReapOrphanHolders_ReapsLegacyWithSocket: a legacy holder (no --agmux-dir)
+// whose Unix socket file exists in THIS instance's SocketDir belongs to this
+// instance and is reaped when orphaned. Uses the real (os.Stat based) socket
+// check against an actual file, with TMPDIR isolated to a temp dir.
+func TestReapOrphanHolders_ReapsLegacyWithSocket(t *testing.T) {
+	ps := holderPSLine(90060, "leg02", "")
+	_, calls := setupReaperTest(t, ps, nil)
+
+	// Isolate SocketDir (os.TempDir()/agmux/socks) and place a real socket file.
+	t.Setenv("TMPDIR", t.TempDir())
+	reaperSocketExists = defaultReaperSocketExists
+	if err := os.MkdirAll(SocketDir(), 0700); err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+	if err := os.WriteFile(SocketPath("leg02"), nil, 0600); err != nil {
+		t.Fatalf("create socket file: %v", err)
+	}
+
+	db := newTestDB(t)
+	defer db.Close()
+
+	m := newTestManager(t, db)
+	m.ReapOrphanHolders()
+
+	if !sigtermedPIDs(*calls)[90060] {
+		t.Errorf("legacy orphan holder with socket in our SocketDir must be reaped; calls %v", *calls)
+	}
+}
+
+// TestReapOrphanHolders_SkipsLegacyWithoutSocket: a legacy holder with no
+// socket file in THIS instance's SocketDir cannot be attributed to this
+// instance (it may belong to an isolated dev server with a different
+// HOME/TMPDIR) and must be skipped. Uses the real socket check against an
+// isolated, empty SocketDir.
+func TestReapOrphanHolders_SkipsLegacyWithoutSocket(t *testing.T) {
+	ps := holderPSLine(90061, "leg03", "")
+	_, calls := setupReaperTest(t, ps, nil)
+
+	// Isolated SocketDir with NO socket file for leg03.
+	t.Setenv("TMPDIR", t.TempDir())
+	reaperSocketExists = defaultReaperSocketExists
+
+	db := newTestDB(t)
+	defer db.Close()
+
+	m := newTestManager(t, db)
+	m.ReapOrphanHolders()
+
+	if len(*calls) != 0 {
+		t.Errorf("legacy holder without a socket in our SocketDir must not be killed, got %v", *calls)
 	}
 }
 

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -68,6 +68,9 @@ type SessionService interface {
 
 	// RecoverStreamProcesses restarts stream processes for all working sessions.
 	RecoverStreamProcesses()
+	// ReapOrphanHolders terminates holder processes that are no longer
+	// referenced by this instance (see #681). Call after RecoverStreamProcesses.
+	ReapOrphanHolders()
 	// StopAllStreamProcesses gracefully stops all running stream processes.
 	StopAllStreamProcesses()
 	// SetCodexCommand sets the codex command for the manager.


### PR DESCRIPTION
## 根本原因

- holder プロセスは Setsid で detach されサーバー再起動を生き延びる設計だが、DB (`sessions.holder_pid`) はセッションごとに**最新 PID を1つしか記録しない**
- Restart と SendKeys auto-recovery のレース等で DB が新 PID に上書きされると、旧 holder は誰からも参照されない孤児として永遠に残留する
- 孤児を回収する仕組みがどこにも存在せず、本番では 125 個の holder が生存（DB 参照は 2 個のみ）

## 変更点

### 1. holder 起動引数に `--agmux-dir` を追加（インスタンス識別マーカー）

`SpawnHolder` が `db.AgmuxDir()` の値を `--agmux-dir` として holder に付与する。複数の agmux インスタンス（例: HOME を差し替えた開発用隔離サーバー）が併走しても、reaper が他インスタンスの holder を誤殺しない。holder 自身はこのフラグを使わない。

### 2. 孤児 holder reaper (`internal/session/reaper.go`)

起動時に `mgr.RecoverStreamProcesses()` の**直後**に `ReapOrphanHolders()` を呼ぶ（Recover が先に既存 holder への再接続・DB 更新を済ませ、残った未参照 holder だけを回収する）。

- `ps -axo pid=,command=` から agmux holder プロセスを列挙
- 除外: 他インスタンス（`--agmux-dir` 不一致）/ DB の holder_pid と一致する正規 holder / streamProcesses 管理下の PID / 自プロセス・PID<=1
- **kill 順序は必ずプロセスグループ (-PID) へ SIGTERM → 最大5秒待ち → 生き残りに SIGKILL**。holder は SIGTERM で stdin.Close() して子の claude CLI を正常終了させるため、SIGKILL 先行は claude の孤児化を招く（#441, #472, #502, #529, #569, #574 で6回再発）
- 孤児が100個以上あるケースを考慮し、SIGTERM は全対象へバッチ送信してから一括ポーリングで待つ（直列待ちだと起動が数分ブロックされる）

### 3. レガシー holder（`--agmux-dir` なし）の帰属判定

`--agmux-dir` を持たない既存 holder を無条件に自インスタンス扱いすると、隔離環境（HOME 差し替え、`/dev-verify` 参照）で新バイナリのサーバーを起動した瞬間に本番の正規レガシー holder を殺してしまう。そこで socket ファイルによる帰属判定を追加:

- holder は生存中 `SocketPath(sessionID)`（`os.TempDir()/agmux/socks/<id>.sock`）の Unix socket を listen し続ける
- **自インスタンスの SocketDir に該当セッションの socket ファイルが存在する場合のみ**、そのレガシー holder を自インスタンス帰属とみなして reap 対象にする
- socket が無ければ他インスタンスの可能性があるので skip（理由をログ出力）
- 候補は ps で生存確認済みの PID のみなので stale socket の心配はない。`--agmux-dir` 付き holder は従来どおりフラグ値の比較で判定

⚠️ 注: `SocketDir` は HOME ではなく `os.TempDir()`（`$TMPDIR`）ベースのため、TMPDIR まで共有するインスタンス同士はこの判定でも区別しきれない。ただし判定は「socket が無ければ殺さない」という安全側にのみ働き、誤殺が増えることはない。`--agmux-dir` 付き holder への移行が進めばレガシー判定自体が不要になる。

### 4. Restart() の二重 spawn 防止

`Restart()` が `spawnMu` を取得していなかったため、`killStaleHolder()` の待機中に `SendKeysWithImages()` の auto-recovery が同一セッションへ新 holder を spawn でき、DB 上書きで孤児が生まれるレースがあった。kill → spawn → DB 更新の区間を `spawnMu` で保護（ロック順序は SendKeysWithImages と同じ spawnMu → streamMu）。

## テスト

`internal/session/reaper_test.go`（ps 出力と kill・socket 判定を注入したユニットテスト）:

- DB の holder_pid と一致する holder は reap されない
- DB に無いセッションの holder は reap される
- 同一セッションで DB の PID と異なる重複 holder のみ reap される
- `--agmux-dir` が他インスタンスを指す holder は reap されない
- `--agmux-dir` が自インスタンス一致 / なし（レガシー）は reap される
- レガシー + 自インスタンスの socket あり → reap される（TMPDIR 隔離 + 実ファイルで os.Stat 判定）
- レガシー + socket なし → skip される
- streamProcesses 管理下の PID は reap されない
- SIGTERM → SIGKILL フォールバックの順序検証
- ps 出力パースのエッジケース

`go build ./...` / `go test ./...` 全パス確認済み。

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)