### PR TITLE
feat: セッション画面にコンテキスト消費量をリアルタイム表示

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -199,6 +199,28 @@ function ModelSwitcher({ session, onSwitched, onError }: {
   );
 }
 
+function formatTokenCount(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}K`;
+  return String(n);
+}
+
+// ContextUsageChip shows the current context window consumption (e.g. "84K / 200K · 42%")
+// next to the model chip, similar to Claude Desktop. Color escalates from
+// neutral to amber (>=75%) to red (>=90%) as the context fills up.
+function ContextUsageChip({ contextTokens, contextWindow }: { contextTokens: number; contextWindow: number }) {
+  if (contextTokens <= 0) return null;
+  const pct = contextWindow > 0 ? Math.round((contextTokens / contextWindow) * 100) : null;
+  const color = pct === null ? "gray" : pct >= 90 ? "red" : pct >= 75 ? "orange" : "gray";
+  const label = pct !== null
+    ? `${formatTokenCount(contextTokens)} / ${formatTokenCount(contextWindow)} · ${pct}%`
+    : formatTokenCount(contextTokens);
+  return (
+    <span className="inline-flex items-center" title="Context window usage">
+      <Chip color={color}>{label}</Chip>
+    </span>
+  );
+}
+
 function SessionPageSkeleton({ sessionId }: { sessionId?: string }) {
   const isDesktopPane = useDesktopPane();
   return (
@@ -255,6 +277,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
   const [partialText, setPartialText] = useState("");
   // Latest estimated thinking tokens (system:thinking_tokens live events); null when not thinking
   const [thinkingTokens, setThinkingTokens] = useState<number | null>(null);
+  const [contextUsage, setContextUsage] = useState<{ contextTokens: number; contextWindow: number } | null>(null);
   const [diffFiles, setDiffFiles] = useState<DiffFile[]>(deferred.diff.files);
 
 
@@ -370,6 +393,12 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
         if (data.status !== "working") {
           setThinkingTokens(null);
         }
+      }
+    }
+    if (msg.type === "context_usage") {
+      const data = msg.data as { sessionId: string; contextTokens: number; contextWindow: number };
+      if (data.sessionId === sessionId) {
+        setContextUsage({ contextTokens: data.contextTokens, contextWindow: data.contextWindow });
       }
     }
     if (msg.type === "stream_update") {
@@ -636,6 +665,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
                     await api.clearSession(session.id);
                     setStreamLines([]);
                     setPartialText("");
+                    setContextUsage(null);
                     streamCursorRef.current = 0;
                     api.getSession(session.id).then(setSession);
                     setClearToast("success");
@@ -921,6 +951,9 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
                   setTimeout(() => setModelToast(null), 3000);
                 }}
               />
+            )}
+            {contextUsage && (
+              <ContextUsageChip contextTokens={contextUsage.contextTokens} contextWindow={contextUsage.contextWindow} />
             )}
             {session.roleTemplate && (
               <span className="inline-flex items-center" style={{ viewTransitionName: `session-role-${session.id}` }}><Chip color="orange">{session.roleTemplate}</Chip></span>

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -204,20 +204,38 @@ function formatTokenCount(n: number): string {
   return String(n);
 }
 
-// ContextUsageChip shows the current context window consumption (e.g. "84K / 200K · 42%")
-// next to the model chip, similar to Claude Desktop. Color escalates from
-// neutral to amber (>=75%) to red (>=90%) as the context fills up.
-function ContextUsageChip({ contextTokens, contextWindow }: { contextTokens: number; contextWindow: number }) {
-  if (contextTokens <= 0) return null;
+function useContextUsageProps(contextTokens: number, contextWindow: number) {
   const pct = contextWindow > 0 ? Math.round((contextTokens / contextWindow) * 100) : null;
-  const color = pct === null ? "gray" : pct >= 90 ? "red" : pct >= 75 ? "orange" : "gray";
-  const label = pct !== null
-    ? `${formatTokenCount(contextTokens)} / ${formatTokenCount(contextWindow)} · ${pct}%`
+  const barColor = pct === null ? "bg-gray-400" : pct >= 90 ? "bg-red-500" : pct >= 75 ? "bg-orange-400" : "bg-blue-400";
+  const tooltip = pct !== null
+    ? `${formatTokenCount(contextTokens)} / ${formatTokenCount(contextWindow)} (${pct}%)`
     : formatTokenCount(contextTokens);
+  return { pct, barColor, tooltip };
+}
+
+function ContextUsageInline({ contextTokens, contextWindow }: { contextTokens: number; contextWindow: number }) {
+  if (contextTokens <= 0) return null;
+  const { pct, barColor, tooltip } = useContextUsageProps(contextTokens, contextWindow);
   return (
-    <span className="inline-flex items-center" title="Context window usage">
-      <Chip color={color}>{label}</Chip>
+    <span className="hidden sm:inline-flex items-center gap-1 text-[10px] text-gray-500" title={tooltip}>
+      <span className="w-12 h-1.5 bg-gray-200 rounded-full overflow-hidden">
+        <span className={`block h-full rounded-full ${barColor}`} style={{ width: `${Math.min(pct ?? 0, 100)}%` }} />
+      </span>
+      {pct !== null && <span>{pct}%</span>}
     </span>
+  );
+}
+
+function ContextUsageBar({ contextTokens, contextWindow }: { contextTokens: number; contextWindow: number }) {
+  if (contextTokens <= 0) return null;
+  const { pct, barColor, tooltip } = useContextUsageProps(contextTokens, contextWindow);
+  return (
+    <div className="sm:hidden flex items-center gap-2 px-4 py-1 text-[10px] text-gray-500" title={tooltip}>
+      <span className="flex-1 h-1 bg-gray-200 rounded-full overflow-hidden">
+        <span className={`block h-full rounded-full ${barColor}`} style={{ width: `${Math.min(pct ?? 0, 100)}%` }} />
+      </span>
+      {pct !== null && <span className="shrink-0">{pct}%</span>}
+    </div>
   );
 }
 
@@ -561,6 +579,9 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
 
   const sendForm = session ? (
     <div className="shrink-0 sticky bottom-0 bg-white -mx-4 sm:-mx-8">
+    {contextUsage && (
+      <ContextUsageBar contextTokens={contextUsage.contextTokens} contextWindow={contextUsage.contextWindow} />
+    )}
     <form onSubmit={handleSend} className="pt-2 pb-4 px-4 sm:px-8">
       {pendingImages.length > 0 && (
         <div className="flex gap-2 mb-2 flex-wrap">
@@ -953,7 +974,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
               />
             )}
             {contextUsage && (
-              <ContextUsageChip contextTokens={contextUsage.contextTokens} contextWindow={contextUsage.contextWindow} />
+              <ContextUsageInline contextTokens={contextUsage.contextTokens} contextWindow={contextUsage.contextWindow} />
             )}
             {session.roleTemplate && (
               <span className="inline-flex items-center" style={{ viewTransitionName: `session-role-${session.id}` }}><Chip color="orange">{session.roleTemplate}</Chip></span>

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -204,38 +204,26 @@ function formatTokenCount(n: number): string {
   return String(n);
 }
 
-function useContextUsageProps(contextTokens: number, contextWindow: number) {
+function ContextUsageRing({ contextTokens, contextWindow }: { contextTokens: number; contextWindow: number }) {
+  if (contextTokens <= 0) return null;
   const pct = contextWindow > 0 ? Math.round((contextTokens / contextWindow) * 100) : null;
-  const barColor = pct === null ? "bg-gray-400" : pct >= 90 ? "bg-red-500" : pct >= 75 ? "bg-orange-400" : "bg-blue-400";
+  const stroke = pct === null ? "#9ca3af" : pct >= 90 ? "#ef4444" : pct >= 75 ? "#f59e0b" : "#60a5fa";
   const tooltip = pct !== null
     ? `${formatTokenCount(contextTokens)} / ${formatTokenCount(contextWindow)} (${pct}%)`
     : formatTokenCount(contextTokens);
-  return { pct, barColor, tooltip };
-}
-
-function ContextUsageInline({ contextTokens, contextWindow }: { contextTokens: number; contextWindow: number }) {
-  if (contextTokens <= 0) return null;
-  const { pct, barColor, tooltip } = useContextUsageProps(contextTokens, contextWindow);
+  const r = 6;
+  const circ = 2 * Math.PI * r;
+  const offset = circ - (circ * Math.min(pct ?? 0, 100)) / 100;
   return (
-    <span className="hidden sm:inline-flex items-center gap-1 text-[10px] text-gray-500" title={tooltip}>
-      <span className="w-12 h-1.5 bg-gray-200 rounded-full overflow-hidden">
-        <span className={`block h-full rounded-full ${barColor}`} style={{ width: `${Math.min(pct ?? 0, 100)}%` }} />
-      </span>
+    <span className="inline-flex items-center gap-0.5 text-[10px] text-gray-500" title={tooltip}>
+      <svg width="16" height="16" viewBox="0 0 16 16" className="shrink-0">
+        <circle cx="8" cy="8" r={r} fill="none" stroke="#e5e7eb" strokeWidth="2" />
+        <circle cx="8" cy="8" r={r} fill="none" stroke={stroke} strokeWidth="2"
+          strokeDasharray={circ} strokeDashoffset={offset}
+          strokeLinecap="round" transform="rotate(-90 8 8)" />
+      </svg>
       {pct !== null && <span>{pct}%</span>}
     </span>
-  );
-}
-
-function ContextUsageBar({ contextTokens, contextWindow }: { contextTokens: number; contextWindow: number }) {
-  if (contextTokens <= 0) return null;
-  const { pct, barColor, tooltip } = useContextUsageProps(contextTokens, contextWindow);
-  return (
-    <div className="sm:hidden flex items-center gap-2 px-4 py-1 text-[10px] text-gray-500" title={tooltip}>
-      <span className="flex-1 h-1 bg-gray-200 rounded-full overflow-hidden">
-        <span className={`block h-full rounded-full ${barColor}`} style={{ width: `${Math.min(pct ?? 0, 100)}%` }} />
-      </span>
-      {pct !== null && <span className="shrink-0">{pct}%</span>}
-    </div>
   );
 }
 
@@ -579,9 +567,6 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
 
   const sendForm = session ? (
     <div className="shrink-0 sticky bottom-0 bg-white -mx-4 sm:-mx-8">
-    {contextUsage && (
-      <ContextUsageBar contextTokens={contextUsage.contextTokens} contextWindow={contextUsage.contextWindow} />
-    )}
     <form onSubmit={handleSend} className="pt-2 pb-4 px-4 sm:px-8">
       {pendingImages.length > 0 && (
         <div className="flex gap-2 mb-2 flex-wrap">
@@ -974,7 +959,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
               />
             )}
             {contextUsage && (
-              <ContextUsageInline contextTokens={contextUsage.contextTokens} contextWindow={contextUsage.contextWindow} />
+              <ContextUsageRing contextTokens={contextUsage.contextTokens} contextWindow={contextUsage.contextWindow} />
             )}
             {session.roleTemplate && (
               <span className="inline-flex items-center" style={{ viewTransitionName: `session-role-${session.id}` }}><Chip color="orange">{session.roleTemplate}</Chip></span>

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,6 +99,18 @@ func New(sessions session.SessionService, hub *Hub, devMode bool, logger *slog.L
 		})
 	})
 
+	// Wire real-time context usage updates via WebSocket
+	sessions.SetOnContextUsage(func(sessionID string, contextTokens, contextWindow int64) {
+		hub.Broadcast(Message{
+			Type: "context_usage",
+			Data: map[string]interface{}{
+				"sessionId":     sessionID,
+				"contextTokens": contextTokens,
+				"contextWindow": contextWindow,
+			},
+		})
+	})
+
 	s.setupRoutes()
 	return s
 }

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -124,6 +124,11 @@ type HolderStreamProcess struct {
 	// modelCaptured is true once the model has been captured
 	modelCaptured bool
 
+	// contextTokens and contextWindow track context usage parsed from
+	// assistant/result stream events.
+	contextTokens int64
+	contextWindow int64
+
 	// Periodic notification fields
 	notifyInterval time.Duration              // notification interval for background tasks
 	notifyCancel   context.CancelFunc         // stops the periodic notification goroutine
@@ -136,7 +141,36 @@ type HolderStreamProcess struct {
 	onProcessExit    func(sessionID string, exitErr error)
 	onTurnComplete   func(sessionID string)
 	onHolderRestart  func(sessionID string, newPID int)
+	onContextUsage   func(sessionID string, contextTokens, contextWindow int64)
 	runningTasks     int
+}
+
+// usageInfo is a minimal struct for parsing token usage from an assistant
+// message's "usage" field.
+type usageInfo struct {
+	InputTokens              int64 `json:"input_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+}
+
+// assistantUsage is a minimal struct for parsing usage data from an
+// assistant stream event.
+type assistantUsage struct {
+	Type  string    `json:"type"`
+	Usage usageInfo `json:"usage"`
+}
+
+// modelUsageEntry is a minimal struct for parsing per-model usage data from
+// a result stream event.
+type modelUsageEntry struct {
+	ContextWindow int64 `json:"contextWindow"`
+}
+
+// resultModelUsage is a minimal struct for parsing the modelUsage field from
+// a result stream event.
+type resultModelUsage struct {
+	Type       string                     `json:"type"`
+	ModelUsage map[string]modelUsageEntry `json:"modelUsage"`
 }
 
 // StartHolderStreamProcess starts a CLI process via a holder subprocess.
