### PR TITLE
feat: セッション詳細にコマンド実行モードを追加

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -87,6 +87,12 @@ export const api = {
       body: JSON.stringify({ text, ...(images && images.length > 0 ? { images } : {}) }),
     }),
 
+  execInSession: (id: string, command: string) =>
+    request<{ exitCode: number }>(`/sessions/${id}/exec`, {
+      method: "POST",
+      body: JSON.stringify({ command }),
+    }),
+
   getStreamOutput: (id: string, limit = 200) =>
     request<{ lines: unknown[]; total: number }>(`/sessions/${id}/stream?limit=${limit}`),
 

--- a/frontend/src/models/stream.ts
+++ b/frontend/src/models/stream.ts
@@ -264,6 +264,28 @@ function isProviderCoLocatedTools(provider?: string): boolean {
 
 // Merge assistant/user entries into display items, pairing tool_use with tool_result by id
 // partialText: incremental text from stream_event deltas (shown as "typing" in the last assistant group)
+// Parse the `<bash-input>...</bash-input><bash-stdout>...</bash-stdout><bash-stderr>...</bash-stderr><bash-error>...</bash-error>`
+// text produced by Command mode exec results, and turn it into a Bash tool_call display item.
+// Returns null if the text does not look like a bash exec result.
+function parseBashExecText(text: string): StreamDisplayItem | null {
+  const inputMatch = text.match(/^<bash-input>([\s\S]*?)<\/bash-input>/);
+  if (!inputMatch) return null;
+  const command = inputMatch[1];
+  const stdoutMatch = text.match(/<bash-stdout>([\s\S]*?)<\/bash-stdout>/);
+  const stderrMatch = text.match(/<bash-stderr>([\s\S]*?)<\/bash-stderr>/);
+  const errorMatch = text.match(/<bash-error>([\s\S]*?)<\/bash-error>/);
+  const resultParts: string[] = [];
+  if (stdoutMatch) resultParts.push(stdoutMatch[1]);
+  if (stderrMatch) resultParts.push(stderrMatch[1]);
+  if (errorMatch) resultParts.push(errorMatch[1]);
+  return {
+    kind: "tool_call",
+    name: "Bash",
+    input: { command },
+    result: resultParts.length > 0 ? resultParts.join("\n") : undefined,
+  };
+}
+
 export function mergeStreamEntries(entries: StreamEntry[], partialText?: string, provider?: string): DisplayGroup[] {
   // First pass: collect all tool_results keyed by tool_use_id, and track Skill tool IDs
   const resultMap = new Map<string, string>();
@@ -568,14 +590,15 @@ export function mergeStreamEntries(entries: StreamEntry[], partialText?: string,
       // Only show user text/image content (tool_results are merged into assistant tool_call items)
       for (const b of blocks) {
         if (b.type === "text" && b.text) {
-          items.push({ kind: "text", text: b.text });
+          items.push(parseBashExecText(b.text) ?? { kind: "text", text: b.text });
         } else if (b.type === "image" && b.source) {
           items.push({ kind: "image", mediaType: b.source.media_type, data: b.source.data });
         }
       }
       // user entries with content as plain string
       if (items.length === 0 && typeof entry.message?.content === "string" && entry.message.content) {
-        items.push({ kind: "text", text: entry.message.content });
+        const content = entry.message.content;
+        items.push(parseBashExecText(content) ?? { kind: "text", text: content });
       }
     }
 

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -7,7 +7,7 @@ import {
   Sparkles, Settings, Copy,
   RotateCcw, ImagePlus, SendHorizonal, Plus, Slash,
   Code, Eye, X, AlertTriangle, LayoutTemplate, ChevronDown,
-  MessageSquare, Terminal,
+  Terminal,
 } from "lucide-react";
 import { useDesktopPane } from "../App";
 import { Modal } from "../components/ui/Modal";
@@ -595,32 +595,22 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
           ))}
         </div>
       )}
-      <div className="flex items-center gap-1 mb-1.5">
-        <div className="inline-flex items-center rounded-lg bg-gray-100 p-0.5">
-          <button
-            type="button"
-            onClick={() => setInputMode("chat")}
-            title="Chat mode"
-            className={`flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium transition-colors ${
-              inputMode === "chat" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-700"
-            }`}
-          >
-            <MessageSquare className="w-3.5 h-3.5" />
-            Chat
-          </button>
-          <button
-            type="button"
-            onClick={() => { setInputMode("command"); setShowSlashMenu(false); }}
-            title="Command mode"
-            className={`flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium transition-colors ${
-              inputMode === "command" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-700"
-            }`}
-          >
+      {inputMode === "command" && (
+        <div className="flex items-center mb-1.5">
+          <span className="inline-flex items-center gap-1 rounded-md bg-amber-100 text-amber-800 px-2 py-0.5 text-xs font-medium">
             <Terminal className="w-3.5 h-3.5" />
-            Command
-          </button>
+            Command mode
+            <button
+              type="button"
+              onClick={() => setInputMode("chat")}
+              title="Exit command mode"
+              className="ml-0.5 -mr-0.5 rounded hover:bg-amber-200 p-0.5"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </span>
         </div>
-      </div>
+      )}
       <div className="flex gap-2 items-center">
         {/* Left action menu */}
         <div className="relative">
