### PR TITLE
fix: clear時にCLIプロセスを再起動してコンテキストをクリアする

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1296,8 +1296,13 @@ func (m *Manager) Clear(id string) error {
 		sp.ClearLines()
 	}
 
-	// Store clear_offset and reset task/goal but keep the existing process and CLI session running.
-	_, err = m.db.Exec("UPDATE sessions SET last_error = NULL, current_task = NULL, goal = NULL, goals = '[]', clear_offset = ?, updated_at = ? WHERE id = ?", clearOffset, time.Now(), id)
+	// Stop the holder process so that the next SendKeys starts a fresh CLI session
+	// without the old context (fixes: clear command does not reset Claude's context).
+	m.stopStreamProcess(id)
+
+	// Store clear_offset and reset task/goal, cli_session_id, and conversation_started
+	// so the next SendKeys spawns a brand-new CLI session with no prior conversation.
+	_, err = m.db.Exec("UPDATE sessions SET last_error = NULL, current_task = NULL, goal = NULL, goals = '[]', clear_offset = ?, cli_session_id = NULL, conversation_started = 0, updated_at = ? WHERE id = ?", clearOffset, time.Now(), id)
 	if err != nil {
 		return err
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1288,21 +1288,12 @@ func (m *Manager) Clear(id string) error {
 		}
 	}
 
-	// Clear in-memory lines in the stream process
-	m.streamMu.Lock()
-	sp, ok := m.streamProcesses[id]
-	m.streamMu.Unlock()
-	if ok {
-		sp.ClearLines()
-	}
-
 	// Stop the holder process so that the next SendKeys starts a fresh CLI session
 	// without the old context (fixes: clear command does not reset Claude's context).
 	m.stopStreamProcess(id)
 
-	// Store clear_offset and reset task/goal, cli_session_id, and conversation_started
-	// so the next SendKeys spawns a brand-new CLI session with no prior conversation.
-	_, err = m.db.Exec("UPDATE sessions SET last_error = NULL, current_task = NULL, goal = NULL, goals = '[]', clear_offset = ?, cli_session_id = NULL, conversation_started = 0, updated_at = ? WHERE id = ?", clearOffset, time.Now(), id)
+	// Store clear_offset and reset all session state
+	_, err = m.db.Exec("UPDATE sessions SET last_error = NULL, current_task = NULL, goal = NULL, goals = '[]', clear_offset = ?, cli_session_id = NULL, conversation_started = 0, holder_pid = 0, updated_at = ? WHERE id = ?", clearOffset, time.Now(), id)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- `Manager.Clear()` が agmux 側の UI 状態のみクリアし、Claude CLI プロセスにはコンテキストクリアの指示を送っていなかったバグを修正
- `Clear()` 時に `stopStreamProcess()` を呼び出してホルダーを停止し、次の `SendKeys` で新規 CLI セッションが起動されるようにした
- DB の `cli_session_id` を NULL に、`conversation_started` を 0 にリセットすることで、`--resume` による古い会話の再接続を防ぐ

## Test plan

- [ ] `go test ./internal/session/...` が通ることを確認（ローカルで44テスト全パス済み）
- [ ] セッションでクリアコマンドを実行後、次のメッセージ送信時に Claude が前の会話コンテキストを持っていないことを確認

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)