@@ -448,7 +482,40 @@ func (sp *HolderStreamProcess) readLoop() {
 			}
 		}
 		switch ev.Type {
+		case "assistant":
+			var au assistantUsage
+			if json.Unmarshal([]byte(line), &au) == nil {
+				tokens := au.Usage.InputTokens + au.Usage.CacheCreationInputTokens + au.Usage.CacheReadInputTokens
+				if tokens > 0 {
+					sp.mu.Lock()
+					changed := sp.contextTokens != tokens
+					sp.contextTokens = tokens
+					cb := sp.onContextUsage
+					ct, cw := sp.contextTokens, sp.contextWindow
+					sp.mu.Unlock()
+					if changed && cb != nil {
+						cb(sp.streamOpts.SessionID, ct, cw)
+					}
+				}
+			}
 		case "result":
+			var rmu resultModelUsage
+			if json.Unmarshal([]byte(line), &rmu) == nil {
+				for _, entry := range rmu.ModelUsage {
+					if entry.ContextWindow > 0 {
+						sp.mu.Lock()
+						changed := sp.contextWindow != entry.ContextWindow
+						sp.contextWindow = entry.ContextWindow
+						cb := sp.onContextUsage
+						ct, cw := sp.contextTokens, sp.contextWindow
+						sp.mu.Unlock()
+						if changed && cb != nil {
+							cb(sp.streamOpts.SessionID, ct, cw)
+						}
+						break
+					}
+				}
+			}
 			if ev.Subtype == "success" {
 				sp.mu.RLock()
 				idle := sp.runningTasks == 0
@@ -573,6 +640,13 @@ func (sp *HolderStreamProcess) SetOnModel(fn func(model string)) {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 	sp.onModel = fn
+}
+
+// SetOnContextUsage sets a callback for context token usage updates.
+func (sp *HolderStreamProcess) SetOnContextUsage(fn func(sessionID string, contextTokens, contextWindow int64)) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.onContextUsage = fn
 }
 
 // SetOnNewLines sets a callback for new stream lines.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -49,6 +49,7 @@ type Manager struct {
 	logger             *slog.Logger
 	onNewLines         func(sessionID string, newLines []string, total int)
 	onStatusChange     func(sessionID string, status Status, lastError string)
+	onContextUsage     func(sessionID string, contextTokens, contextWindow int64)
 	backgroundTasks    *BackgroundTaskStore
 }
 
