### PR TITLE
fix: clearSession の NOT NULL 制約違反を修正

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1297,7 +1297,7 @@ func (m *Manager) Clear(id string) error {
 	m.stopStreamProcess(id)
 
 	// Store clear_offset and reset all session state
-	_, err = m.db.Exec("UPDATE sessions SET last_error = NULL, current_task = NULL, goal = NULL, goals = '[]', clear_offset = ?, cli_session_id = NULL, conversation_started = 0, holder_pid = 0, updated_at = ? WHERE id = ?", clearOffset, time.Now(), id)
+	_, err = m.db.Exec("UPDATE sessions SET last_error = NULL, current_task = NULL, goal = NULL, goals = '[]', clear_offset = ?, cli_session_id = '', conversation_started = 0, holder_pid = 0, updated_at = ? WHERE id = ?", clearOffset, time.Now(), id)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- `Manager.Clear()` で `cli_session_id = NULL` を設定していたが、`sessions` テーブルのスキーマは `cli_session_id TEXT NOT NULL DEFAULT ''` のため、clear が常に NOT NULL 制約違反で HTTP 500 を返していた
- `NULL` → `''`（空文字列）に修正

Closes #694

## 原因
PR #688（commit 5798ae2）で CLI プロセス再起動のために `cli_session_id = NULL` リセットを追加した際の混入。同ファイル内の `UpdateCliSessionID()` は正しく文字列値を使用しており、それに合わせた修正。

## Test plan
- [x] `make test` 通過
- [x] `curl -s -X POST http://localhost:4321/api/sessions/{id}/clear` で再現確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)