### PR TITLE
fix: 期限切れKeychain認証情報でセッションが認証失敗するのを自動修復 (#701)

### DIFF
--- a/cmd/agmux/main.go
+++ b/cmd/agmux/main.go
@@ -235,6 +235,12 @@ func serveCmd() *cobra.Command {
 			// a true orphan (#681) and can be terminated safely.
 			mgr.ReapOrphanHolders()
 
+			// Clear out Claude Code credential storage that would otherwise
+			// wedge sessions with "OAuth session expired and could not be
+			// refreshed". Sessions also repair before spawning; this watch
+			// covers the gap for sessions that are already running. See #701.
+			go session.WatchClaudeCredentials(context.Background(), session.DefaultCredentialWatchInterval)
+
 			// Create controller session (singleton) AFTER recovery so that
 			// a surviving controller holder can be reconnected first.
 			controllerDir, err := db.ControllerDir()

--- a/internal/session/claude_credentials.go
+++ b/internal/session/claude_credentials.go
@@ -1,0 +1,254 @@
+package session
+
+// Claude Code keeps its OAuth credentials in two places on macOS: the login
+// Keychain and ~/.claude/.credentials.json. The Keychain wins whenever it can
+// be read, and the file is consulted only when that read fails.
+//
+// A Keychain entry holding an already expired token therefore wedges every
+// CLI process that can read it: the CLI decides the session is expired,
+// retries the refresh with the equally stale refresh token, and gives up with
+// "Failed to authenticate: OAuth session expired and could not be refreshed"
+// without ever reaching the API.
+//
+// agmux runs as a launchd agent, and processes in that lineage can read the
+// Keychain secret — while a CLI started from an ordinary shell cannot, so it
+// falls back to the still-valid file. That asymmetry is why the same command
+// succeeds by hand and fails under agmux. See #701.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+// claudeKeychainService is the generic-password service name Claude Code
+// stores its OAuth credentials under.
+const claudeKeychainService = "Claude Code-credentials"
+
+// claudeSecurityTimeout bounds each `security` invocation so a locked or
+// otherwise unresponsive Keychain cannot stall a session spawn.
+const claudeSecurityTimeout = 5 * time.Second
+
+// claudeCredentials is the subset of Claude Code's credential payload agmux
+// needs. ExpiresAt is a Unix timestamp in milliseconds, and is a pointer so an
+// absent field stays distinguishable from the expiresAt=0 corruption this
+// package exists to detect.
+type claudeCredentials struct {
+	ClaudeAiOauth struct {
+		ExpiresAt *int64 `json:"expiresAt"`
+	} `json:"claudeAiOauth"`
+}
+
+// errNoClaudeKeychainEntry reports that no Claude Code entry exists in the
+// Keychain, which is the healthy state after a repair.
+var errNoClaudeKeychainEntry = errors.New("no Claude Code keychain entry")
+
+// Indirection points so tests can drive the repair logic without touching the
+// real Keychain.
+var (
+	claudeKeychainRead   = readClaudeKeychainSecret
+	claudeKeychainDelete = deleteClaudeKeychainSecret
+	claudeCredsFilePath  = defaultClaudeCredsFilePath
+)
+
+// defaultClaudeCredsFilePath returns the path of Claude Code's on-disk
+// credential fallback.
+func defaultClaudeCredsFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", ".credentials.json"), nil
+}
+
+// claudeKeychainAccount returns the account name Claude Code files its
+// Keychain entry under, which is the current username.
+func claudeKeychainAccount() string {
+	if u, err := user.Current(); err == nil {
+		return u.Username
+	}
+	return os.Getenv("USER")
+}
+
+// runSecurity invokes the macOS `security` tool, retrying without the account
+// filter when the account-qualified lookup finds nothing. Older entries were
+// written with a different account, and matching on the service alone still
+// identifies the item unambiguously.
+func runSecurity(args ...string) ([]byte, error) {
+	account := claudeKeychainAccount()
+
+	withAccount := append([]string{args[0], "-a", account}, args[1:]...)
+	out, err := runSecurityOnce(withAccount)
+	if err == nil {
+		return out, nil
+	}
+
+	return runSecurityOnce(args)
+}
+
+func runSecurityOnce(args []string) ([]byte, error) {
+	ctxCmd := exec.Command("security", args...)
+	done := make(chan struct{})
+	var out []byte
+	var err error
+	go func() {
+		out, err = ctxCmd.Output()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return out, err
+	case <-time.After(claudeSecurityTimeout):
+		_ = ctxCmd.Process.Kill()
+		<-done
+		return nil, fmt.Errorf("security timed out after %s", claudeSecurityTimeout)
+	}
+}
+
+// readClaudeKeychainSecret returns the raw credential JSON stored in the
+// Keychain, or errNoClaudeKeychainEntry when there is nothing to read.
+func readClaudeKeychainSecret() ([]byte, error) {
+	out, err := runSecurity("find-generic-password", "-w", "-s", claudeKeychainService)
+	if err != nil {
+		return nil, errNoClaudeKeychainEntry
+	}
+	return out, nil
+}
+
+// deleteClaudeKeychainSecret removes the Claude Code entry from the Keychain.
+func deleteClaudeKeychainSecret() error {
+	if _, err := runSecurity("delete-generic-password", "-s", claudeKeychainService); err != nil {
+		return fmt.Errorf("delete keychain entry: %w", err)
+	}
+	return nil
+}
+
+// parseClaudeExpiry extracts the OAuth expiry from a credential payload.
+//
+// It reports ok=false when the payload carries no expiry field at all. An
+// explicit expiresAt of 0 is instead reported as a valid — and long past —
+// timestamp, because that is precisely the corruption being detected. Keeping
+// the two apart matters: an unrecognized payload must never be mistaken for
+// an expired one, or agmux would delete a Keychain entry it cannot judge.
+func parseClaudeExpiry(payload []byte) (time.Time, bool) {
+	var creds claudeCredentials
+	if err := json.Unmarshal(payload, &creds); err != nil {
+		return time.Time{}, false
+	}
+	if creds.ClaudeAiOauth.ExpiresAt == nil {
+		return time.Time{}, false
+	}
+	return time.UnixMilli(*creds.ClaudeAiOauth.ExpiresAt), true
+}
+
+// ClaudeCredentialState describes what a repair attempt found.
+type ClaudeCredentialState int
+
+const (
+	// ClaudeCredsHealthy means no stale Keychain entry is shadowing a valid
+	// credential file.
+	ClaudeCredsHealthy ClaudeCredentialState = iota
+	// ClaudeCredsRepaired means an expired Keychain entry was removed so the
+	// CLI falls back to the valid credential file.
+	ClaudeCredsRepaired
+	// ClaudeCredsUnrecoverable means the Keychain entry is expired and the
+	// credential file cannot stand in for it, so only a re-login helps.
+	ClaudeCredsUnrecoverable
+)
+
+// RepairClaudeCredentials removes a Keychain entry holding expired Claude Code
+// OAuth credentials, but only when ~/.claude/.credentials.json still holds a
+// token valid at now. That guard is what makes the deletion safe: agmux never
+// discards the last working credential, so the worst case is that the CLI
+// keeps using the file it would have used anyway.
+//
+// It is a no-op off macOS, where no Keychain exists.
+func RepairClaudeCredentials(now time.Time) (ClaudeCredentialState, error) {
+	if runtime.GOOS != "darwin" {
+		return ClaudeCredsHealthy, nil
+	}
+
+	payload, err := claudeKeychainRead()
+	if err != nil {
+		// Nothing in the Keychain is the healthy post-repair state, and an
+		// unreadable Keychain means the CLI will fall back to the file on its
+		// own. Neither warrants an error.
+		return ClaudeCredsHealthy, nil
+	}
+
+	keychainExpiry, ok := parseClaudeExpiry(payload)
+	if !ok || keychainExpiry.After(now) {
+		return ClaudeCredsHealthy, nil
+	}
+
+	// The Keychain entry is expired. Only remove it if the file can take over.
+	path, err := claudeCredsFilePath()
+	if err != nil {
+		return ClaudeCredsUnrecoverable, fmt.Errorf("locate credentials file: %w", err)
+	}
+	fileBytes, err := os.ReadFile(path)
+	if err != nil {
+		return ClaudeCredsUnrecoverable, nil
+	}
+	fileExpiry, ok := parseClaudeExpiry(fileBytes)
+	if !ok || !fileExpiry.After(now) {
+		return ClaudeCredsUnrecoverable, nil
+	}
+
+	if err := claudeKeychainDelete(); err != nil {
+		return ClaudeCredsUnrecoverable, err
+	}
+	return ClaudeCredsRepaired, nil
+}
+
+// DefaultCredentialWatchInterval is how often the daemon re-checks credential
+// health. It is well under the CLI's own credential cache lifetime, so a
+// Keychain entry that goes bad mid-session is cleared before a long-running
+// process re-reads it.
+const DefaultCredentialWatchInterval = 5 * time.Minute
+
+// WatchClaudeCredentials repairs broken Claude Code credential storage on a
+// timer until ctx is cancelled. The pre-spawn repair alone would leave a
+// corrupted Keychain entry in place between spawns, where a session that is
+// already running would still pick it up once its cached credentials lapse.
+//
+// Only state changes are logged, so a healthy daemon stays quiet.
+func WatchClaudeCredentials(ctx context.Context, interval time.Duration) {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	if interval <= 0 {
+		interval = DefaultCredentialWatchInterval
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	last := ClaudeCredsHealthy
+	for {
+		state, err := RepairClaudeCredentials(time.Now())
+		switch {
+		case err != nil:
+			slog.Warn("credential watch: repair failed", "component", "credential_watch", "error", err)
+		case state == ClaudeCredsRepaired:
+			slog.Info("credential watch: removed expired keychain credentials; CLI will use ~/.claude/.credentials.json", "component", "credential_watch")
+		case state == ClaudeCredsUnrecoverable && last != ClaudeCredsUnrecoverable:
+			slog.Warn("credential watch: keychain credentials are expired and ~/.claude/.credentials.json cannot replace them; run `claude` and re-login", "component", "credential_watch")
+		}
+		last = state
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/session/claude_credentials_test.go
+++ b/internal/session/claude_credentials_test.go
@@ -1,0 +1,247 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// credsJSON builds a Claude Code credential payload expiring at the given time.
+func credsJSON(t *testing.T, expiry time.Time) []byte {
+	t.Helper()
+	payload := map[string]any{
+		"claudeAiOauth": map[string]any{
+			"expiresAt":        expiry.UnixMilli(),
+			"refreshToken":     "refresh",
+			"subscriptionType": "max",
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal creds: %v", err)
+	}
+	return b
+}
+
+// stubClaudeCreds points the repair logic at in-memory Keychain contents and a
+// temp credentials file, restoring the real hooks via t.Cleanup. A nil
+// keychain payload means "no entry". It returns a pointer that reports whether
+// the delete hook ran.
+func stubClaudeCreds(t *testing.T, keychain []byte, file []byte) *bool {
+	t.Helper()
+
+	origRead, origDelete, origPath := claudeKeychainRead, claudeKeychainDelete, claudeCredsFilePath
+	t.Cleanup(func() {
+		claudeKeychainRead, claudeKeychainDelete, claudeCredsFilePath = origRead, origDelete, origPath
+	})
+
+	deleted := false
+	claudeKeychainRead = func() ([]byte, error) {
+		if keychain == nil {
+			return nil, errNoClaudeKeychainEntry
+		}
+		return keychain, nil
+	}
+	claudeKeychainDelete = func() error {
+		deleted = true
+		return nil
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".credentials.json")
+	if file != nil {
+		if err := os.WriteFile(path, file, 0o600); err != nil {
+			t.Fatalf("write creds file: %v", err)
+		}
+	}
+	claudeCredsFilePath = func() (string, error) { return path, nil }
+
+	return &deleted
+}
+
+// skipUnlessDarwin guards tests whose subject is a no-op on other platforms.
+func skipUnlessDarwin(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "darwin" {
+		t.Skip("keychain repair only runs on darwin")
+	}
+}
+
+func TestRepairClaudeCredentialsRemovesExpiredKeychainEntry(t *testing.T) {
+	skipUnlessDarwin(t)
+	now := time.Now()
+
+	// The corruption seen in #701: the Keychain carries expiresAt=0 while the
+	// file still holds a usable token.
+	deleted := stubClaudeCreds(t, credsJSON(t, time.UnixMilli(0)), credsJSON(t, now.Add(8*time.Hour)))
+
+	state, err := RepairClaudeCredentials(now)
+	if err != nil {
+		t.Fatalf("RepairClaudeCredentials: %v", err)
+	}
+	if state != ClaudeCredsRepaired {
+		t.Errorf("state = %v, want ClaudeCredsRepaired", state)
+	}
+	if !*deleted {
+		t.Error("expired keychain entry was not deleted")
+	}
+}
+
+func TestRepairClaudeCredentialsKeepsValidKeychainEntry(t *testing.T) {
+	skipUnlessDarwin(t)
+	now := time.Now()
+
+	deleted := stubClaudeCreds(t, credsJSON(t, now.Add(time.Hour)), credsJSON(t, now.Add(8*time.Hour)))
+
+	state, err := RepairClaudeCredentials(now)
+	if err != nil {
+		t.Fatalf("RepairClaudeCredentials: %v", err)
+	}
+	if state != ClaudeCredsHealthy {
+		t.Errorf("state = %v, want ClaudeCredsHealthy", state)
+	}
+	if *deleted {
+		t.Error("deleted a keychain entry that was still valid")
+	}
+}
+
+func TestRepairClaudeCredentialsKeepsExpiredEntryWhenFileCannotReplaceIt(t *testing.T) {
+	skipUnlessDarwin(t)
+	now := time.Now()
+
+	cases := []struct {
+		name string
+		file []byte
+	}{
+		{name: "file missing", file: nil},
+		{name: "file also expired", file: credsJSON(t, now.Add(-time.Hour))},
+		{name: "file unparseable", file: []byte("not json")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deleted := stubClaudeCreds(t, credsJSON(t, time.UnixMilli(0)), tc.file)
+
+			state, err := RepairClaudeCredentials(now)
+			if err != nil {
+				t.Fatalf("RepairClaudeCredentials: %v", err)
+			}
+			if state != ClaudeCredsUnrecoverable {
+				t.Errorf("state = %v, want ClaudeCredsUnrecoverable", state)
+			}
+			// Deleting here would destroy the only credentials left.
+			if *deleted {
+				t.Error("deleted the keychain entry with no valid fallback")
+			}
+		})
+	}
+}
+
+func TestRepairClaudeCredentialsNoKeychainEntry(t *testing.T) {
+	skipUnlessDarwin(t)
+	now := time.Now()
+
+	deleted := stubClaudeCreds(t, nil, credsJSON(t, now.Add(8*time.Hour)))
+
+	state, err := RepairClaudeCredentials(now)
+	if err != nil {
+		t.Fatalf("RepairClaudeCredentials: %v", err)
+	}
+	if state != ClaudeCredsHealthy {
+		t.Errorf("state = %v, want ClaudeCredsHealthy", state)
+	}
+	if *deleted {
+		t.Error("attempted to delete a nonexistent entry")
+	}
+}
+
+func TestRepairClaudeCredentialsPropagatesDeleteFailure(t *testing.T) {
+	skipUnlessDarwin(t)
+	now := time.Now()
+
+	stubClaudeCreds(t, credsJSON(t, time.UnixMilli(0)), credsJSON(t, now.Add(8*time.Hour)))
+	claudeKeychainDelete = func() error { return errors.New("boom") }
+
+	state, err := RepairClaudeCredentials(now)
+	if err == nil {
+		t.Fatal("expected an error when the delete fails")
+	}
+	if state != ClaudeCredsUnrecoverable {
+		t.Errorf("state = %v, want ClaudeCredsUnrecoverable", state)
+	}
+}
+
+func TestParseClaudeExpiry(t *testing.T) {
+	t.Run("zero expiry is a valid, long-past timestamp", func(t *testing.T) {
+		got, ok := parseClaudeExpiry([]byte(`{"claudeAiOauth":{"expiresAt":0}}`))
+		if !ok {
+			t.Fatal("ok = false, want true")
+		}
+		if !got.Equal(time.UnixMilli(0)) {
+			t.Errorf("expiry = %v, want epoch", got)
+		}
+	})
+
+	t.Run("missing oauth block is not parseable", func(t *testing.T) {
+		if _, ok := parseClaudeExpiry([]byte(`{}`)); ok {
+			t.Error("ok = true, want false")
+		}
+	})
+
+	t.Run("invalid json is not parseable", func(t *testing.T) {
+		if _, ok := parseClaudeExpiry([]byte(`nope`)); ok {
+			t.Error("ok = true, want false")
+		}
+	})
+}
+
+func TestWatchClaudeCredentialsRepairsThenStops(t *testing.T) {
+	skipUnlessDarwin(t)
+	now := time.Now()
+
+	deleted := stubClaudeCreds(t, credsJSON(t, time.UnixMilli(0)), credsJSON(t, now.Add(8*time.Hour)))
+
+	// A cancelled context still gets one pass, so the daemon repairs
+	// immediately at startup rather than waiting out the first interval.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		WatchClaudeCredentials(ctx, time.Hour)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("WatchClaudeCredentials did not return after ctx cancellation")
+	}
+	if !*deleted {
+		t.Error("watch did not repair the expired keychain entry")
+	}
+}
+
+// TestClaudeProviderImplementsCredentialRepairer keeps the provider wired into
+// the pre-spawn repair hook.
+func TestClaudeProviderImplementsCredentialRepairer(t *testing.T) {
+	var p Provider = NewClaudeProvider("claude", "bypassPermissions")
+	if _, ok := p.(credentialRepairer); !ok {
+		t.Fatal("ClaudeProvider no longer implements credentialRepairer")
+	}
+}
+
+// TestNonClaudeProvidersSkipCredentialRepair documents that the repair is
+// Claude-specific; other CLIs manage their own credentials.
+func TestNonClaudeProvidersSkipCredentialRepair(t *testing.T) {
+	for _, p := range []Provider{NewCodexProvider("codex"), NewCursorProvider("cursor-agent")} {
+		if _, ok := p.(credentialRepairer); ok {
+			t.Errorf("%s unexpectedly implements credentialRepairer", p.Name())
+		}
+	}
+}

--- a/internal/session/claude_credentials_test.go
+++ b/internal/session/claude_credentials_test.go
@@ -227,6 +227,56 @@ func TestWatchClaudeCredentialsRepairsThenStops(t *testing.T) {
 	}
 }
 
+// recordingProvider is a Provider that reports a canned repair outcome and
+// remembers whether the pre-spawn hook asked for one. It borrows the rest of
+// the Provider surface from ClaudeProvider.
+type recordingProvider struct {
+	*ClaudeProvider
+	state  ClaudeCredentialState
+	err    error
+	called int
+}
+
+func (p *recordingProvider) RepairCredentials() (ClaudeCredentialState, error) {
+	p.called++
+	return p.state, p.err
+}
+
+func TestRepairProviderCredentialsInvokesRepairer(t *testing.T) {
+	// Every outcome must leave the spawn free to proceed, so the only
+	// observable difference between them is what gets logged.
+	for _, tc := range []struct {
+		name  string
+		state ClaudeCredentialState
+		err   error
+	}{
+		{name: "healthy", state: ClaudeCredsHealthy},
+		{name: "repaired", state: ClaudeCredsRepaired},
+		{name: "unrecoverable", state: ClaudeCredsUnrecoverable},
+		{name: "error", err: errors.New("security unavailable")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &recordingProvider{
+				ClaudeProvider: NewClaudeProvider("claude", "bypassPermissions"),
+				state:          tc.state,
+				err:            tc.err,
+			}
+
+			repairProviderCredentials("sess-1", p)
+
+			if p.called != 1 {
+				t.Errorf("RepairCredentials called %d times, want 1", p.called)
+			}
+		})
+	}
+}
+
+func TestRepairProviderCredentialsSkipsNonRepairers(t *testing.T) {
+	// Codex manages its own credentials; the hook must leave it alone rather
+	// than block the spawn.
+	repairProviderCredentials("sess-1", NewCodexProvider("codex"))
+}
+
 // TestClaudeProviderImplementsCredentialRepairer keeps the provider wired into
 // the pre-spawn repair hook.
 func TestClaudeProviderImplementsCredentialRepairer(t *testing.T) {

--- a/internal/session/holder_stream.go
+++ b/internal/session/holder_stream.go
@@ -173,8 +173,38 @@ type resultModelUsage struct {
 	ModelUsage map[string]modelUsageEntry `json:"modelUsage"`
 }
 
+// credentialRepairer is implemented by providers whose CLI can be wedged by
+// broken credential storage that agmux is able to repair before spawning.
+type credentialRepairer interface {
+	RepairCredentials() (ClaudeCredentialState, error)
+}
+
+// repairProviderCredentials gives the provider a chance to clear out
+// credential state that would make the CLI fail to authenticate. Failures are
+// logged and swallowed: a spawn that might work is better than one refused
+// over a diagnostic that could not run.
+func repairProviderCredentials(sessionID string, provider Provider) {
+	r, ok := provider.(credentialRepairer)
+	if !ok {
+		return
+	}
+	state, err := r.RepairCredentials()
+	if err != nil {
+		slog.Warn("credential repair failed", "component", "session_manager", "sessionId", sessionID, "provider", provider.Name(), "error", err)
+		return
+	}
+	switch state {
+	case ClaudeCredsRepaired:
+		slog.Info("removed expired keychain credentials; CLI will use ~/.claude/.credentials.json", "component", "session_manager", "sessionId", sessionID, "provider", provider.Name())
+	case ClaudeCredsUnrecoverable:
+		slog.Warn("keychain credentials are expired and ~/.claude/.credentials.json cannot replace them; run `claude` and re-login", "component", "session_manager", "sessionId", sessionID, "provider", provider.Name())
+	}
+}
+
 // StartHolderStreamProcess starts a CLI process via a holder subprocess.
 func StartHolderStreamProcess(opts StreamOpts, provider Provider) (*HolderStreamProcess, error) {
+	repairProviderCredentials(opts.SessionID, provider)
+
 	// Build the command that the holder will execute
 	cmd := provider.BuildStreamCommand(opts)
 	cmd.Env = provider.AppendOTelEnv(cmd.Env, 0)

--- a/internal/session/provider_claude.go
+++ b/internal/session/provider_claude.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/myuon/agmux/internal/config"
@@ -101,6 +102,13 @@ func (p *ClaudeProvider) BuildStreamCommand(opts StreamOpts) *exec.Cmd {
 	// Prevent git from hanging on interactive auth prompts (e.g. HTTPS push)
 	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
 	return cmd
+}
+
+// RepairCredentials clears a Keychain entry holding expired OAuth credentials
+// when the on-disk credential file can take over, so the CLI does not fail
+// with "OAuth session expired and could not be refreshed". See #701.
+func (p *ClaudeProvider) RepairCredentials() (ClaudeCredentialState, error) {
+	return RepairClaudeCredentials(time.Now())
 }
 
 func (p *ClaudeProvider) ParseSessionID(jsonlLine []byte) (string, bool) {


### PR DESCRIPTION
Fixes #701

## 問題

セッションにメッセージを送ると `Failed to authenticate: OAuth session expired and could not be refreshed` が返り、再起動しても復旧しない。

Claude Code は OAuth 認証情報を Keychain (`Claude Code-credentials`) と `~/.claude/.credentials.json` の 2 箇所に持ち、Keychain が読める限りそちらを優先してファイルはフォールバックにしか使わない。Keychain 側に期限切れの値が入ると、CLI は API に到達する前にローカルで認証失敗する（`duration_api_ms: 0` / 93ms で終了）。

実際に観測されたのは `expiresAt: 0`（1970-01-01）という値で、ファイル側は正常な日時を保持していた。

### agmux 経由でのみ失敗する理由

agmux は launchd エージェント (`com.myuon.agmux`) として動くため、その系統の子プロセスは Keychain のシークレットを読めてしまう。一方、通常シェルから起動した CLI は読めずファイルにフォールバックする。

```
Keychain のシークレット読み取り:
  launchd 配下（= agmux が spawn する claude）  → exit=0   → 壊れた方を使う → 失敗
  通常シェル配下（= 手で叩く claude）           → exit=36  → ファイルに fallback → 成功
```

この非対称性のせいで「同じコマンドが手元では成功し agmux 経由でのみ失敗する」状態になっていた。環境変数・モデルID・引数はいずれも無関係であることを切り分け済み（`launchctl submit` 経由で `claude -p` を実行すると agmux 抜きで再現する）。

## 変更内容

`internal/session/claude_credentials.go` を追加し、Keychain とファイルの `expiresAt` を比較して破損を検知・修復する。

**安全条件**: ファイル側が有効なときに限り Keychain エントリを削除する。破損しているのに代替が無い場合は削除せず、再ログインが必要な旨をログに出す。これにより最後の有効な認証情報を失うことが構造的に起きない。

`expiresAt` は `*int64` として扱い、「フィールド不在」と「明示的な 0」を区別している。区別しないと想定外の形式のペイロードを期限切れと誤判定して削除しに行ってしまう。

**発火点は 2 箇所**:

1. **セッション起動前** — `StartHolderStreamProcess` から呼ぶ。`credentialRepairer` オプショナルインターフェースにしたので codex / cursor プロバイダには影響しない
2. **デーモンの定期チェック（5分間隔）** — 起動済みセッションが後から壊れたエントリを拾う隙間を埋める。Claude Code 側の認証情報キャッシュ寿命より十分短い間隔。状態変化時のみログを出すので平常時は静か

macOS 以外では no-op。`security` 呼び出しには 5 秒のタイムアウトを設けており、Keychain がロック等で無反応でもセッション起動を止めない。

## 検証

ユニットテスト 12 本（修復する / 有効なら残す / 代替が無ければ消さない（3ケース） / エントリ無し / 削除失敗の伝播 / パース / プロバイダ配線）。`make test` 全通過。

加えて実環境で本物の破損エントリを使って確認した。launchd 経由で `expiresAt: 0` のエントリを作成（今回の障害と同一の状態）し、修復コードを launchd 配下で実行:

```
--- before ---
{"keychain_expiresAt":0}
state=1 err=<nil>          ← ClaudeCredsRepaired
--- after ---
keychain entry: GONE
```

**未検証**: デーモンレベルの通し確認（launchd デーモンの再起動が必要なため）。検証済みなのは修復ロジック本体で、未検証なのは `StartHolderStreamProcess` からの呼び出し配線の部分。