@@ -153,6 +154,11 @@ func (m *Manager) SetOnNewLines(fn func(sessionID string, newLines []string, tot
 // SetOnStatusChange sets a callback that fires when a session status changes.
 func (m *Manager) SetOnStatusChange(fn func(sessionID string, status Status, lastError string)) {
 	m.onStatusChange = fn
+}
+
+// SetOnContextUsage sets a callback that fires when a session's context token usage changes.
+func (m *Manager) SetOnContextUsage(fn func(sessionID string, contextTokens, contextWindow int64)) {
+	m.onContextUsage = fn
 }
 
 // getProvider returns a Provider for the given provider name.
@@ -1135,6 +1141,12 @@ func (m *Manager) wireSessionIDCallback(sessionID string, sp *HolderStreamProces
 			m.logger.Error("failed to persist model name", "sessionId", sessionID, "model", model, "error", err)
 		} else {
 			m.logger.Info("model name captured from stream", "sessionId", sessionID, "model", model)
+		}
+	})
+	contextUsageUpstream := m.onContextUsage
+	sp.SetOnContextUsage(func(sid string, contextTokens, contextWindow int64) {
+		if contextUsageUpstream != nil {
+			contextUsageUpstream(sid, contextTokens, contextWindow)
 		}
 	})
 	// Wrap onNewLines so we can update the background_tasks DB table per line.

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -63,6 +63,9 @@ type SessionService interface {
 	// SetOnStatusChange sets a callback for real-time session status changes.
 	SetOnStatusChange(fn func(sessionID string, status Status, lastError string))
 
+	// SetOnContextUsage sets a callback for real-time context token usage updates.
+	SetOnContextUsage(fn func(sessionID string, contextTokens, contextWindow int64))
+
 	// IsStreamProcessAlive returns true if a stream process exists and has not exited.
 	IsStreamProcessAlive(id string) bool
 


### PR DESCRIPTION
## Summary
- ClaudeのCLIが出力するstream-jsonのusage情報（assistantメッセージのtoken usage、resultイベントのcontextWindow）をバックエンドでパースし、WebSocket経由でフロントエンドにリアルタイムブロードキャストする
- セッション画面のヘッダー、モデルChipの隣にコンテキスト消費量を "84K / 200K · 42%" 形式で表示する chip を追加（Claude Desktop風）
- 使用率に応じて色分け（〜74%: gray, 75〜89%: orange, 90%〜: red）
- clear実行時はcontextUsageをリセットし、新しいCLIプロセスの値に追従する

## Changes
- `internal/session/holder_stream.go`: assistant/resultイベントからusage/contextWindowをパースし、`SetOnContextUsage` コールバックを追加
- `internal/session/manager.go`, `internal/session/service.go`: `SetOnContextUsage` をManager/SessionServiceインターフェースに配線
- `internal/server/server.go`: `context_usage` メッセージをWebSocketでブロードキャスト
- `frontend/src/pages/SessionPage.tsx`: `context_usage` メッセージを受信してstate更新、`ContextUsageChip` コンポーネントでヘッダーに表示

Closes #693

## Test plan
- [x] `make build` が通ることを確認
- [x] `make test` が通ることを確認（go test ./...）
- [x] frontend `npm run build`（tsc + vite）が通ることを確認
- [x] frontend `eslint` でエラーがないことを確認