### PR TITLE
fix: エラーメッセージの長いパスが画面をはみ出さないよう折り返す

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -306,7 +306,7 @@ export function DesktopLayout() {
       {/* Error banner */}
       {error && (
         <div className="bg-red-50 border-b border-red-200 text-red-700 px-4 py-2 text-sm shrink-0 flex items-center justify-between">
-          <span>{error}</span>
+          <span className="wrap-anywhere">{error}</span>
           <button onClick={() => setError(null)} className="ml-2 text-red-500 hover:text-red-800">x</button>
         </div>
       )}
@@ -425,7 +425,7 @@ export function Dashboard() {
       {/* Error banner */}
       {error && (
         <div className="bg-red-50 border-b border-red-200 text-red-700 px-4 py-2 text-sm shrink-0 flex items-center justify-between">
-          <span>{error}</span>
+          <span className="wrap-anywhere">{error}</span>
           <button onClick={() => setError(null)} className="ml-2 text-red-500 hover:text-red-800">x</button>
         </div>
       )}

--- a/frontend/src/components/ui/AlertBanner.tsx
+++ b/frontend/src/components/ui/AlertBanner.tsx
@@ -15,7 +15,7 @@ export function AlertBanner({
   variant?: AlertBannerVariant;
 }) {
   return (
-    <div className={`rounded-lg px-4 py-3 text-sm border ${variantStyles[variant]}`}>
+    <div className={`rounded-lg px-4 py-3 text-sm border wrap-anywhere ${variantStyles[variant]}`}>
       {children}
     </div>
   );

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -13,7 +13,7 @@ export function ToastBar({ message, variant = "success", onClose }: { message: s
   const Icon = variant === "success" ? CheckCircle2 : AlertTriangle;
 
   return (
-    <div className={`${styles} text-white px-4 py-2 rounded shadow-lg text-sm flex items-center gap-2 w-fit max-w-full`}>
+    <div className={`${styles} text-white px-4 py-2 rounded shadow-lg text-sm flex items-center gap-2 w-fit max-w-full wrap-anywhere`}>
       <Icon className="w-4 h-4 shrink-0" />
       {message}
       {onClose && (


### PR DESCRIPTION
## Summary
unix socket のパス（例: `read unix /var/folders/.../T/agmux/socks/C3coo.sock: ...`）のような区切り文字のない長い文字列を含むエラーメッセージが折り返されず、特にモバイル幅で画面の横幅をはみ出していた問題を修正します。

エラーメッセージを表示する以下の要素に Tailwind v4 の `wrap-anywhere`（`overflow-wrap: anywhere`）を追加しました。`anywhere` は flex アイテムの min-content 幅計算にも折り返し位置を反映するため、flex レイアウト内でも確実に折り返されます。

- `frontend/src/components/ui/AlertBanner.tsx`: 共通エラーバナー（セッション画面の `session.lastError` 表示を含む。Issue のスクショの箇所）
- `frontend/src/App.tsx`: 画面上部のエラーバナー（デスクトップ/モバイル両レイアウトの2箇所）
- `frontend/src/components/ui/Toast.tsx`: `ToastBar`（error variant のトースト）

なお `StreamDisplayItemView` のエラー表示は既に `min-w-0` + `break-words` 対応済みのため変更していません。

Closes #697

## Test plan
- [x] `make build` 成功（frontend build + go build）
- [x] ビルド後の CSS に `.wrap-anywhere{overflow-wrap:anywhere}` が出力されることを確認
- [x] `npm run lint` で新規エラーなし（既存22件はベースラインと同一）

🤖 Generated with [Claude Code](https://claude.com/claude-code)