@@ -643,6 +633,17 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
                   setShowActionMenu(false);
                 }}
               />
+              {session.type !== "controller" && (
+                <ActionMenuItem
+                  icon={<Terminal className="w-4 h-4" />}
+                  label="Command mode"
+                  onClick={() => {
+                    setInputMode("command");
+                    setShowSlashMenu(false);
+                    setShowActionMenu(false);
+                  }}
+                />
+              )}
               {slashCommands.length > 0 && (
                 <ActionMenuItem
                   icon={<Slash className="w-4 h-4" />}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -7,6 +7,7 @@ import {
   Sparkles, Settings, Copy,
   RotateCcw, ImagePlus, SendHorizonal, Plus, Slash,
   Code, Eye, X, AlertTriangle, LayoutTemplate, ChevronDown,
+  MessageSquare, Terminal,
 } from "lucide-react";
 import { useDesktopPane } from "../App";
 import { Modal } from "../components/ui/Modal";
@@ -279,6 +280,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
 
   const [session, setSession] = useState<Session | null>(initialSession);
   const [message, setMessage] = useState("");
+  const [inputMode, setInputMode] = useState<"chat" | "command">("chat");
   const [streamLines, setStreamLines] = useState<unknown[]>(deferred.streamOutput.lines);
   const [partialText, setPartialText] = useState("");
   // Latest estimated thinking tokens (system:thinking_tokens live events); null when not thinking
@@ -550,7 +552,11 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
     setSendError(null);
     setIsSending(true);
     try {
-      await api.sendToSession(sessionId, text, images);
+      if (inputMode === "command") {
+        await api.execInSession(sessionId, text);
+      } else {
+        await api.sendToSession(sessionId, text, images);
+      }
       // Stream mode updates arrive via WebSocket automatically
     } catch (err) {
       console.error("Failed to send message:", err);
@@ -589,6 +595,32 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
           ))}
         </div>
       )}
