### PR TITLE
fix: エラーメッセージの長いパスが画面をはみ出さないよう折り返す

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -306,7 +306,7 @@ export function DesktopLayout() {
       {/* Error banner */}
       {error && (
         <div className="bg-red-50 border-b border-red-200 text-red-700 px-4 py-2 text-sm shrink-0 flex items-center justify-between">
-          <span>{error}</span>
+          <span className="wrap-anywhere">{error}</span>
           <button onClick={() => setError(null)} className="ml-2 text-red-500 hover:text-red-800">x</button>
         </div>
       )}
@@ -425,7 +425,7 @@ export function Dashboard() {
       {/* Error banner */}
       {error && (
         <div className="bg-red-50 border-b border-red-200 text-red-700 px-4 py-2 text-sm shrink-0 flex items-center justify-between">
-          <span>{error}</span>
+          <span className="wrap-anywhere">{error}</span>
           <button onClick={() => setError(null)} className="ml-2 text-red-500 hover:text-red-800">x</button>
         </div>
       )}

--- a/frontend/src/components/ui/AlertBanner.tsx
+++ b/frontend/src/components/ui/AlertBanner.tsx
@@ -15,7 +15,7 @@ export function AlertBanner({
   variant?: AlertBannerVariant;
 }) {
   return (
-    <div className={`rounded-lg px-4 py-3 text-sm border ${variantStyles[variant]}`}>
+    <div className={`rounded-lg px-4 py-3 text-sm border wrap-anywhere ${variantStyles[variant]}`}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- セッション画面のエラーバナー（`AlertBanner`）に unix socket パスのような区切り文字のない長い文字列が含まれると、テキストが折り返されず画面の横幅をはみ出す問題を修正
- `AlertBanner` コンポーネントと `App.tsx` 上部のエラーバナーに Tailwind の `wrap-anywhere`（`overflow-wrap: anywhere`）を付与し、通常の単語は保ちつつ長い連続文字列のみ折り返すようにした
- `Toast.tsx` は現状すべて短い固定文言のみを表示しており、今回のバグの実データフローに含まれないためスコープ外とした

Closes #697

## Test plan
- [x] `make build` が成功することを確認
- [x] Vite dev サーバー + `agent-browser` でモバイル幅(375px)にて、`AlertBanner` に長い unix socket パス文字列を表示し、修正前ははみ出し・修正後は折り返されることを目視確認

修正前（375px幅ではみ出る）:
![before](https://pub-a3d6b4ebed8c4be09b2fd4033aeed486.r2.dev/myuon/agmux/pr-699/b531705dcba883b0f776f5c46715bd59c2346500/before-wrap.jpg)

修正後（wrap-anywhere で折り返される）:
![after](https://pub-a3d6b4ebed8c4be09b2fd4033aeed486.r2.dev/myuon/agmux/pr-699/b531705dcba883b0f776f5c46715bd59c2346500/after-wrap.jpg)