### PR TITLE
fix: サブエージェント完了検知のゾンビタスク復活とrace conditionを修正

### DIFF
--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -166,6 +166,13 @@ export function extractActiveTasks(entries: StreamEntry[]): ActiveTask[] {
       if (taskId) {
         tasks.delete(taskId);
       }
+    } else if (subtype === "task_updated") {
+      const taskId = raw.task_id as string;
+      const patch = raw.patch as Record<string, unknown> | undefined;
+      const patchStatus = patch?.status as string | undefined;
+      if (taskId && (patchStatus === "completed" || patchStatus === "failed")) {
+        tasks.delete(taskId);
+      }
     }
   }
   // Remove tasks that were explicitly stopped via TaskStop

--- a/internal/session/background_task.go
+++ b/internal/session/background_task.go
@@ -89,6 +89,7 @@ type rawStreamLine struct {
 	LastIn   json.RawMessage        `json:"last_tool_input"`
 	Output   string                 `json:"output"`
 	Usage    map[string]json.Number `json:"usage"`
+	Patch    json.RawMessage        `json:"patch"`
 	Message  *struct {
 		Role    string          `json:"role"`
 		Content json.RawMessage `json:"content"`
@@ -246,6 +247,21 @@ func (s *BackgroundTaskStore) ApplyLine(sessionID string, line []byte) error {
 			return nil
 		}
 		return s.deleteTask(sessionID, ev.TaskID)
+
+	case "task_updated":
+		if ev.TaskID == "" {
+			return nil
+		}
+		var patch struct {
+			Status string `json:"status"`
+		}
+		if len(ev.Patch) > 0 {
+			if err := json.Unmarshal(ev.Patch, &patch); err == nil {
+				if patch.Status == "completed" || patch.Status == "failed" {
+					return s.deleteTask(sessionID, ev.TaskID)
+				}
+			}
+		}
 	}
 
 	return nil
@@ -607,14 +623,10 @@ func (s *BackgroundTaskStore) upsertTask(sessionID string, t BackgroundTask) err
 }
 
 func (s *BackgroundTaskStore) deleteTask(sessionID, taskID string) error {
-	_, err := s.db.Exec(
-		`DELETE FROM background_tasks WHERE session_id = ? AND task_id = ?`,
-		sessionID, taskID,
-	)
-	if err != nil {
-		return fmt.Errorf("delete background task: %w", err)
-	}
-	return nil
+	// Use tombstone (logical delete) instead of physical DELETE so that a
+	// delayed task_progress arriving after task_notification cannot resurrect
+	// the task via upsertTask's INSERT path (which guards on dismissed_at IS NULL).
+	return s.Dismiss(sessionID, taskID)
 }
 
 func nullableString(s string) sql.NullString {

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -25,8 +25,10 @@ type ImageData struct {
 
 // streamEvent is a minimal struct for parsing event type and subtype from JSONL lines.
 type streamEvent struct {
-	Type    string `json:"type"`
-	Subtype string `json:"subtype"`
+	Type    string          `json:"type"`
+	Subtype string          `json:"subtype"`
+	TaskID  string          `json:"task_id"`
+	Patch   json.RawMessage `json:"patch"`
 }
 
 // parseStreamEvent parses the type and subtype from a JSONL line.
@@ -176,10 +178,19 @@ func StartHolderStreamProcess(opts StreamOpts, provider Provider) (*HolderStream
 	// Load existing lines from JSONL file (respecting clear offset)
 	sp.loadExistingLines(opts.SessionID, opts.ClearOffset)
 
-	// Start reading from the socket
-	go sp.readLoop()
+	// NOTE: readLoop is NOT started here. The caller must call sp.StartReadLoop()
+	// after wiring all callbacks (e.g. wireSessionIDCallback) to avoid a race
+	// window where events arrive before onNewLines is set.
 
 	return sp, nil
+}
+
+// StartReadLoop starts the background goroutine that reads lines from the
+// holder socket and dispatches them via onNewLines. It must be called after
+// all callbacks (onNewLines, onSessionID, etc.) have been wired, so that no
+// event is dropped between process start and callback registration.
+func (sp *HolderStreamProcess) StartReadLoop() {
+	go sp.readLoop()
 }
 
 // ReconnectHolderStreamProcess reconnects to an existing holder process.
@@ -225,8 +236,9 @@ func ReconnectHolderStreamProcess(opts StreamOpts, provider Provider, holderPID 
 	// Load all existing lines from JSONL file (respecting clear offset)
 	sp.loadExistingLines(opts.SessionID, opts.ClearOffset)
 
-	// Start reading from the socket
-	go sp.readLoop()
+	// NOTE: readLoop is NOT started here. The caller must call sp.StartReadLoop()
+	// after wiring all callbacks (e.g. wireSessionIDCallback) to avoid a race
+	// window where events arrive before onNewLines is set.
 
 	return sp, nil
 }
@@ -415,6 +427,29 @@ func (sp *HolderStreamProcess) readLoop() {
 				// Stop periodic notification when all background tasks complete
 				if remaining == 0 {
 					sp.stopPeriodicNotification()
+				}
+			case "task_updated":
+				// task_updated with patch.status == "completed" or "failed" signals
+				// that the task is done (used by local_bash and interrupted/failed
+				// local_agent tasks). Decrement runningTasks the same way
+				// task_notification does.
+				var patch struct {
+					Status string `json:"status"`
+				}
+				if len(ev.Patch) > 0 {
+					if err := json.Unmarshal(ev.Patch, &patch); err == nil {
+						if patch.Status == "completed" || patch.Status == "failed" {
+							sp.mu.Lock()
+							if sp.runningTasks > 0 {
+								sp.runningTasks--
+							}
+							remaining := sp.runningTasks
+							sp.mu.Unlock()
+							if remaining == 0 {
+								sp.stopPeriodicNotification()
+							}
+						}
+					}
 				}
 			}
 		}

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -301,6 +301,11 @@ func (sp *HolderStreamProcess) loadExistingLines(sessionID string, clearOffset i
 func (sp *HolderStreamProcess) readLoop() {
 	defer close(sp.done)
 
+	// completedTaskIDs tracks task IDs that have already been decremented from
+	// runningTasks, preventing double-decrement when both task_notification and
+	// task_updated fire for the same task.
+	completedTaskIDs := make(map[string]struct{})
+
 	reader := bufio.NewReader(sp.conn)
 	for {
 		line, err := reader.ReadString('\n')
@@ -418,15 +423,9 @@ func (sp *HolderStreamProcess) readLoop() {
 					sp.startPeriodicNotification()
 				}
 			case "task_notification":
-				sp.mu.Lock()
-				if sp.runningTasks > 0 {
-					sp.runningTasks--
-				}
-				remaining := sp.runningTasks
-				sp.mu.Unlock()
-				// Stop periodic notification when all background tasks complete
-				if remaining == 0 {
-					sp.stopPeriodicNotification()
+				if _, done := completedTaskIDs[ev.TaskID]; !done {
+					completedTaskIDs[ev.TaskID] = struct{}{}
+					sp.DecrementRunningTasks()
 				}
 			case "task_updated":
 				// task_updated with patch.status == "completed" or "failed" signals
@@ -439,14 +438,9 @@ func (sp *HolderStreamProcess) readLoop() {
 				if len(ev.Patch) > 0 {
 					if err := json.Unmarshal(ev.Patch, &patch); err == nil {
 						if patch.Status == "completed" || patch.Status == "failed" {
-							sp.mu.Lock()
-							if sp.runningTasks > 0 {
-								sp.runningTasks--
-							}
-							remaining := sp.runningTasks
-							sp.mu.Unlock()
-							if remaining == 0 {
-								sp.stopPeriodicNotification()
+							if _, done := completedTaskIDs[ev.TaskID]; !done {
+								completedTaskIDs[ev.TaskID] = struct{}{}
+								sp.DecrementRunningTasks()
 							}
 						}
 					}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -309,6 +309,7 @@ func (m *Manager) RecoverStreamProcesses() {
 				m.killStaleHolder(id)
 			} else {
 				m.wireSessionIDCallback(id, sp)
+				sp.StartReadLoop()
 				m.streamMu.Lock()
 				m.streamProcesses[id] = sp
 				m.streamMu.Unlock()
@@ -324,6 +325,7 @@ func (m *Manager) RecoverStreamProcesses() {
 			continue
 		}
 		m.wireSessionIDCallback(id, sp)
+		sp.StartReadLoop()
 		m.streamMu.Lock()
 		m.streamProcesses[id] = sp
 		m.streamMu.Unlock()
@@ -598,6 +600,7 @@ func (m *Manager) Create(name, projectPath, prompt string, worktree bool, opts .
 	}
 	if sp != nil {
 		m.wireSessionIDCallback(id, sp)
+		sp.StartReadLoop()
 		m.streamMu.Lock()
 		m.streamProcesses[id] = sp
 		m.streamMu.Unlock()
@@ -971,6 +974,7 @@ func (m *Manager) Fork(id string, preserveContext bool, initialPrompt string) (*
 	}
 
 	m.wireSessionIDCallback(newID, sp)
+	sp.StartReadLoop()
 	m.streamMu.Lock()
 	m.streamProcesses[newID] = sp
 	m.streamMu.Unlock()
@@ -1380,6 +1384,7 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			hsp.recordUserMessage(text)
 			sp = hsp
 			m.wireSessionIDCallback(id, sp)
+			sp.StartReadLoop()
 			m.streamMu.Lock()
 			m.streamProcesses[id] = sp
 			m.streamMu.Unlock()
@@ -1404,6 +1409,7 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 			hsp.recordUserMessage(text)
 			sp = hsp
 			m.wireSessionIDCallback(id, sp)
+			sp.StartReadLoop()
 			m.streamMu.Lock()
 			m.streamProcesses[id] = sp
 			m.streamMu.Unlock()
@@ -1428,6 +1434,7 @@ func (m *Manager) SendKeysWithImages(id string, text string, images []ImageData)
 		}
 		sp = hsp
 		m.wireSessionIDCallback(id, sp)
+		sp.StartReadLoop()
 		m.streamMu.Lock()
 		m.streamProcesses[id] = sp
 		m.streamMu.Unlock()
@@ -1656,6 +1663,7 @@ func (m *Manager) CreateController(projectPath string) (*Session, error) {
 		return nil, fmt.Errorf("start stream process for controller: %w", err)
 	}
 	m.wireSessionIDCallback(id, sp)
+	sp.StartReadLoop()
 	m.streamMu.Lock()
 	m.streamProcesses[id] = sp
 	m.streamMu.Unlock()
@@ -1966,6 +1974,7 @@ func (m *Manager) Reconnect(id string) error {
 		return fmt.Errorf("start stream process: %w", err)
 	}
 	m.wireSessionIDCallback(id, sp)
+	sp.StartReadLoop()
 	m.streamMu.Lock()
 	m.streamProcesses[id] = sp
 	m.streamMu.Unlock()
@@ -2042,6 +2051,7 @@ func (m *Manager) Restart(id string) error {
 		return fmt.Errorf("start stream process: %w", err)
 	}
 	m.wireSessionIDCallback(id, sp)
+	sp.StartReadLoop()
 	m.streamMu.Lock()
 	m.streamProcesses[id] = sp
 	m.streamMu.Unlock()


### PR DESCRIPTION
## Summary

- `deleteTask` をトゥームストーン方式 (`Dismiss`) に変更し、遅延 `task_progress` によるゾンビタスク復活を防止
- `task_updated` イベント (`patch.status: completed/failed`) を処理し、`local_bash` や中断/失敗した `local_agent` タスクの完了を検知 (バックエンド + フロントエンド)
- `StartHolderStreamProcess`/`ReconnectHolderStreamProcess` で `readLoop` 自動起動を除去し `StartReadLoop()` メソッドを追加。全 `wireSessionIDCallback` 呼び出し後に `StartReadLoop()` を呼ぶことでサーバー再起動時の race window を解消

## Changes

**`internal/session/background_task.go`**
- `rawStreamLine` に `Patch json.RawMessage` フィールドを追加
- `deleteTask` を物理 DELETE から `Dismiss` (論理削除) に変更
- `ApplyLine` の switch に `task_updated` ケースを追加

**`internal/session/holder_stream.go`**
- `streamEvent` に `TaskID` / `Patch` フィールドを追加
- `StartHolderStreamProcess` / `ReconnectHolderStreamProcess` から `go sp.readLoop()` を除去
- `StartReadLoop()` public メソッドを追加
- `readLoop` 内の task tracking switch に `task_updated` ケースを追加

**`internal/session/manager.go`**
- 全 10 箇所の `wireSessionIDCallback` 呼び出しの直後に `sp.StartReadLoop()` を追加

**`frontend/src/models/stream.ts`**
- `extractActiveTasks` に `task_updated` (`completed`/`failed`) でタスクを削除する処理を追加

## Test plan

- [x] `go test ./internal/...` がすべてパス

Closes #687