+      <div className="flex items-center gap-1 mb-1.5">
+        <div className="inline-flex items-center rounded-lg bg-gray-100 p-0.5">
+          <button
+            type="button"
+            onClick={() => setInputMode("chat")}
+            title="Chat mode"
+            className={`flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium transition-colors ${
+              inputMode === "chat" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            <MessageSquare className="w-3.5 h-3.5" />
+            Chat
+          </button>
+          <button
+            type="button"
+            onClick={() => { setInputMode("command"); setShowSlashMenu(false); }}
+            title="Command mode"
+            className={`flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium transition-colors ${
+              inputMode === "command" ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            <Terminal className="w-3.5 h-3.5" />
+            Command
+          </button>
+        </div>
+      </div>
       <div className="flex gap-2 items-center">
         {/* Left action menu */}
         <div className="relative">
@@ -758,7 +790,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
         />
         {/* Message input with slash command popup */}
         <div className="relative flex-1">
-          {showSlashMenu && (() => {
+          {inputMode === "chat" && showSlashMenu && (() => {
             const filtered = slashCommands.filter((cmd) =>
               slashFilter === "" || cmd.toLowerCase().includes(slashFilter.toLowerCase())
             );
@@ -796,7 +828,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
             onChange={(e) => {
               const val = e.target.value;
               setMessage(val);
-              if (val.startsWith("/") && slashCommands.length > 0) {
+              if (inputMode === "chat" && val.startsWith("/") && slashCommands.length > 0) {
                 const filter = val.slice(1).split(" ")[0];
                 if (!val.includes(" ") || val === "/") {
                   setSlashFilter(filter);
@@ -819,7 +851,7 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
                 // Allow default newline behavior; do not submit
                 return;
               }
-              if (!showSlashMenu) return;
+              if (inputMode !== "chat" || !showSlashMenu) return;
               const filtered = slashCommands.filter((cmd) =>
                 slashFilter === "" || cmd.toLowerCase().includes(slashFilter.toLowerCase())
               );
@@ -855,8 +887,16 @@ function SessionPageInner({ session: initialSession, deferred }: { session: Sess
               }
             }}
             disabled={isSending}
-            placeholder="Send a message..."
-            className="block w-full border border-gray-300 rounded px-3 py-2 text-sm resize-none h-9 overflow-auto disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
+            placeholder={
+              inputMode === "command"
+                ? `Run a shell command in ${session.projectPath}…`
+                : "Send a message..."
+            }
+            className={`block w-full rounded px-3 py-2 text-sm resize-none h-9 overflow-auto disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed ${
+              inputMode === "command"
+                ? "border border-amber-400 bg-amber-50 focus:outline-none focus:ring-1 focus:ring-amber-400"
+                : "border border-gray-300"
+            }`}
           />
         </div>
         {/* Send button */}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -151,6 +154,7 @@ func (s *Server) setupRoutes() {
 		r.Delete("/sessions/{id}", s.deleteSession)
 		r.Post("/sessions/{id}/stop", s.stopSession)
 		r.Post("/sessions/{id}/send", s.sendToSession)
+		r.Post("/sessions/{id}/exec", s.execInSession)
 		r.Put("/sessions/{id}/context", s.updateSessionContext)
 		r.Put("/sessions/{id}/model", s.updateSessionModel)
 		r.Get("/sessions/{id}/goals", s.getGoals)
@@ -255,6 +259,14 @@ type sendImageData struct {
 type sendRequest struct {
 	Text   string          `json:"text"`
 	Images []sendImageData `json:"images,omitempty"`
+}
+
+type execRequest struct {
+	Command string `json:"command"`
+}
+
+type execResponse struct {
+	ExitCode int `json:"exitCode"`
 }
 
 type updateContextRequest struct {
@@ -491,6 +503,86 @@ func (s *Server) sendToSession(w http.ResponseWriter, r *http.Request) {
 	_ = s.sessions.UpdateStatus(id, session.StatusWorking)
 	s.recordSessionAction(id, "session_send_keys", req.Text)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "sent"})
+}
+
+// maxExecOutputBytes is the maximum number of bytes captured from stdout/stderr
+// before the output is truncated when running a command via execInSession.
+const maxExecOutputBytes = 65536
+
+// truncateExecOutput truncates s to at most maxExecOutputBytes bytes, appending
+// a truncation marker when the input was cut short.
+func truncateExecOutput(s string) string {
+	if len(s) <= maxExecOutputBytes {
+		return s
+	}
+	return s[:maxExecOutputBytes] + "\n...(truncated)"
+}
+
+func (s *Server) execInSession(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req execRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	sess, err := s.sessions.Get(id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	if sess.ProjectPath == "" {
+		writeError(w, http.StatusBadRequest, "session has no project path")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", "-c", req.Command)
+	cmd.Dir = sess.ProjectPath
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	exitCode := 0
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+
+	var msg strings.Builder
+	msg.WriteString("<bash-input>")
+	msg.WriteString(req.Command)
+	msg.WriteString("</bash-input>\n")
+	msg.WriteString("<bash-stdout>")
+	msg.WriteString(truncateExecOutput(stdout.String()))
+	msg.WriteString("</bash-stdout>")
+	if stderrOut := truncateExecOutput(stderr.String()); stderrOut != "" {
+		msg.WriteString("\n<bash-stderr>")
+		msg.WriteString(stderrOut)
+		msg.WriteString("</bash-stderr>")
+	}
+	if exitCode != 0 {
+		msg.WriteString("\n<bash-error>exit code: ")
+		msg.WriteString(strconv.Itoa(exitCode))
+		msg.WriteString("</bash-error>")
+	}
+
+	if err := s.sessions.SendKeysWithImages(id, msg.String(), nil); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	_ = s.sessions.UpdateStatus(id, session.StatusWorking)
+	s.recordSessionAction(id, "session_exec_command", req.Command)
+	writeJSON(w, http.StatusOK, execResponse{ExitCode: exitCode})
 }
 
 type broadcastRequest struct {


### PR DESCRIPTION
## 概要

セッション詳細画面のメッセージ入力欄に **Chat / Command** モードトグルを追加した。Command モードで入力すると、そのセッションの project path を作業ディレクトリとして任意のシェルコマンドを実行し、結果を会話ログに表示する。Claude Code の `!` 機能に相当する。

## 挙動

- 入力欄上部の Chat/Command トグルで切替
- Command モード: placeholder が `Run a shell command in <projectPath>…` に変わり、入力枠が amber 色になる
- 送信すると `POST /api/sessions/{id}/exec` を呼び、`bash -c <command>` を project path で実行（60秒タイムアウト、stdout/stderr は各64KBで打ち切り）
- 実行結果を `<bash-input>/<bash-stdout>/<bash-stderr>`（exit≠0 なら `<bash-error>`）形式のメッセージとして既存の送信経路で流す → **agent のコンテキストにも渡り**、会話ログにも表示される
- フロントは `<bash-input>` を含む user メッセージを既存の Bash tool_call UI に変換して描画

## 変更

- `internal/server/server.go`: `POST /api/sessions/{id}/exec` ハンドラ新設（純追加）
- `frontend/src/pages/SessionPage.tsx`: Chat/Command トグル、`handleSend` 分岐、Command モードの placeholder/枠色、スラッシュ補完を chat 限定にガード
- `frontend/src/api/client.ts`: `execInSession(id, command)`
- `frontend/src/models/stream.ts`: bash 結果テキストを Bash tool_call 表示アイテムに変換

## 動作確認

隔離環境（HOME/TMPDIR 差し替え・port 4322 + vite dev、本番4321に無影響）で確認済み。スクショは後続コメントに添付。

🤖 Generated with [Claude Code](https://claude.com/claude-code)